### PR TITLE
[FE-2760] Allow per-request overriding of header parameters.

### DIFF
--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -4,6 +4,35 @@
 export interface QueryRequest {
   /** The query. */
   query: string;
+  /**
+   * If true, unconditionally run the query as strictly serialized.
+   * This affects read-only transactions. Transactions which write
+   * will always be strictly serialized.
+   * Overrides the optional setting for the client.
+   */
+  linearized?: boolean;
+  /**
+   * The timeout to use in this query in milliseconds.
+   * Overrides the timeout for the client.
+   */
+  timeout_ms?: number;
+  /**
+   * The max number of times to retry the query if contention is encountered.
+   * Overrides the optional setting for the client.
+   */
+  max_contention_retries?: number;
+
+  /**
+   * Tags provided back via logging and telemetry.
+   * Overrides the optional setting on the client.
+   */
+  tags?: { [key: string]: string };
+  /**
+   * A traceparent provided back via logging and telemetry.
+   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
+   * Overrides the optional setting for the client.
+   */
+  traceparent?: string;
 }
 
 /**


### PR DESCRIPTION
Ticket(s): FE-2760

## Problem

- need to be able to set the request level headers on any request.

## Solution

- allow them to be set.
- setting them overrides the clientConfiguration settings.
## Result

- people can do this.

## Out of scope

- still haven't messed with `last_txn`. Will follow up with that.

## Testing

```
~/workplace/fauna-js (main_requestOverrides) » yarn test                                                                                                            130 ↵ cleve@Cleves-MBP
 yarn run v1.22.17
 warning ../../package.json: No license field
 $ jest
 PASS  __tests__/functional/client-configuration.test.ts
 PASS  __tests__/unit/query.test.ts
 PASS  __tests__/integration/query.test.ts

Test Suites: 3 passed, 3 total
Tests:       40 passed, 40 total
Snapshots:   0 total
Time:        3.323 s
Ran all test suites.
 ✨  Done in 4.40s.
```