### PR TITLE
Use public docker image for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
     "build:node": "esbuild src/index.ts --bundle --sourcemap --platform=node --outfile=lib/node/index.js",
     "build:types": "tsc -emitDeclarationOnly --declaration true",
     "lint": "eslint -f unix \"src/**/*.{ts,tsx}\"",
-    "fauna-local": "docker start faunadb-fql-x || docker run --rm -d --name faunadb-fql-x -p 8443:8443 -p 8084:8084 -v $PWD/fauna-local-config.yml:/fauna/etc/fauna-local-config.yml gcr.io/faunadb-cloud/faunadb/enterprise --config /fauna/etc/fauna-local-config.yml",
-    "fauna-local-alt-port": "docker start faunadb-fql-x-alt-port || docker run --rm -d --name faunadb-fql-x-alt-port -p 7443:8443 -p 7084:8084 -v $PWD/fauna-local-config.yml:/fauna/etc/fauna-local-config.yml gcr.io/faunadb-cloud/faunadb/enterprise --config /fauna/etc/fauna-local-config.yml",
+    "fauna-local": "docker start faunadb-fql-x || docker run --rm -d --name faunadb-fql-x -p 8443:8443 -p 8084:8084 -v $PWD/fauna-local-config.yml:/fauna/etc/fauna-local-config.yml fauna/faunadb --config /fauna/etc/fauna-local-config.yml",
+    "fauna-local-alt-port": "docker start faunadb-fql-x-alt-port || docker run --rm -d --name faunadb-fql-x-alt-port -p 7443:8443 -p 7084:8084 -v $PWD/fauna-local-config.yml:/fauna/etc/fauna-local-config.yml fauna/faunadb --config /fauna/etc/fauna-local-config.yml",
     "prepare": "husky install",
     "test": "yarn fauna-local; yarn fauna-local-alt-port; ./prepare-test-env.sh; jest",
     "test:ci": "yarn install; jest --ci --reporters=default --reporters=jest-junit"


### PR DESCRIPTION
Ticket(s): [FE-3079](https://faunadb.atlassian.net/browse/FE-3079)

## Problem
Can run tests out of the box unless you have access to the private repo

## Solution
FQLX can be enabled in the public docker image, now, so we can test against that

## Result
update the test scripts in package.json

## Testing
I've been temporarily doing this the whole time and now am finally making a PR for it 😄

[FE-3079]: https://faunadb.atlassian.net/browse/FE-3079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ