### PR TITLE
add simple integ test against existing collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ import { Client } from "fauna";
 const client = new Client({ endpoint: endpoints.preview });
 ```
 
-The following snippet uses the client object, just created inthe previous example, to execute queries in Fauna.
+The following snippet uses the client object, just created in the previous example, to execute queries in Fauna.
 
 ```typescript
 (async () => {
@@ -96,7 +96,7 @@ The following snippet uses the client object, just created inthe previous exampl
 
 ## Export your secret as an environment variable
 
-Rather than hard coding your secret into your code, the driver can load your secret automaticaly from a FAUNA_SECRET evironment variable. Open a terminal and execute the following command:
+Rather than hard coding your secret into your code, the driver can load your secret automatically from a FAUNA_SECRET environment variable. Open a terminal and execute the following command:
 
 `export FAUNA_SECRET=your-secret`
 

--- a/__tests__/integration/existing-collection.test.ts
+++ b/__tests__/integration/existing-collection.test.ts
@@ -1,0 +1,119 @@
+import { Client } from "../../src";
+import { endpoints } from "../../src";
+import { ServiceError } from "../../src";
+import { env } from "process";
+import { fql } from "../../src";
+
+const client = new Client({
+  endpoint: env["endpoint"] ? new URL(env["endpoint"]) : endpoints.local,
+  max_conns: 5,
+  secret: env["secret"] || "secret",
+});
+
+const authorsData = [
+  {
+    firstName: "one",
+    lastName: "one",
+    genre: "mystery",
+  },
+  {
+    firstName: "two",
+    lastName: "two",
+    genre: "fantasy",
+  },
+  {
+    firstName: "three",
+    lastName: "four",
+    genre: "sci-fi",
+  },
+  {
+    firstName: "five",
+    lastName: "six",
+    genre: "sci-fi",
+  },
+  {
+    firstName: "seven",
+    lastName: "eight",
+    genre: "mystery",
+  },
+];
+
+beforeAll(async () => {
+  /**
+   * The intent of these tests is to run against an already existing collection and so
+   * the creation/schema updates aren't necessary.  The below collection/schema creation
+   * is intended to only be run the first time this is executed for a given environment.
+   * The actual data creation is fine to execute multiple times due to the presence of the
+   * unique constraint in the schema.
+   */
+  const collDoesNotExist = (
+    await client.query(fql`
+  Collection.byName("Authors") == null
+  `)
+  ).data;
+  if (collDoesNotExist) {
+    console.log(
+      "No existing Authors collection found, creating collection and schema."
+    );
+    console.log(
+      await client.query(fql`
+    Collection.create({
+      name: "Authors",
+      indexes: {
+        byName: {
+          terms: [ { field: "firstName" }, { field: "lastName" } ]
+        },
+        byGenre: {
+          terms: [ { field: "genre" } ]
+        }
+      },
+      constraints: [
+        { unique: [ "firstName", "lastName" ] }
+      ]
+    })
+    `)
+    );
+  }
+  for (const author of authorsData) {
+    try {
+      await client.query(fql`
+    Authors.create(${author})
+    `);
+    } catch (error) {
+      if (error instanceof ServiceError) {
+        // we expect unique constraint errors to happen with our schema
+        if (!error.message.includes("unique constraint")) {
+          throw error;
+        }
+      } else {
+        throw error;
+      }
+    }
+  }
+});
+
+describe("querying for existing data", () => {
+  it("Can query an existing index", async () => {
+    const authorsByScifi = [
+      {
+        firstName: "three",
+        lastName: "four",
+        genre: "sci-fi",
+      },
+      {
+        firstName: "five",
+        lastName: "six",
+        genre: "sci-fi",
+      },
+    ];
+
+    const result = await client.query(fql`
+    Authors.byGenre("sci-fi") {
+      firstName,
+      lastName,
+      genre
+    }
+    `);
+    expect(result.data.data).toEqual(authorsByScifi);
+  });
+});

--- a/__tests__/integration/existing-collection.test.ts
+++ b/__tests__/integration/existing-collection.test.ts
@@ -1,14 +1,8 @@
-import { Client } from "../../src";
-import { endpoints } from "../../src";
+import { getClient } from "../client";
 import { ServiceError } from "../../src";
-import { env } from "process";
 import { fql } from "../../src";
 
-const client = new Client({
-  endpoint: env["endpoint"] ? new URL(env["endpoint"]) : endpoints.local,
-  max_conns: 5,
-  secret: env["secret"] || "secret",
-});
+const client = getClient();
 
 const authorsData = [
   {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "fauna-local-alt-port": "docker start faunadb-fql-x-alt-port || docker run --rm -d --name faunadb-fql-x-alt-port -p 7443:8443 -p 7084:8084 fauna/faunadb",
     "prepare": "husky install",
     "test": "yarn fauna-local; yarn fauna-local-alt-port; ./prepare-test-env.sh; jest",
-    "test:ci": "yarn install; jest --ci --reporters=default --reporters=jest-junit"
+    "test:ci": "yarn install; jest --ci --reporters=default --reporters=jest-junit",
+    "test:integration": "yarn install; jest --run-in-band ./__tests__/integration"
   },
   "jest-junit": {
     "outputDirectory": "reports",


### PR DESCRIPTION
We have now finalized our collection data format and will begin giving some customers early access to fql x.  This test is going to ensure that we don't make any backwards incompatible changes to our collection data format.  The plan is to run this after the dev and preview deploys in the database pipeline.

We also plan to run the full drivers test suite in these pipelines to ensure we don't have any backwards incompatible drivers changes.  Some of those tests don't currently work when pointed at dev, taking an incremental approach here and will be getting this test in the pipeline first while I work on resolving the other drivers tests.  At that point will switch to running all of the integ tests in the pipeline.

