### PR TITLE
[FE-2754] Fix bug in connection pooling that was not adding keep-alive to headers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -55,18 +55,14 @@ export class Client {
       // release socket for usage after 4s of inactivity. Must be less than Fauna's server
       // side idle timeout of 5 seconds.
       freeSocketTimeout: 4000,
+      keepAlive: true,
     };
-    let httpAgents: { httpAgent: Agent } | { httpsAgent: HttpsAgent };
-    if (this.clientConfiguration.endpoint.protocol === "http") {
-      httpAgents = { httpAgent: new Agent(agentSettings) };
-    } else {
-      httpAgents = { httpsAgent: new HttpsAgent(agentSettings) };
-    }
     this.client = axios.create({
       baseURL: this.clientConfiguration.endpoint.toString(),
       timeout,
-      ...httpAgents,
     });
+    this.client.defaults.httpAgent = new Agent(agentSettings);
+    this.client.defaults.httpsAgent = new HttpsAgent(agentSettings);
     this.client.defaults.headers.common[
       "Authorization"
     ] = `Bearer ${this.clientConfiguration.secret}`;


### PR DESCRIPTION

Ticket(s): FE-2754

## Problem

- axios was being misconfigured and so not actually using a connection pool

## Solution

- set the default httpAgent and httpsAgent rather than trying to construct axios with these.

## Result

- we actually keep connections alive

## Testing

Wrote a new test to catch this. It failed before the patch. Now it passes:

```
~/workplace/fauna-js (main_fixKeepAlive) » yarn test 
 yarn run v1.22.17
 warning ../../package.json: No license field
 $ jest
 PASS  __tests__/functional/client-configuration.test.ts
 PASS  __tests__/unit/query.test.ts
 PASS  __tests__/integration/query.test.ts

Test Suites: 3 passed, 3 total
Tests:       41 passed, 41 total
Snapshots:   0 total
Time:        3.01 s, estimated 4 s
Ran all test suites.
 ✨  Done in 3.84s.
```
