### PR TITLE
[FE-2751][FE-2750] Allow clients to specify default headers in client…

### DIFF
--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -11,13 +11,45 @@ describe("endpoints", () => {
     });
     const client = new Client({
       endpoint: endpoints["my-alternative-port"],
-      maxConns: 5,
+      max_conns: 5,
       secret: "secret",
-      queryTimeoutMillis: 60,
+      timeout_ms: 60,
     });
     expect(client.client.defaults.baseURL).toEqual("http://localhost:7443/");
     const result = await client.query<number>({ query: '"taco".length' });
     expect(result.txn_time).not.toBeUndefined();
     expect(result).toEqual({ data: 4, txn_time: result.txn_time });
   });
+
+  it.each`
+    configFieldName             | configFieldValue                                             | expectedHeader
+    ${"linearized"}             | ${true}                                                      | ${"x-linearized: true"}
+    ${"max_contention_retries"} | ${3}                                                         | ${"x-max-contention-retries: 3"}
+    ${"tags"}                   | ${{ t1: "v1", t2: "v2" }}                                    | ${"x-fauna-tags: t1=v1,t2=v2"}
+    ${"traceparent"}            | ${"00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00"} | ${"traceparent: 00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00"}
+  `(
+    "Setting clientConfiguration $configFieldName leads to it being sent in headers",
+    async ({ configFieldName, configFieldValue, expectedHeader }) => {
+      // @ts-ignore
+      const client = new Client({
+        endpoint: endpoints.local,
+        max_conns: 5,
+        secret: "secret",
+        timeout_ms: 5000,
+        [configFieldName]: configFieldValue,
+      });
+      client.client.interceptors.response.use(function (response) {
+        if (response.request?._header) {
+          expect(response.request._header).toEqual(
+            expect.stringContaining("x-timeout-ms: 5000")
+          );
+          expect(response.request._header).toEqual(
+            expect.stringContaining(`\n${expectedHeader}`)
+          );
+        }
+        return response;
+      });
+      await client.query<number>({ query: '"taco".length' });
+    }
+  );
 });

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -12,9 +12,9 @@ import { env } from "process";
 
 const client = new Client({
   endpoint: env["endpoint"] ? new URL(env["endpoint"]) : endpoints.local,
-  maxConns: 5,
+  max_conns: 5,
   secret: env["secret"] || "secret",
-  queryTimeoutMillis: 60,
+  timeout_ms: 60,
 });
 
 describe("query", () => {
@@ -76,9 +76,9 @@ describe("query", () => {
     expect.assertions(4);
     const badClient = new Client({
       endpoint: env["endpoint"] ? new URL(env["endpoint"]) : endpoints.local,
-      maxConns: 5,
+      max_conns: 5,
       secret: "nah",
-      queryTimeoutMillis: 60,
+      timeout_ms: 60,
     });
     try {
       await badClient.query<number>({ query: '"taco".length' });
@@ -100,9 +100,9 @@ describe("query", () => {
     expect.assertions(2);
     const myBadClient = new Client({
       endpoint: new URL("http://localhost:1"),
-      maxConns: 1,
+      max_conns: 1,
       secret: "secret",
-      queryTimeoutMillis: 60,
+      timeout_ms: 60,
     });
     try {
       await myBadClient.query<number>({ query: '"taco".length;' });
@@ -120,9 +120,9 @@ describe("query", () => {
     expect.assertions(2);
     const myBadClient = new Client({
       endpoint: env["endpoint"] ? new URL(env["endpoint"]) : endpoints.local,
-      maxConns: 5,
+      max_conns: 5,
       secret: env["secret"] || "secret",
-      queryTimeoutMillis: 60,
+      timeout_ms: 60,
     });
     myBadClient.client.post = () => {
       throw new Error("boom!");
@@ -143,9 +143,9 @@ describe("query", () => {
     expect.assertions(2);
     const badClient = new Client({
       endpoint: new URL("https://frontdoor.fauna.com/"),
-      maxConns: 5,
+      max_conns: 5,
       secret: "nah",
-      queryTimeoutMillis: 60,
+      timeout_ms: 60,
     });
     try {
       await badClient.query({ query: "foo" });

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -19,9 +19,9 @@ describe("query", () => {
   beforeAll(() => {
     client = new Client({
       endpoint: endpoints.local,
-      maxConns: 5,
+      max_conns: 5,
       secret: "seekrit",
-      queryTimeoutMillis: 60,
+      timeout_ms: 60,
     });
     mockAxios = new MockAdapter(client.client);
   });

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -9,17 +9,37 @@ export interface ClientConfiguration {
   /**
    * The maximum number of connections to a make to Fauna.
    */
-  maxConns: number;
+  max_conns: number;
   /**
    * A secret for your Fauna DB, used to authorize your queries.
    * @see https://docs.fauna.com/fauna/current/security/keys
    */
   secret: string;
   /**
-   * The timeout of the query, in milliseconds. This controls the maximum amount of
+   * The timeout of each query, in milliseconds. This controls the maximum amount of
    * time Fauna will execute your query before marking it failed.
    */
-  queryTimeoutMillis: number;
+  timeout_ms: number;
+  /**
+   * If true, unconditionally run the query as strictly serialized.
+   * This affects read-only transactions. Transactions which write
+   * will always be strictly serialized.
+   */
+  linearized?: boolean;
+  /**
+   * The max number of times to retry the query if contention is encountered.
+   */
+  max_contention_retries?: number;
+
+  /**
+   * Tags provided back via logging and telemetry.
+   */
+  tags?: { [key: string]: string };
+  /**
+   * A traceparent provided back via logging and telemetry.
+   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
+   */
+  traceparent?: string;
 }
 
 /**


### PR DESCRIPTION

Ticket(s): FE-2751, FE-2750

## Problem

1. Clients need a way to configure clients and request via timeouts, linearized, etc.

## Solution

1. Fit clientConfiguration with these settings. The client will use those by default.
2. Eventually _(not in this PR)_, allow per request overrides of those settings.

## Result

1. Users have control over client behavior.

## Out of scope

1. Request level header setting
3. tracking the most recent transaction and applying to the `x-last-txn` header.

## Testing

```
~/workplace/fql-x-javascript (main_headers) » yarn test                                                                                                                    cleve@Cleves-MBP
 yarn run v1.22.17
 warning ../../package.json: No license field
 $ jest
 PASS  __tests__/functional/client-configuration.test.ts
 PASS  __tests__/unit/query.test.ts
 PASS  __tests__/integration/query.test.ts

Test Suites: 3 passed, 3 total
Tests:       35 passed, 35 total
Snapshots:   0 total
Time:        3.347 s
Ran all test suites.
 ✨  Done in 4.66s.
```