### PR TITLE
[FE-3064] Define an HTTPClient interface and default fetch client

### DIFF
--- a/lib/client-configuration.d.ts
+++ b/lib/client-configuration.d.ts
@@ -1,4 +1,3 @@
-/// <reference types="node" />
 /**
  * Configuration for a client.
  */

--- a/lib/http-client/fetch-client.d.ts
+++ b/lib/http-client/fetch-client.d.ts
@@ -1,0 +1,6 @@
+/** following reference needed to include types for experimental fetch API in Node */
+/// <reference lib="dom" />
+import { HTTPClient, HTTPRequest, HTTPResponse } from "./index";
+export declare class FetchClient implements HTTPClient {
+    request({ data, headers: requestHeaders, method, url, keepalive, }: HTTPRequest): Promise<HTTPResponse>;
+}

--- a/lib/http-client/fetch-client.d.ts
+++ b/lib/http-client/fetch-client.d.ts
@@ -1,6 +1,10 @@
 /** following reference needed to include types for experimental fetch API in Node */
 /// <reference lib="dom" />
 import { HTTPClient, HTTPRequest, HTTPResponse } from "./index";
+/**
+ * An implementation for {@link HTTPClient} that uses the native fetch API
+ */
 export declare class FetchClient implements HTTPClient {
+    /** {@inheritDoc HTTPClient.request} */
     request({ data, headers: requestHeaders, method, url, keepalive, }: HTTPRequest): Promise<HTTPResponse>;
 }

--- a/lib/http-client/fetch-client.d.ts
+++ b/lib/http-client/fetch-client.d.ts
@@ -6,5 +6,5 @@ import { HTTPClient, HTTPRequest, HTTPResponse } from "./index";
  */
 export declare class FetchClient implements HTTPClient {
     /** {@inheritDoc HTTPClient.request} */
-    request({ data, headers: requestHeaders, method, url, keepalive, }: HTTPRequest): Promise<HTTPResponse>;
+    request({ data, headers: requestHeaders, method, url, }: HTTPRequest): Promise<HTTPResponse>;
 }

--- a/lib/http-client/index.d.ts
+++ b/lib/http-client/index.d.ts
@@ -9,7 +9,7 @@ export declare type HTTPRequest = {
 export declare type HTTPResponse = {
     headers: Record<string, string>;
     status: number;
-    body: unknown;
+    body: string;
 };
 export interface HTTPClient {
     request(req: HTTPRequest): Promise<HTTPResponse>;

--- a/lib/http-client/index.d.ts
+++ b/lib/http-client/index.d.ts
@@ -15,9 +15,9 @@ export declare type HTTPRequest = {
  * It is returned to, and handled by, the {@link Client}.
  */
 export declare type HTTPResponse = {
+    body: string;
     headers: Record<string, string>;
     status: number;
-    body: string;
 };
 /**
  * An interface to provide implementation-specific, asyncronous http calls.

--- a/lib/http-client/index.d.ts
+++ b/lib/http-client/index.d.ts
@@ -1,14 +1,14 @@
+import { QueryRequest } from "../wire-protocol";
 export { FetchClient } from "./fetch-client";
 /**
  * An object representing an http request.
  * The {@link Client} provides this to the {@link HTTPClient} implementation.
  */
 export declare type HTTPRequest = {
-    data: Record<string, any>;
+    data: QueryRequest;
     headers: Record<string, string>;
     method: string;
     url: string;
-    keepalive?: boolean;
 };
 /**
  * An object representing an http request.

--- a/lib/http-client/index.d.ts
+++ b/lib/http-client/index.d.ts
@@ -1,0 +1,16 @@
+export { FetchClient } from "./fetch-client";
+export declare type HTTPRequest = {
+    data: Record<string, any>;
+    headers: Record<string, string>;
+    method: string;
+    url: string;
+    keepalive?: boolean;
+};
+export declare type HTTPResponse = {
+    headers: Record<string, string>;
+    status: number;
+    body: unknown;
+};
+export interface HTTPClient {
+    request(req: HTTPRequest): Promise<HTTPResponse>;
+}

--- a/lib/http-client/index.d.ts
+++ b/lib/http-client/index.d.ts
@@ -1,4 +1,8 @@
 export { FetchClient } from "./fetch-client";
+/**
+ * An object representing an http request.
+ * The {@link Client} provides this to the {@link HTTPClient} implementation.
+ */
 export declare type HTTPRequest = {
     data: Record<string, any>;
     headers: Record<string, string>;
@@ -6,11 +10,25 @@ export declare type HTTPRequest = {
     url: string;
     keepalive?: boolean;
 };
+/**
+ * An object representing an http request.
+ * It is returned to, and handled by, the {@link Client}.
+ */
 export declare type HTTPResponse = {
     headers: Record<string, string>;
     status: number;
     body: string;
 };
+/**
+ * An interface to provide implementation-specific, asyncronous http calls.
+ * This driver provides default implementations for common environments. Users
+ * can configure the {@link Client} to use custom implementations if desired.
+ */
 export interface HTTPClient {
+    /**
+     * Makes an HTTP request and returns the response
+     * @param req - an {@link HTTPRequest}
+     * @returns A Promise&lt;{@link HTTPResponse}&gt;
+     */
     request(req: HTTPRequest): Promise<HTTPResponse>;
 }

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -13,7 +13,6 @@ export class FetchClient implements HTTPClient {
     headers: requestHeaders,
     method,
     url,
-    keepalive,
   }: HTTPRequest): Promise<HTTPResponse> {
     // TODO: handle client timeouts with AbortController. Emit NetworkError if so.
 
@@ -21,7 +20,6 @@ export class FetchClient implements HTTPClient {
       method,
       headers: { ...requestHeaders, "Content-Type": "application/json" },
       body: JSON.stringify(data),
-      keepalive,
     });
 
     const status = response.status;

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -2,12 +2,6 @@
 /// <reference lib="dom" />
 
 import { HTTPClient, HTTPRequest, HTTPResponse } from "./index";
-import {
-  NetworkError,
-  ProtocolError,
-  QueryFailure,
-  QuerySuccess,
-} from "../wire-protocol";
 
 export class FetchClient implements HTTPClient {
   async request({
@@ -24,33 +18,14 @@ export class FetchClient implements HTTPClient {
       headers: requestHeaders,
       body: JSON.stringify(data),
       keepalive,
-    })
-      // handle network errors directly
-      .catch((error) => {
-        throw new NetworkError(
-          "The network connection encountered a problem.",
-          {
-            cause: error,
-          }
-        );
-      });
+    });
 
     const status = response.status;
 
     const responseHeaders: Record<string, string> = {};
     response.headers.forEach((value, key) => (responseHeaders[key] = value));
 
-    const body: QuerySuccess<unknown> | QueryFailure = await response
-      .json()
-      // handle JSON parsing errors directly
-      .catch((error) => {
-        throw new ProtocolError({
-          message:
-            "Error parsing response as JSON. Response: " +
-            JSON.stringify(error),
-          httpStatus: status,
-        });
-      });
+    const body = await response.text();
 
     return {
       status,

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -1,0 +1,61 @@
+/** following reference needed to include types for experimental fetch API in Node */
+/// <reference lib="dom" />
+
+import { HTTPClient, HTTPRequest, HTTPResponse } from "./index";
+import {
+  NetworkError,
+  ProtocolError,
+  QueryFailure,
+  QuerySuccess,
+} from "../wire-protocol";
+
+export class FetchClient implements HTTPClient {
+  async request({
+    data,
+    headers: requestHeaders,
+    method,
+    url,
+    keepalive,
+  }: HTTPRequest): Promise<HTTPResponse> {
+    // TODO: handle client timeouts with AbortController. Emit NetworkError if so.
+
+    const response = await fetch(url, {
+      method,
+      headers: requestHeaders,
+      body: JSON.stringify(data),
+      keepalive,
+    })
+      // handle network errors directly
+      .catch((error) => {
+        throw new NetworkError(
+          "The network connection encountered a problem.",
+          {
+            cause: error,
+          }
+        );
+      });
+
+    const status = response.status;
+
+    const responseHeaders: Record<string, string> = {};
+    response.headers.forEach((value, key) => (responseHeaders[key] = value));
+
+    const body: QuerySuccess<unknown> | QueryFailure = await response
+      .json()
+      // handle JSON parsing errors directly
+      .catch((error) => {
+        throw new ProtocolError({
+          message:
+            "Error parsing response as JSON. Response: " +
+            JSON.stringify(error),
+          httpStatus: status,
+        });
+      });
+
+    return {
+      status,
+      body,
+      headers: responseHeaders,
+    };
+  }
+}

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -19,7 +19,7 @@ export class FetchClient implements HTTPClient {
 
     const response = await fetch(url, {
       method,
-      headers: requestHeaders,
+      headers: { ...requestHeaders, "Content-Type": "application/json" },
       body: JSON.stringify(data),
       keepalive,
     });

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -3,7 +3,11 @@
 
 import { HTTPClient, HTTPRequest, HTTPResponse } from "./index";
 
+/**
+ * An implementation for {@link HTTPClient} that uses the native fetch API
+ */
 export class FetchClient implements HTTPClient {
+  /** {@inheritDoc HTTPClient.request} */
   async request({
     data,
     headers: requestHeaders,

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,4 +1,5 @@
 import type { Client } from "../client";
+import { QueryRequest } from "../wire-protocol";
 export { FetchClient } from "./fetch-client";
 
 /**
@@ -6,11 +7,10 @@ export { FetchClient } from "./fetch-client";
  * The {@link Client} provides this to the {@link HTTPClient} implementation.
  */
 export type HTTPRequest = {
-  data: Record<string, any>;
+  data: QueryRequest;
   headers: Record<string, string>;
   method: string;
   url: string;
-  keepalive?: boolean;
 };
 
 /**

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,5 +1,10 @@
+import type { Client } from "../client";
 export { FetchClient } from "./fetch-client";
 
+/**
+ * An object representing an http request.
+ * The {@link Client} provides this to the {@link HTTPClient} implementation.
+ */
 export type HTTPRequest = {
   data: Record<string, any>;
   headers: Record<string, string>;
@@ -8,12 +13,26 @@ export type HTTPRequest = {
   keepalive?: boolean;
 };
 
+/**
+ * An object representing an http request.
+ * It is returned to, and handled by, the {@link Client}.
+ */
 export type HTTPResponse = {
   headers: Record<string, string>;
   status: number;
   body: string;
 };
 
+/**
+ * An interface to provide implementation-specific, asyncronous http calls.
+ * This driver provides default implementations for common environments. Users
+ * can configure the {@link Client} to use custom implementations if desired.
+ */
 export interface HTTPClient {
+  /**
+   * Makes an HTTP request and returns the response
+   * @param req - an {@link HTTPRequest}
+   * @returns A Promise&lt;{@link HTTPResponse}&gt;
+   */
   request(req: HTTPRequest): Promise<HTTPResponse>;
 }

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,0 +1,19 @@
+export { FetchClient } from "./fetch-client";
+
+export type HTTPRequest = {
+  data: Record<string, any>;
+  headers: Record<string, string>;
+  method: string;
+  url: string;
+  keepalive?: boolean;
+};
+
+export type HTTPResponse = {
+  headers: Record<string, string>;
+  status: number;
+  body: unknown;
+};
+
+export interface HTTPClient {
+  request(req: HTTPRequest): Promise<HTTPResponse>;
+}

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -11,7 +11,7 @@ export type HTTPRequest = {
 export type HTTPResponse = {
   headers: Record<string, string>;
   status: number;
-  body: unknown;
+  body: string;
 };
 
 export interface HTTPClient {

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -18,9 +18,9 @@ export type HTTPRequest = {
  * It is returned to, and handled by, the {@link Client}.
  */
 export type HTTPResponse = {
+  body: string;
   headers: Record<string, string>;
   status: number;
-  body: string;
 };
 
 /**


### PR DESCRIPTION
Ticket(s): [FE-3064](https://faunadb.atlassian.net/browse/FE-3064)

This is an initial milestone to review a generic HTTPClient interface


[FE-3064]: https://faunadb.atlassian.net/browse/FE-3064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ