### PR TITLE
Remove max_conns configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ export interface QueryRequestHeaders {
 }
 ```
 
-The following example shows how to set the `linearized` and `max_contention_rertries` headers object to a Client instance:
+The following example shows how to set the `linearized` and `max_contention_retries` headers object to a Client instance:
 
 ```typescript
 const client = new Client({

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ import { Client, endpoints, fql } from "fauna";
 
 const client = new Client({
   endpoint: endpoints.preview,
-  max_conns: 5, // maximum number of connections to keep alive and awaiting requests to Fauna
   secret: "<my_fauna_secret>",
   query_timeout_ms: 60_000,
 });
@@ -68,7 +67,6 @@ import { Client } from "fauna";
 
 const client = new Client();
 // secret defaults to whatever is stored in a FAUNA_SECRET environmental variable
-// max_conns defaults to 10
 // query_timeout_ms defaults to 60,000
 // endpoint defaults to endpoints.cloud
 ```
@@ -260,12 +258,11 @@ export interface QueryRequestHeaders {
 }
 ```
 
-The following example shows how to set the `linearized` and `max_connection_rertries` headers object to a Client instance:
+The following example shows how to set the `linearized` and `max_contention_rertries` headers object to a Client instance:
 
 ```typescript
 const client = new Client({
   endpoint: endpoints.preview,
-  max_conns: 5,
   secret,
   query_timeout_ms: 60_000,
   linearized: true,

--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -52,7 +52,6 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
     });
     const client = getClient({
       endpoint: endpoints["my-alternative-port"],
-      max_conns: 5,
       secret: "secret",
       query_timeout_ms: 60_000,
     });
@@ -109,7 +108,6 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
 
       const client = getClient(
         {
-          max_conns: 5,
           query_timeout_ms: 5000,
           [fieldName]: fieldValue,
         },

--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -10,7 +10,6 @@ import { fql } from "../../src/query-builder";
 import { ClientError } from "../../src/errors";
 
 const client = getClient({
-  max_conns: 5,
   query_timeout_ms: 60_000,
 });
 

--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -18,7 +18,6 @@ describe("last_txn_ts tracking in client", () => {
 
     const myClient = getClient(
       {
-        max_conns: 5,
         query_timeout_ms: 60_000,
       },
       httpClient
@@ -68,7 +67,6 @@ if (Collection.byName('Products') == null) {\
 
     const myClient = getClient(
       {
-        max_conns: 5,
         query_timeout_ms: 60_000,
       },
       httpClient

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -1,10 +1,6 @@
-import { env } from "process";
 import { getClient } from "../client";
 import { Client } from "../../src/client";
-import {
-  type ClientConfiguration,
-  endpoints,
-} from "../../src/client-configuration";
+import { type ClientConfiguration } from "../../src/client-configuration";
 import {
   AuthenticationError,
   ClientError,
@@ -19,7 +15,6 @@ import { fql } from "../../src/query-builder";
 import { type QueryRequest, QuerySuccess } from "../../src/wire-protocol";
 
 const client = getClient({
-  max_conns: 5,
   query_timeout_ms: 60_000,
 });
 
@@ -118,7 +113,6 @@ describe.each`
       };
       const clientConfiguration: Partial<ClientConfiguration> = {
         format: "tagged",
-        max_conns: 5,
         query_timeout_ms: 60,
         linearized: true,
         max_contention_retries: 7,
@@ -184,7 +178,6 @@ describe.each`
   it("throws a QueryTimeoutError if the query times out", async () => {
     expect.assertions(4);
     const badClient = getClient({
-      max_conns: 5,
       query_timeout_ms: 1,
     });
     try {
@@ -213,7 +206,6 @@ describe.each`
   it("throws a AuthenticationError creds are invalid", async () => {
     expect.assertions(4);
     const badClient = getClient({
-      max_conns: 5,
       secret: "nah",
       query_timeout_ms: 60,
     });
@@ -242,7 +234,6 @@ describe.each`
     expect.assertions(2);
     const myBadClient = getClient({
       endpoint: new URL("http://localhost:1"),
-      max_conns: 1,
       secret: "secret",
       query_timeout_ms: 60,
     });
@@ -272,7 +263,6 @@ describe.each`
     };
     const myBadClient = getClient(
       {
-        max_conns: 5,
         query_timeout_ms: 60,
       },
       httpClient
@@ -293,7 +283,6 @@ describe.each`
     expect.assertions(2);
     const badClient = getClient({
       endpoint: new URL("https://frontdoor.fauna.com/"),
-      max_conns: 5,
       secret: "nah",
       query_timeout_ms: 60,
     });

--- a/__tests__/integration/template-format.test.ts
+++ b/__tests__/integration/template-format.test.ts
@@ -2,7 +2,6 @@ import { fql } from "../../src/query-builder";
 import { getClient } from "../client";
 
 const client = getClient({
-  max_conns: 5,
   query_timeout_ms: 60_000,
 });
 

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -15,7 +15,6 @@ import { FetchClient } from "../../src/http-client";
 
 const client = getClient(
   {
-    max_conns: 5,
     query_timeout_ms: 60,
   },
   // use the FetchClient implementation, so we can mock requests

--- a/demo/README.md
+++ b/demo/README.md
@@ -43,7 +43,6 @@ import { Client, endpoints, fql } from "fauna";
 
 const client = new Client({
   endpoint: endpoints.preview,
-  max_conns: 5, // maximum number of connections to keep alive and awaiting requests to Fauna
   secret: "<my_fauna_secret>",
   query_timeout_ms: 60_000,
 });
@@ -56,7 +55,6 @@ import { Client } from "fauna";
 
 const client = new Client();
 // secret defaults to whatever is stored in a FAUNA_SECRET environmental variable
-// max_conns defaults to 10
 // query_timeout_ms defaults to 60,000
 // endpoint defaults to endpoints.cloud
 ```
@@ -97,7 +95,6 @@ const secret = getSecret();
 
 const client = new Client({
   endpoint: endpoints.preview,
-  max_conns: 5,
   secret,
   query_timeout_ms: 60_000,
 });
@@ -279,12 +276,11 @@ export interface QueryRequestHeaders {
 }
 ```
 
-The following example shows how to set the `linearized` and `max_connection_rertries` headers object to a Client instance:
+The following example shows how to set the `linearized` and `max_contention_rertries` headers object to a Client instance:
 
 ```typescript
 const client = new Client({
   endpoint: endpoints.preview,
-  max_conns: 5,
   secret,
   query_timeout_ms: 60_000,
   linearized: true,

--- a/demo/README.md
+++ b/demo/README.md
@@ -276,7 +276,7 @@ export interface QueryRequestHeaders {
 }
 ```
 
-The following example shows how to set the `linearized` and `max_contention_rertries` headers object to a Client instance:
+The following example shows how to set the `linearized` and `max_contention_retries` headers object to a Client instance:
 
 ```typescript
 const client = new Client({

--- a/demo/typescript/exercises/client-exercises.ts
+++ b/demo/typescript/exercises/client-exercises.ts
@@ -4,13 +4,11 @@ import { getSecret } from "../utils";
 
 /**
  * Your task - return a client that talks to Fauna's preview endpoint,
- * has a max_conns to Fauna of 10, and has a query timeout of 60 seconds.
+ * has a query timeout of 60 seconds.
  * You can use the imported getSecret() function to retrieve your secret from
  * the FAUNA_SECRET environmental variable.
  */
-export function constructingClients() {
-
-}
+export function constructingClients() {}
 
 /**
  * Your task - return an array the URLs of the three endpoints that come
@@ -21,9 +19,7 @@ export function constructingClients() {
  * a local container).
  * Hint: the client contains an `endpoints` object you can use for this!
  */
-export function useEndpoints() {
-
-}
+export function useEndpoints() {}
 
 /**
  * Your task - extend endpoints to have new URL endpoint of
@@ -33,9 +29,7 @@ export function useEndpoints() {
  * or call some other endpoint not supported by default in the driver (such as a local container
  * on a port other than the standatd 8443).
  */
-export function extendEndpoints() {
-
-}
+export function extendEndpoints() {}
 
 /**
  * Your task - you an also configure a client to have default values for the
@@ -49,6 +43,4 @@ export function extendEndpoints() {
  * Return a client that has linearized set to true and max_contention_retries set to 5.
  * all other settings do not matter.
  */
-export function defaultHeaders() {
-  
-}
+export function defaultHeaders() {}

--- a/demo/typescript/exercises/query-exercises.ts
+++ b/demo/typescript/exercises/query-exercises.ts
@@ -2,7 +2,6 @@ import { Client, endpoints, fql, type QuerySuccess } from "fauna";
 import { getSecret, type PartialCustomer } from "../utils";
 
 const client: Client = new Client({
-  max_conns: 10,
   secret: getSecret(),
   endpoint: endpoints.preview,
   query_timeout_ms: 60_000,

--- a/demo/typescript/solutions/client-solutions.ts
+++ b/demo/typescript/solutions/client-solutions.ts
@@ -3,7 +3,7 @@ import { getSecret } from "../utils";
 
 /**
  * Your task - return a client that talks to Fauna's preview endpoint,
- * has a max_conns to Fauna of 10, and has a query timeout of 60 seconds.
+ * has a query timeout of 60 seconds.
  * You can use the getSecret() function to retrieve your secret from
  * the FAUNA_SECRET environmental variable.
  */
@@ -14,11 +14,10 @@ export function constructingClients(): Client {
   // ClientConfiguration type to the driver.
   const clientConfiguration: ClientConfiguration = {
     // there are required and optional fields in a ClientConfiguration.
-    // Required are the endpoint, the max_conns the client should maintain to Fauna,
-    // the secret you'll use to communicate to Fauna, and the query timeout to use.
+    // Required are the endpoint, the secret you'll use to communicate to Fauna,
+    // and the query timeout to use.
     // Here's a basic settings:
     endpoint: endpoints.preview,
-    max_conns: 10,
     query_timeout_ms: 60_000,
     secret,
   };
@@ -78,7 +77,6 @@ export function defaultHeaders() {
     endpoint: endpoints.preview,
     secret: getSecret(),
     query_timeout_ms: 60_000,
-    max_conns: 10,
     linearized: true,
     max_contention_retries: 5,
   });

--- a/demo/typescript/solutions/query-solutions.ts
+++ b/demo/typescript/solutions/query-solutions.ts
@@ -3,7 +3,6 @@ import { randomUUID } from "node:crypto";
 import { getSecret, type PartialCustomer } from "../utils";
 
 const client: Client = new Client({
-  max_conns: 10,
   secret: getSecret(),
   endpoint: endpoints.preview,
   query_timeout_ms: 60_000,

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -27,10 +27,6 @@ export interface ClientConfiguration {
    */
   format?: ValueFormat;
   /**
-   * The maximum number of connections to a make to Fauna.
-   */
-  max_conns: number;
-  /**
    * A secret for your Fauna DB, used to authorize your queries.
    * @see https://docs.fauna.com/fauna/current/security/keys
    */

--- a/src/client.ts
+++ b/src/client.ts
@@ -30,14 +30,6 @@ import {
 } from "./http-client";
 import { TaggedTypeFormat } from "./tagged-type";
 
-const defaultClientConfiguration: Pick<
-  ClientConfiguration,
-  "endpoint" | "max_conns"
-> = {
-  endpoint: endpoints.cloud,
-  max_conns: 10,
-};
-
 /**
  * Client for calling Fauna.
  */
@@ -60,7 +52,6 @@ export class Client {
    *  const myClient = new Client(
    *   {
    *     endpoint: endpoints.cloud,
-   *     max_conns: 10,
    *     secret: "foo",
    *     query_timeout_ms: 60_000,
    *   }
@@ -72,7 +63,7 @@ export class Client {
     httpClient?: HTTPClient
   ) {
     this.#clientConfiguration = {
-      ...defaultClientConfiguration,
+      endpoint: endpoints.cloud,
       ...clientConfiguration,
       secret: this.#getSecret(clientConfiguration),
     };


### PR DESCRIPTION
Ticket(s): [FE-3290](https://faunadb.atlassian.net/browse/FE-3290)

## Problem
After removing axios, the `max_conns` configuration is not necessary to support the fetch or http2 APIs.

## Solution
Remove `max_conns` as a client configuration options and from the Client, tests, demo, and READMEs

There was no place where the max_conns configuration was being used, so no substantive changes were made.


[FE-3109]: https://faunadb.atlassian.net/browse/FE-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FE-3290]: https://faunadb.atlassian.net/browse/FE-3290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ