### PR TITLE
Tagged Type Formatting

### DIFF
--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -89,50 +89,50 @@ describe("tagged format", () => {
     // expect(result).toEqual(
     //   `{"child":{"more":{"itsworking":{"@date":"1983-04-15T00:00:00.000Z"}}},"date":{"@date":"1923-05-13T00:00:00.000Z"},"decimal":{"@decimal":4.14},"long":{"@int":32},"name":"Hello, World","number":{"@int":48},"time":{"@time":"2023-01-30T21:27:45.204Z"}}`
     // );
-    const backToObj = JSON.parse(result);
+    const backToObj = JSON.parse(result)["@object"];
     expect(backToObj.decimal).toStrictEqual({ "@decimal": 4.14 });
     expect(backToObj.extra).toHaveLength(2);
     expect(backToObj.child.more.itsworking).toStrictEqual({
-      "@date": "1983-04-15T00:00:00.000Z",
+      "@date": "1983-04-15",
     });
   });
 
   it("handleds conflicts", () => {
     var result = TaggedTypeFormat.encode({
-      date: { "@date": new Date(2022, 11, 1) },
-      time: { "@time": new Date(2022, 11, 2) },
+      date: { "@date": new Date("2022-11-01T00:00:00.000Z") },
+      time: { "@time": new Date("2022-11-02T05:00:00.000Z") },
       int: { "@int": 1 },
       long: { "@long": 9999999999999 },
       double: { "@double": 1.99 },
     });
-    expect(result["date"]["@object"]["@date"]).toEqual(new Date(2022, 11, 1));
-    expect(result["time"]["@object"]["@time"]).toEqual(new Date(2022, 11, 2));
-    expect(result["int"]["@object"]["@int"]).toEqual(1);
-    expect(result["long"]["@object"]["@long"]).toEqual(9999999999999);
-    expect(result["double"]["@object"]["@double"]).toEqual(1.99);
+    expect(result["date"]["@object"]["@date"]).toStrictEqual({
+      "@date": "2022-11-01",
+    });
+    expect(result["time"]["@object"]["@time"]).toStrictEqual({
+      "@time": "2022-11-02T05:00:00.000Z",
+    });
+    expect(result["int"]["@object"]["@int"]).toStrictEqual({ "@int": 1 });
+    expect(result["long"]["@object"]["@long"]).toStrictEqual({
+      "@int": 9999999999999,
+    });
+    expect(result["double"]["@object"]["@double"]).toEqual({
+      "@decimal": 1.99,
+    });
   });
 
   it("handles nested conflict types", () => {
     expect(
       JSON.stringify(
         TaggedTypeFormat.encode({
-          "@object": {
+          "@date": {
             "@date": {
-              "@object": {
-                "@date": {
-                  "@object": {
-                    "@time": {
-                      "@time": "2022-12-02T02:00:00+00:00",
-                    },
-                  },
-                },
-              },
+              "@time": new Date("2022-12-02T02:00:00.000Z"),
             },
           },
         })
       )
     ).toEqual(
-      '{"@object":{"@date":{"@object":{"@date":{"@object":{"@time":{"@time":"2022-12-02T02:00:00+00:00"}}}}}}}'
+      '{"@object":{"@date":{"@object":{"@date":{"@object":{"@time":{"@time":"2022-12-02T02:00:00.000Z"}}}}}}}'
     );
   });
 

--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -86,9 +86,6 @@ describe("tagged format", () => {
       })
     );
 
-    // expect(result).toEqual(
-    //   `{"child":{"more":{"itsworking":{"@date":"1983-04-15T00:00:00.000Z"}}},"date":{"@date":"1923-05-13T00:00:00.000Z"},"decimal":{"@decimal":4.14},"long":{"@int":32},"name":"Hello, World","number":{"@int":48},"time":{"@time":"2023-01-30T21:27:45.204Z"}}`
-    // );
     const backToObj = JSON.parse(result)["@object"];
     expect(backToObj.double).toStrictEqual({ "@double": 4.14 });
     expect(backToObj.extra).toHaveLength(2);

--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -111,4 +111,28 @@ describe("tagged format", () => {
     expect(result["@long"]).toEqual(9999999999999);
     expect(result["@double"]).toEqual(1.99);
   });
+
+  it("handles nested conflict types", () => {
+    expect(
+      JSON.stringify(
+        TaggedTypeFormat.encode({
+          "@object": {
+            "@date": {
+              "@object": {
+                "@date": {
+                  "@object": {
+                    "@time": {
+                      "@time": "2022-12-02T02:00:00+00:00",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+      )
+    ).toEqual(
+      '{"@object":{"@date":{"@object":{"@date":{"@object":{"@time":{"@time":"2022-12-02T02:00:00+00:00"}}}}}}}'
+    );
+  });
 });

--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -65,7 +65,7 @@ describe("tagged format", () => {
       TaggedTypeFormat.encode({
         child: { more: { itsworking: new Date("1983-04-15") } },
         date: new Date("1923-05-13"),
-        decimal: 4.14,
+        double: 4.14,
         long: 32,
         name: "Hello, World",
         number: 48,
@@ -90,7 +90,7 @@ describe("tagged format", () => {
     //   `{"child":{"more":{"itsworking":{"@date":"1983-04-15T00:00:00.000Z"}}},"date":{"@date":"1923-05-13T00:00:00.000Z"},"decimal":{"@decimal":4.14},"long":{"@int":32},"name":"Hello, World","number":{"@int":48},"time":{"@time":"2023-01-30T21:27:45.204Z"}}`
     // );
     const backToObj = JSON.parse(result)["@object"];
-    expect(backToObj.decimal).toStrictEqual({ "@decimal": 4.14 });
+    expect(backToObj.double).toStrictEqual({ "@double": 4.14 });
     expect(backToObj.extra).toHaveLength(2);
     expect(backToObj.child.more.itsworking).toStrictEqual({
       "@date": "1983-04-15",
@@ -116,7 +116,7 @@ describe("tagged format", () => {
       "@int": 9999999999999,
     });
     expect(result["double"]["@object"]["@double"]).toEqual({
-      "@decimal": 1.99,
+      "@double": 1.99,
     });
   });
 

--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -12,7 +12,6 @@ describe("tagged format", () => {
       "name": "fir",
       "age": { "@int": "200" },
       "birthdate": { "@date": "1823-02-08" },
-      "molecules": { "@long": "999999999999999999" },
       "circumference": { "@double": "3.82" },
       "created_at": { "@time": "2003-02-08T13:28:12.000555+00:00" },
       "extras": {
@@ -34,7 +33,8 @@ describe("tagged format", () => {
           "employee": { "@int": "5" },
           "time": { "@time": "2023-02-08T14:22:01.000001+00:00" }
         }
-      ]
+      ],
+      "molecules": { "@long": "999999999999999999" }
     }`;
 
     const bugs_mod: Module = "Bugs";
@@ -46,7 +46,6 @@ describe("tagged format", () => {
     expect(result.name).toEqual("fir");
     expect(result.age).toEqual(200);
     expect(result.birthdate).toBeInstanceOf(Date);
-    expect(result.molecules).toEqual(999999999999999999);
     expect(result.circumference).toEqual(3.82);
     expect(result.created_at).toBeInstanceOf(Date);
     expect(result.extras.nest.num_sticks).toEqual(58);
@@ -58,6 +57,7 @@ describe("tagged format", () => {
     expect(result.measurements[1].id).toEqual(2);
     expect(result.measurements[1].employee).toEqual(5);
     expect(result.measurements[1].time).toBeInstanceOf(Date);
+    expect(result.molecules).toEqual(BigInt("999999999999999999"));
   });
 
   it("can be encoded", () => {
@@ -66,7 +66,7 @@ describe("tagged format", () => {
         child: { more: { itsworking: new Date("1983-04-15") } },
         date: new Date("1923-05-13"),
         double: 4.14,
-        long: 32,
+        int: 32,
         name: "Hello, World",
         number: 48,
         time: new Date("2023-01-30T16:27:45.204243-05:00"),
@@ -94,12 +94,12 @@ describe("tagged format", () => {
     });
   });
 
-  it("handleds conflicts", () => {
+  it("handles conflicts", () => {
     var result = TaggedTypeFormat.encode({
       date: { "@date": new Date("2022-11-01T00:00:00.000Z") },
       time: { "@time": new Date("2022-11-02T05:00:00.000Z") },
       int: { "@int": 1 },
-      long: { "@long": 9999999999999 },
+      long: { "@long": BigInt("99999999999999999") },
       double: { "@double": 1.99 },
     });
     expect(result["date"]["@object"]["@date"]).toStrictEqual({
@@ -110,7 +110,7 @@ describe("tagged format", () => {
     });
     expect(result["int"]["@object"]["@int"]).toStrictEqual({ "@int": 1 });
     expect(result["long"]["@object"]["@long"]).toStrictEqual({
-      "@int": 9999999999999,
+      "@long": "99999999999999999",
     });
     expect(result["double"]["@object"]["@double"]).toEqual({
       "@double": 1.99,

--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -99,17 +99,17 @@ describe("tagged format", () => {
 
   it("handleds conflicts", () => {
     var result = TaggedTypeFormat.encode({
-      "@date": new Date(2022, 11, 1),
-      "@time": new Date(2022, 11, 2),
-      "@int": 1,
-      "@long": 9999999999999,
-      "@double": 1.99,
+      date: { "@date": new Date(2022, 11, 1) },
+      time: { "@time": new Date(2022, 11, 2) },
+      int: { "@int": 1 },
+      long: { "@long": 9999999999999 },
+      double: { "@double": 1.99 },
     });
-    expect(result["@date"]).toEqual(new Date(2022, 11, 1));
-    expect(result["@time"]).toEqual(new Date(2022, 11, 2));
-    expect(result["@int"]).toEqual(1);
-    expect(result["@long"]).toEqual(9999999999999);
-    expect(result["@double"]).toEqual(1.99);
+    expect(result["date"]["@object"]["@date"]).toEqual(new Date(2022, 11, 1));
+    expect(result["time"]["@object"]["@time"]).toEqual(new Date(2022, 11, 2));
+    expect(result["int"]["@object"]["@int"]).toEqual(1);
+    expect(result["long"]["@object"]["@long"]).toEqual(9999999999999);
+    expect(result["double"]["@object"]["@double"]).toEqual(1.99);
   });
 
   it("handles nested conflict types", () => {
@@ -134,5 +134,15 @@ describe("tagged format", () => {
     ).toEqual(
       '{"@object":{"@date":{"@object":{"@date":{"@object":{"@time":{"@time":"2022-12-02T02:00:00+00:00"}}}}}}}'
     );
+  });
+
+  it("wraps user-provided `@` fields", () => {
+    expect(
+      JSON.stringify(
+        TaggedTypeFormat.encode({
+          "@foo": true,
+        })
+      )
+    ).toEqual('{"@object":{"@foo":true}}');
   });
 });

--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -1,0 +1,114 @@
+import {
+  TaggedTypeFormat,
+  DocumentReference,
+  Module,
+} from "../../src/tagged-type";
+
+describe("tagged format", () => {
+  it("can be decoded", () => {
+    const allTypes: string = `{
+      "bugs_coll": { "@mod": "Bugs" },
+      "bug": { "@doc": "Bugs:123" },
+      "name": "fir",
+      "age": { "@int": "200" },
+      "birthdate": { "@date": "1823-02-08" },
+      "molecules": { "@long": "999999999999999999" },
+      "circumference": { "@double": "3.82" },
+      "created_at": { "@time": "2003-02-08T13:28:12.000555+00:00" },
+      "extras": {
+        "nest": {
+          "@object": {
+            "num_sticks": { "@int": "58" },
+            "@extras": { "egg": { "fertilized": false } }
+          }
+        }
+      },
+      "measurements": [
+        {
+          "id": { "@int": "1" },
+          "employee": { "@int": "3" },
+          "time": { "@time": "2013-02-08T12:00:05.000123+00:00" }
+        },
+        {
+          "id": { "@int": "2" },
+          "employee": { "@int": "5" },
+          "time": { "@time": "2023-02-08T14:22:01.000001+00:00" }
+        }
+      ]
+    }`;
+
+    const bugs_mod: Module = "Bugs";
+    const bugs_doc: DocumentReference = "Bugs:123";
+
+    const result = TaggedTypeFormat.decode(allTypes);
+    expect(result.bugs_coll).toBe(bugs_mod);
+    expect(result.bug).toBe(bugs_doc);
+    expect(result.name).toEqual("fir");
+    expect(result.age).toEqual(200);
+    expect(result.birthdate).toBeInstanceOf(Date);
+    expect(result.molecules).toEqual(999999999999999999);
+    expect(result.circumference).toEqual(3.82);
+    expect(result.created_at).toBeInstanceOf(Date);
+    expect(result.extras.nest.num_sticks).toEqual(58);
+    expect(result.extras.nest["@extras"].egg.fertilized).toBe(false);
+    expect(result.measurements).toHaveLength(2);
+    expect(result.measurements[0].id).toEqual(1);
+    expect(result.measurements[0].employee).toEqual(3);
+    expect(result.measurements[0].time).toBeInstanceOf(Date);
+    expect(result.measurements[1].id).toEqual(2);
+    expect(result.measurements[1].employee).toEqual(5);
+    expect(result.measurements[1].time).toBeInstanceOf(Date);
+  });
+
+  it("can be encoded", () => {
+    let result = JSON.stringify(
+      TaggedTypeFormat.encode({
+        child: { more: { itsworking: new Date("1983-04-15") } },
+        date: new Date("1923-05-13"),
+        decimal: 4.14,
+        long: 32,
+        name: "Hello, World",
+        number: 48,
+        time: new Date("2023-01-30T16:27:45.204243-05:00"),
+        extra: [
+          {
+            id: 1,
+            time: new Date(),
+          },
+          {
+            id: 2,
+            time: new Date(),
+          },
+        ],
+        "@foobar": {
+          date: new Date("1888-08-08"),
+        },
+      })
+    );
+
+    // expect(result).toEqual(
+    //   `{"child":{"more":{"itsworking":{"@date":"1983-04-15T00:00:00.000Z"}}},"date":{"@date":"1923-05-13T00:00:00.000Z"},"decimal":{"@decimal":4.14},"long":{"@int":32},"name":"Hello, World","number":{"@int":48},"time":{"@time":"2023-01-30T21:27:45.204Z"}}`
+    // );
+    const backToObj = JSON.parse(result);
+    expect(backToObj.decimal).toStrictEqual({ "@decimal": 4.14 });
+    expect(backToObj.extra).toHaveLength(2);
+    expect(backToObj.child.more.itsworking).toStrictEqual({
+      "@date": "1983-04-15T00:00:00.000Z",
+    });
+  });
+
+  it("handleds conflicts", () => {
+    var result = TaggedTypeFormat.encode({
+      "@date": new Date(2022, 11, 1),
+      "@time": new Date(2022, 11, 2),
+      "@int": 1,
+      "@long": 9999999999999,
+      "@double": 1.99,
+    });
+    expect(result["@date"]).toEqual(new Date(2022, 11, 1));
+    expect(result["@time"]).toEqual(new Date(2022, 11, 2));
+    expect(result["@int"]).toEqual(1);
+    expect(result["@long"]).toEqual(9999999999999);
+    expect(result["@double"]).toEqual(1.99);
+  });
+});

--- a/lib/tagged-type.d.ts
+++ b/lib/tagged-type.d.ts
@@ -1,0 +1,21 @@
+export declare type Module = string;
+export declare type DocumentReference = string;
+/**
+ * TaggedType provides the encoding/decoding of the Fauna Tagged Type formatting
+ */
+export declare class TaggedTypeFormat {
+    /**
+     * Encode the Object to the Tagged Type format for Fauna
+     *
+     * @param obj - Object that will be encoded
+     * @returns Map of result
+     */
+    static encode(obj: any): any;
+    /**
+     * Decode the JSON string result from Fauna to remove Tagged Type formatting.
+     *
+     * @param input - JSON string result from Fauna
+     * @returns object of result of FQL query
+     */
+    static decode(input: string): any;
+}

--- a/lib/values.d.ts
+++ b/lib/values.d.ts
@@ -1,0 +1,22 @@
+/**
+ * An Instant represents a fixed point in time (called "exact time"), without
+ * regard to calendar or location, e.g. July 20, 1969, at 20:17 UTC.
+ *
+ * @remarks This class follows the TC39 proposal for `Temporal.Instant`. See the
+ * proposal here: https://tc39.es/proposal-temporal/docs/index.html.
+ * Since fauna has both `Time` and `Date` data types, we want to make a clear
+ * distinction between them and avoid using the native `Date` class.
+ */
+declare class Instant {
+}
+/**
+ * A Temporal.PlainDate object represents a calendar date that is not associated
+ * with a particular time or time zone, e.g. August 24th, 2006.
+ *
+ * @remarks This class follows the TC39 proposal for `Temporal.Plain`. See the
+ * proposal here: https://tc39.es/proposal-temporal/docs/index.html.
+ * Since fauna has both `Time` and `Date` data types, we want to make a clear
+ * distinction between them and avoid using the native `Date` class.
+ */
+declare class PlainDate {
+}

--- a/lib/values.d.ts
+++ b/lib/values.d.ts
@@ -7,16 +7,16 @@
  * Since fauna has both `Time` and `Date` data types, we want to make a clear
  * distinction between them and avoid using the native `Date` class.
  */
-declare class Instant {
+declare class FaunaTime {
 }
 /**
  * A Temporal.PlainDate object represents a calendar date that is not associated
  * with a particular time or time zone, e.g. August 24th, 2006.
  *
- * @remarks This class follows the TC39 proposal for `Temporal.Plain`. See the
+ * @remarks This class follows the TC39 proposal for `Temporal.PlainDate`. See the
  * proposal here: https://tc39.es/proposal-temporal/docs/index.html.
  * Since fauna has both `Time` and `Date` data types, we want to make a clear
  * distinction between them and avoid using the native `Date` class.
  */
-declare class PlainDate {
+declare class FaunaDate {
 }

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -31,8 +31,6 @@ export class TaggedTypeFormat {
         return Number(value["@int"]);
       } else if (value["@long"]) {
         return Number(value["@long"]);
-      } else if (value["@decimal"]) {
-        return Number(value["@decimal"]);
       } else if (value["@double"]) {
         return Number(value["@double"]);
       } else if (value["@date"]) {
@@ -54,7 +52,7 @@ class TaggedTypeEncoded {
   readonly #encodeMap = {
     number: (value: number): { [key: string]: number } => {
       if (`${value}`.indexOf(".") > 0) {
-        return { "@decimal": value };
+        return { "@double": value };
       } else {
         return { "@int": value };
       }

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -12,7 +12,7 @@ export class TaggedTypeFormat {
    * @returns Map of result
    */
   static encode(obj: any): any {
-    return new taggedTypeEncoded(obj).result;
+    return new TaggedTypeEncoded(obj).result;
   }
 
   /**
@@ -48,7 +48,7 @@ export class TaggedTypeFormat {
   }
 }
 
-class taggedTypeEncoded {
+class TaggedTypeEncoded {
   readonly result: any;
 
   readonly #encodeMap = {

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -84,7 +84,7 @@ class TaggedTypeEncoded {
     },
     object: (input: any): TaggedObject | Record<string, any> => {
       let wrapped = false;
-      const _out: { [key: string]: any } = {};
+      const _out: Record<string, any> = {};
 
       for (const k in input) {
         if (k.startsWith("@")) {

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -1,0 +1,117 @@
+export type Module = string;
+export type DocumentReference = string;
+
+/**
+ * TaggedType provides the encoding/decoding of the Fauna Tagged Type formatting
+ */
+export class TaggedTypeFormat {
+  /**
+   * Encode the Object to the Tagged Type format for Fauna
+   *
+   * @param obj - Object that will be encoded
+   * @returns Map of result
+   */
+  static encode(obj: any): any {
+    return new taggedTypeEncoded(obj).result;
+  }
+
+  /**
+   * Decode the JSON string result from Fauna to remove Tagged Type formatting.
+   *
+   * @param input - JSON string result from Fauna
+   * @returns object of result of FQL query
+   */
+  static decode(input: string): any {
+    return JSON.parse(input, (_, value: any) => {
+      if (value["@mod"]) {
+        return value["@mod"] as Module;
+      } else if (value["@doc"]) {
+        return value["@doc"] as DocumentReference;
+      } else if (value["@int"]) {
+        return Number(value["@int"]);
+      } else if (value["@long"]) {
+        return Number(value["@long"]);
+      } else if (value["@decimal"]) {
+        return Number(value["@decimal"]);
+      } else if (value["@double"]) {
+        return Number(value["@double"]);
+      } else if (value["@date"]) {
+        return new Date(value["@date"]);
+      } else if (value["@time"]) {
+        return new Date(value["@time"]);
+      } else if (value["@object"]) {
+        return value["@object"];
+      }
+
+      return value;
+    });
+  }
+}
+
+class taggedTypeEncoded {
+  readonly result: any;
+
+  readonly #encodeMap = {
+    number: (value: number): { [key: string]: number } => {
+      if (`${value}`.indexOf(".") > 0) {
+        return { "@decimal": value };
+      } else {
+        return { "@int": value };
+      }
+    },
+    string: (value: string): string => {
+      return value;
+    },
+    object: (input: any): { [key: string]: string } => {
+      const _out: { [key: string]: any } = {};
+      for (const k in input) {
+        if (k.startsWith("@")) {
+          _out[k] = input[k];
+        } else {
+          _out[k] = TaggedTypeFormat.encode(input[k]);
+        }
+      }
+      return _out;
+    },
+    array: (input: Array<any>): Array<any> => {
+      const _out: any = [];
+      for (const i in input) _out.push(TaggedTypeFormat.encode(input[i]));
+
+      return _out;
+    },
+    date: (dateValue: Date): { [key: string]: string } => {
+      if (
+        dateValue.getUTCHours() == 0 &&
+        dateValue.getUTCMinutes() == 0 &&
+        dateValue.getUTCSeconds() == 0 &&
+        dateValue.getUTCMilliseconds() == 0
+      ) {
+        return { "@date": dateValue.toISOString() };
+      }
+
+      return { "@time": dateValue.toISOString() };
+    },
+  };
+
+  constructor(input: any) {
+    this.result = {};
+
+    switch (typeof input) {
+      case "string":
+        this.result = this.#encodeMap["string"](input);
+        break;
+      case "number":
+        this.result = this.#encodeMap["number"](input);
+        break;
+      case "object":
+        if (Array.isArray(input)) {
+          this.result = this.#encodeMap["array"](input);
+        } else if (input instanceof Date) {
+          this.result = this.#encodeMap["date"](input);
+        } else {
+          this.result = this.#encodeMap["object"](input);
+        }
+        break;
+    }
+  }
+}

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -46,11 +46,18 @@ export class TaggedTypeFormat {
   }
 }
 
+type TaggedDate = { "@date": string };
+type TaggedDouble = { "@double": number };
+type TaggedInt = { "@int": number };
+type TaggedLong = { "@long": string };
+type TaggedObject = { "@object": Record<string, any> };
+type TaggedTime = { "@time": string };
+
 class TaggedTypeEncoded {
   readonly result: any;
 
   readonly #encodeMap = {
-    bigint: (value: bigint): { "@long": bigint } => {
+    bigint: (value: bigint): TaggedLong => {
       if (value >= -(2 ^ 63) + 1 && value <= 2 ** 63 - 1) {
         return {
           "@long": value.toString(),
@@ -58,7 +65,7 @@ class TaggedTypeEncoded {
       }
       throw new TypeError("Precision loss when converting int to Fauna type");
     },
-    number: (value: number): { [key: string]: number } => {
+    number: (value: number): TaggedDouble | TaggedInt | TaggedLong => {
       if (`${value}`.includes(".")) {
         return { "@double": value };
       } else {
@@ -75,7 +82,7 @@ class TaggedTypeEncoded {
     string: (value: string): string => {
       return value;
     },
-    object: (input: any): { [key: string]: string } => {
+    object: (input: any): TaggedObject | Record<string, any> => {
       let wrapped = false;
       const _out: { [key: string]: any } = {};
 
@@ -92,7 +99,7 @@ class TaggedTypeEncoded {
       for (const i in input) _out.push(TaggedTypeFormat.encode(input[i]));
       return _out;
     },
-    date: (dateValue: Date): { [key: string]: string } => {
+    date: (dateValue: Date): TaggedDate | TaggedTime => {
       if (
         dateValue.getUTCHours() == 0 &&
         dateValue.getUTCMinutes() == 0 &&

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -66,7 +66,7 @@ class TaggedTypeEncoded {
       const _out: { [key: string]: any } = {};
       for (const k in input) {
         if (k.startsWith("@")) {
-          _out[k] = input[k];
+          _out["@object"] = k == "@object" ? input[k] : { [k]: input[k] };
         } else {
           _out[k] = TaggedTypeFormat.encode(input[k]);
         }

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -53,7 +53,7 @@ class TaggedTypeEncoded {
     bigint: (value: bigint): { "@long": bigint } => {
       if (value >= -(2 ^ 63) + 1 && value <= 2 ** 63 - 1) {
         return {
-          "@long": value,
+          "@long": value.toString(),
         };
       }
       throw new TypeError("Precision loss when converting int to Fauna type");
@@ -66,7 +66,7 @@ class TaggedTypeEncoded {
           return { "@int": value };
         } else if (value >= -(2 ^ 63) + 1 && value <= 2 ** 63 - 1) {
           return {
-            "@long": value,
+            "@long": value.toString(),
           };
         }
         return { "@double": value };
@@ -111,6 +111,9 @@ class TaggedTypeEncoded {
     this.result = input;
 
     switch (typeof input) {
+      case "bigint":
+        this.result = this.#encodeMap["bigint"](input);
+        break;
       case "string":
         this.result = this.#encodeMap["string"](input);
         break;

--- a/src/values.ts
+++ b/src/values.ts
@@ -7,15 +7,15 @@
  * Since fauna has both `Time` and `Date` data types, we want to make a clear
  * distinction between them and avoid using the native `Date` class.
  */
-class Instant {}
+class FaunaTime {}
 
 /**
  * A Temporal.PlainDate object represents a calendar date that is not associated
  * with a particular time or time zone, e.g. August 24th, 2006.
  *
- * @remarks This class follows the TC39 proposal for `Temporal.Plain`. See the
+ * @remarks This class follows the TC39 proposal for `Temporal.PlainDate`. See the
  * proposal here: https://tc39.es/proposal-temporal/docs/index.html.
  * Since fauna has both `Time` and `Date` data types, we want to make a clear
  * distinction between them and avoid using the native `Date` class.
  */
-class PlainDate {}
+class FaunaDate {}

--- a/src/values.ts
+++ b/src/values.ts
@@ -1,0 +1,21 @@
+/**
+ * An Instant represents a fixed point in time (called "exact time"), without
+ * regard to calendar or location, e.g. July 20, 1969, at 20:17 UTC.
+ *
+ * @remarks This class follows the TC39 proposal for `Temporal.Instant`. See the
+ * proposal here: https://tc39.es/proposal-temporal/docs/index.html.
+ * Since fauna has both `Time` and `Date` data types, we want to make a clear
+ * distinction between them and avoid using the native `Date` class.
+ */
+class Instant {}
+
+/**
+ * A Temporal.PlainDate object represents a calendar date that is not associated
+ * with a particular time or time zone, e.g. August 24th, 2006.
+ *
+ * @remarks This class follows the TC39 proposal for `Temporal.Plain`. See the
+ * proposal here: https://tc39.es/proposal-temporal/docs/index.html.
+ * Since fauna has both `Time` and `Date` data types, we want to make a clear
+ * distinction between them and avoid using the native `Date` class.
+ */
+class PlainDate {}


### PR DESCRIPTION
Ticket(s): FE-2979

## Problem

Latest version of FQL X defaults to tagged type formatting

## Solution

Implement tagged type formatting encoding/decoding

## Result

Can send/received tagged type format

## Out of scope

Updating the Client request/response to use `tagged` format

## Testing
