### PR TITLE
Provide common error base class

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,9 +1,18 @@
 import { QueryFailure } from "./wire-protocol";
 
 /**
+ * A common error base class for all other errors.
+ */
+abstract class FaunaError extends Error {
+  constructor(...args: any[]) {
+    super(...args);
+  }
+}
+
+/**
  * An error representing a query failure returned by Fauna.
  */
-export class ServiceError extends Error {
+export class ServiceError extends FaunaError {
   /**
    * The HTTP Status Code of the error.
    */
@@ -166,7 +175,7 @@ export class ServiceTimeoutError extends ServiceError {
  * This indicates Fauna was never called - the client failed internally
  * prior to sending the request.
  */
-export class ClientError extends Error {
+export class ClientError extends FaunaError {
   constructor(message: string, options: { cause: any }) {
     super(message, options);
     // Maintains proper stack trace for where our error was thrown (only available on V8)
@@ -181,7 +190,7 @@ export class ClientError extends Error {
  * An error representing a failure due to the network.
  * This indicates Fauna was never reached.
  */
-export class NetworkError extends Error {
+export class NetworkError extends FaunaError {
   constructor(message: string, options: { cause: any }) {
     super(message, options);
     // Maintains proper stack trace for where our error was thrown (only available on V8)
@@ -196,7 +205,7 @@ export class NetworkError extends Error {
  * An error representing a HTTP failure - but one not directly
  * emitted by Fauna.
  */
-export class ProtocolError extends Error {
+export class ProtocolError extends FaunaError {
   /**
    * The HTTP Status Code of the error.
    */


### PR DESCRIPTION
Ticket(s): [FE-3076](https://faunadb.atlassian.net/browse/FE-3076)

## Problem
The error classes don't have a common base class besides `Error`. Per standup discussion, we want to synchronize the drivers by providing a common base class.

## Solution
Create a new `abstract class FaunaError` with which to derive the other errors.

## Testing
not affected

[FE-3076]: https://faunadb.atlassian.net/browse/FE-3076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ