### PR TITLE
Updated authentication test

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -227,7 +227,7 @@ describe.each`
       );
     } catch (e) {
       if (e instanceof AuthenticationError) {
-        expect(e.message).toEqual("Unauthorized: Access token required");
+        expect(e.message).toBeDefined();
         expect(e.code).toEqual("unauthorized");
         expect(e.httpStatus).toEqual(401);
         expect(e.summary).toBeUndefined();


### PR DESCRIPTION
Ticket(s): FE-###

## Problem

Updated to the latest nightly docker image and the test started to fail. Test shouldn't assert the `message` contents from core.

## Solution

Simplify the test assertion

## Result

Test validates the driver only

## Out of scope

## Testing
