### PR TITLE
ts-ignore NetworkError instances in tests

### DIFF
--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -153,7 +153,8 @@ describe("query", () => {
         expect(e.message).toEqual(
           "The network connection encountered a problem."
         );
-        expect(e.cause).not.toBeUndefined();
+        // @ts-ignore
+        expect(e.cause).toBeDefined();
       }
     }
   });
@@ -170,7 +171,8 @@ describe("query", () => {
         expect(e.message).toEqual(
           "The network connection encountered a problem."
         );
-        expect(e.cause).not.toBeUndefined();
+        // @ts-ignore
+        expect(e.cause).toBeDefined();
       }
     }
   });
@@ -204,7 +206,8 @@ describe("query", () => {
           expect(e.message).toEqual(
             "The network connection encountered a problem."
           );
-          expect(e.cause).not.toBeUndefined();
+          // @ts-ignore
+        expect(e.cause).toBeDefined();
         }
       }
     }
@@ -223,7 +226,8 @@ describe("query", () => {
         expect(e.message).toEqual(
           "The network connection encountered a problem."
         );
-        expect(e.cause).not.toBeUndefined();
+        // @ts-ignore
+        expect(e.cause).toBeDefined();
       }
     }
   });


### PR DESCRIPTION
## Problem

Something is up with the TypeScript linting where it can't figure out that NetworkError extends Error

```
Property 'cause' does not exist on type 'NetworkError'.
```

## Solution

- `@ts-ignore` the lines for now
- simplified `expect` while I was there

## Result

No "Problems" showing up in my workspace now 🙌 

## Out of scope

## Testing
