### PR TITLE
Organize request and response types

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ const client = new Client({
   endpoint: endpoints.preview,
   max_conns: 5, // maximum number of connections to keep alive and awaiting requests to Fauna
   secret: "<my_fauna_secret>",
-  query_timeout_ms: 60_000,
+  queryOptions: {
+    query_timeout_ms: 60_000,
+  },
 });
 ```
 
@@ -267,9 +269,11 @@ const client = new Client({
   endpoint: endpoints.preview,
   max_conns: 5,
   secret,
-  query_timeout_ms: 60_000,
-  linearized: true,
-  max_contention_retries: 4,
+  queryOptions: {
+    query_timeout_ms: 60_000,
+    linearized: true,
+    max_contention_retries: 4,
+  },
 });
 ```
 

--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -21,7 +21,10 @@ describe("ClientConfiguration", () => {
 
   it("Client respectes passed in client configuration over defaults", () => {
     process.env["FAUNA_SECRET"] = "foo";
-    const client = new Client({ secret: "bar", query_timeout_ms: 10 });
+    const client = new Client({
+      secret: "bar",
+      queryOptions: { query_timeout_ms: 10 },
+    });
     // TODO: when the Client accepts an http client add a mock that validates
     //   the configuration changes were applied.
   });
@@ -54,7 +57,7 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
       endpoint: endpoints["my-alternative-port"],
       max_conns: 5,
       secret: "secret",
-      query_timeout_ms: 60_000,
+      queryOptions: { query_timeout_ms: 60_000 },
     });
     const result = await client.query<number>({ query: '"taco".length' });
     expect(result.data).toEqual(4);
@@ -109,8 +112,10 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
       const client = getClient(
         {
           max_conns: 5,
-          query_timeout_ms: 5000,
-          [fieldName]: fieldValue,
+          queryOptions: {
+            query_timeout_ms: 5000,
+            [fieldName]: fieldValue,
+          },
         },
         httpClient
       );

--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -60,7 +60,7 @@ if (Collection.byName('Products') == null) {\
         if (expectedLastTxn === undefined) {
           expect(req.headers["x-last-txn-ts"]).toBeUndefined();
         } else {
-          expect(req.headers["x-last-txn-ts"]).toEqual(expectedLastTxn);
+          expect(req.headers["x-last-txn-ts"]).toEqual(String(expectedLastTxn));
         }
         return getDefaultHTTPClient().request(req);
       },

--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -19,7 +19,9 @@ describe("last_txn_ts tracking in client", () => {
     const myClient = getClient(
       {
         max_conns: 5,
-        query_timeout_ms: 60_000,
+        queryOptions: {
+          query_timeout_ms: 60_000,
+        },
       },
       httpClient
     );
@@ -69,7 +71,9 @@ if (Collection.byName('Products') == null) {\
     const myClient = getClient(
       {
         max_conns: 5,
-        query_timeout_ms: 60_000,
+        queryOptions: {
+          query_timeout_ms: 60_000,
+        },
       },
       httpClient
     );

--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -60,7 +60,7 @@ if (Collection.byName('Products') == null) {\
         if (expectedLastTxn === undefined) {
           expect(req.headers["x-last-txn-ts"]).toBeUndefined();
         } else {
-          expect(req.headers["x-last-txn-ts"]).toEqual(String(expectedLastTxn));
+          expect(req.headers["x-last-txn-ts"]).toEqual(expectedLastTxn);
         }
         return getDefaultHTTPClient().request(req);
       },

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -17,7 +17,9 @@ import { type QueryRequest, QuerySuccess } from "../../src/wire-protocol";
 
 const client = getClient({
   max_conns: 5,
-  query_timeout_ms: 60_000,
+  queryOptions: {
+    query_timeout_ms: 60_000,
+  },
 });
 
 function getTsa(tsa: TemplateStringsArray, ..._: any[]) {
@@ -114,13 +116,16 @@ describe.each`
         },
       };
       const clientConfiguration: Partial<ClientConfiguration> = {
-        format: "tagged",
+        queryOptions: {
+          format: "tagged",
+          query_timeout_ms: 60,
+          linearized: true,
+          max_contention_retries: 7,
+          query_tags: { alpha: "beta", gamma: "delta" },
+          traceparent:
+            "00-750efa5fb6a131eb2cf4db39f28366cb-000000000000000b-00",
+        },
         max_conns: 5,
-        query_timeout_ms: 60,
-        linearized: true,
-        max_contention_retries: 7,
-        query_tags: { alpha: "beta", gamma: "delta" },
-        traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-000000000000000b-00",
       };
       const myClient = getClient(clientConfiguration, httpClient);
       const headers = { [fieldName]: fieldValue };
@@ -207,7 +212,9 @@ describe.each`
     expect.assertions(4);
     const badClient = getClient({
       max_conns: 5,
-      query_timeout_ms: 1,
+      queryOptions: {
+        query_timeout_ms: 1,
+      },
     });
     try {
       await doQuery<number>(
@@ -237,7 +244,9 @@ describe.each`
     const badClient = getClient({
       max_conns: 5,
       secret: "nah",
-      query_timeout_ms: 60,
+      queryOptions: {
+        query_timeout_ms: 60,
+      },
     });
     try {
       await doQuery<number>(
@@ -266,7 +275,9 @@ describe.each`
       endpoint: new URL("http://localhost:1"),
       max_conns: 1,
       secret: "secret",
-      query_timeout_ms: 60,
+      queryOptions: {
+        query_timeout_ms: 60,
+      },
     });
     try {
       await doQuery<number>(
@@ -295,7 +306,9 @@ describe.each`
     const myBadClient = getClient(
       {
         max_conns: 5,
-        query_timeout_ms: 60,
+        queryOptions: {
+          query_timeout_ms: 60,
+        },
       },
       httpClient
     );
@@ -317,7 +330,9 @@ describe.each`
       endpoint: new URL("https://frontdoor.fauna.com/"),
       max_conns: 5,
       secret: "nah",
-      query_timeout_ms: 60,
+      queryOptions: {
+        query_timeout_ms: 60,
+      },
     });
     try {
       await doQuery<number>(queryType, getTsa`foo`, "foo", badClient);

--- a/__tests__/integration/template-format.test.ts
+++ b/__tests__/integration/template-format.test.ts
@@ -3,7 +3,9 @@ import { getClient } from "../client";
 
 const client = getClient({
   max_conns: 5,
-  query_timeout_ms: 60_000,
+  queryOptions: {
+    query_timeout_ms: 60_000,
+  },
 });
 
 describe("query using template format", () => {

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -16,7 +16,9 @@ import { FetchClient } from "../../src/http-client";
 const client = getClient(
   {
     max_conns: 5,
-    query_timeout_ms: 60,
+    queryOptions: {
+      query_timeout_ms: 60,
+    },
   },
   // use the FetchClient implementation, so we can mock requests
   new FetchClient()

--- a/demo/README.md
+++ b/demo/README.md
@@ -45,7 +45,9 @@ const client = new Client({
   endpoint: endpoints.preview,
   max_conns: 5, // maximum number of connections to keep alive and awaiting requests to Fauna
   secret: "<my_fauna_secret>",
-  query_timeout_ms: 60_000,
+  queryOptions: {
+    query_timeout_ms: 60_000,
+  },
 });
 ```
 
@@ -99,7 +101,9 @@ const client = new Client({
   endpoint: endpoints.preview,
   max_conns: 5,
   secret,
-  query_timeout_ms: 60_000,
+  queryOptions: {
+    query_timeout_ms: 60_000,
+  },
 });
 ```
 
@@ -286,9 +290,11 @@ const client = new Client({
   endpoint: endpoints.preview,
   max_conns: 5,
   secret,
-  query_timeout_ms: 60_000,
-  linearized: true,
-  max_contention_retries: 4,
+  queryOptions: {
+    query_timeout_ms: 60_000,
+    linearized: true,
+    max_contention_retries: 4,
+  },
 });
 ```
 

--- a/demo/typescript/solutions/client-solutions.ts
+++ b/demo/typescript/solutions/client-solutions.ts
@@ -19,8 +19,10 @@ export function constructingClients(): Client {
     // Here's a basic settings:
     endpoint: endpoints.preview,
     max_conns: 10,
-    query_timeout_ms: 60_000,
     secret,
+    queryOptions: {
+      query_timeout_ms: 60_000,
+    },
   };
   // note, the driver also exposes an "endpoints" constant that embeds certain default
   // endpoints you can configure a client with.
@@ -77,9 +79,11 @@ export function defaultHeaders() {
   return new Client({
     endpoint: endpoints.preview,
     secret: getSecret(),
-    query_timeout_ms: 60_000,
     max_conns: 10,
-    linearized: true,
-    max_contention_retries: 5,
+    queryOptions: {
+      query_timeout_ms: 60_000,
+      linearized: true,
+      max_contention_retries: 5,
+    },
   });
 }

--- a/demo/typescript/solutions/query-solutions.ts
+++ b/demo/typescript/solutions/query-solutions.ts
@@ -6,7 +6,9 @@ const client: Client = new Client({
   max_conns: 10,
   secret: getSecret(),
   endpoint: endpoints.preview,
-  query_timeout_ms: 60_000,
+  queryOptions: {
+    query_timeout_ms: 60_000,
+  },
 });
 
 /**

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -896,15 +896,6 @@ acorn@^8.4.1, acorn@^8.8.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
   integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
-agentkeepalive@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
-  integrity sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==
-  dependencies:
-    debug "^4.1.0"
-    depd "^1.1.2"
-    humanize-ms "^1.2.1"
-
 ajv@^6.10.0, ajv@^6.12.4, ajv@~6.12.6:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -990,20 +981,6 @@ async@^3.2.3:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
-
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
-axios@^1.1.2:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.4.tgz#6555dd955d2efa9b8f4cb4cb0b3371b7b243537a"
-  integrity sha512-lIQuCfBJvZB/Bv7+RWUqEJqNShGOVpk9v7P0ZWx5Ip0qY6u7JBAU6dzQPMLasU9vHL2uD8av/1FDJXj7n6c39w==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
 
 babel-jest@^29.4.0:
   version "29.4.0"
@@ -1250,13 +1227,6 @@ colorspace@1.1.x:
     color "^3.1.3"
     text-hex "1.0.x"
 
-combined-stream@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1307,16 +1277,6 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
-
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
-
-depd@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
-  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -1610,10 +1570,7 @@ fastq@^1.6.0:
     reusify "^1.0.4"
 
 "fauna@file:./..":
-  version "10.0.0"
-  dependencies:
-    agentkeepalive "^4.2.1"
-    axios "^1.1.2"
+  version "0.1.0"
 
 fb-watchman@^2.0.0:
   version "2.0.2"
@@ -1674,20 +1631,6 @@ fn.name@1.x.x:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
-
-follow-redirects@^1.15.0:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
-  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1822,13 +1765,6 @@ human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
-
-humanize-ms@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
-  integrity sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==
-  dependencies:
-    ms "^2.0.0"
 
 ignore@^5.1.4, ignore@^5.2.0:
   version "5.2.4"
@@ -2501,18 +2437,6 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-mime-types@^2.1.12:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2535,7 +2459,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -2751,11 +2675,6 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pump@^3.0.0:
   version "3.0.0"

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -1,29 +1,11 @@
 /**
  * Configuration for a client.
  */
-export interface ClientConfiguration {
+export type ClientConfiguration = SharedOptions & {
   /**
    * The {@link URL} of Fauna to call. See {@link endpoints} for some default options.
    */
   endpoint: URL;
-  /**
-   * Determines the encoded format expected for the query `arguments` field, and
-   * the `data` field of a successful response.
-   * @remarks **Note, it is very unlikely you need to change this value from its default.**
-   * By default the driver transmits type information over the wire. Fauna also assumes type information is
-   * transmitted by default and thus leaving this value undefined will allow Fauna and the driver to send and
-   * receive type data.
-   *  Type information allows the driver and Fauna to distinguish between types such as int" and "long" which do not
-   * have a standard way of distinguishing in JSON.
-   * Since Fauna assumes typed information is transmitted by default, clients can leave this value undefined to make
-   * full usage of Fauna's primitive types.
-   * You can also explicitly set this to "tagged" to get the typing data sent.
-   * Rare use cases can also deal with standard JSON by setting the value to "simple". Not that the types
-   * enocodable in standard JSON are a subset of the types encodable in the default "tagged" format.
-   * It is not recommended that users use the "simple" format as you will lose the typing of your data. e.g. a "Date"
-   * will no longer be recognized by the Fauna as a "Date", but will instead be treated as a string.
-   */
-  format?: ValueFormat;
   /**
    * The maximum number of connections to a make to Fauna.
    */
@@ -33,77 +15,16 @@ export interface ClientConfiguration {
    * @see https://docs.fauna.com/fauna/current/security/keys
    */
   secret: string;
-  /**
-   * The timeout of each query, in milliseconds. This controls the maximum amount of
-   * time Fauna will execute your query before marking it failed.
-   * Default is undefined which let's Fauna determine the query timeout to apply. This
-   * is recommended for most queries.
-   */
-  query_timeout_ms?: number;
-  /**
-   * If true, unconditionally run the query as strictly serialized.
-   * This affects read-only transactions. Transactions which write
-   * will always be strictly serialized.
-   */
-  linearized?: boolean;
-  /**
-   * The max number of times to retry the query if contention is encountered.
-   */
-  max_contention_retries?: number;
+};
 
-  /**
-   * Tags provided back via logging and telemetry.
-   */
-  query_tags?: { [key: string]: string };
-  /**
-   * A traceparent provided back via logging and telemetry.
-   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
-   */
-  traceparent?: string;
-}
-
-export interface QueryRequestOptions {
-  /**
-   * Determines the encoded format expected for the query `arguments` field, and
-   * the `data` field of a successful response.
-   */
-  format?: ValueFormat;
+export type QueryRequestOptions = SharedOptions & {
   /**
    * The ISO-8601 timestamp of the last transaction the client has previously observed.
    * This client will track this by default, however, if you wish to override
    * this value for a given request set this value.
    */
   last_txn_ts?: number;
-  /**
-   * If true, unconditionally run the query as strictly serialized.
-   * This affects read-only transactions. Transactions which write
-   * will always be strictly serialized.
-   * Overrides the optional setting for the client.
-   */
-  linearized?: boolean;
-  /**
-   * The timeout to use in this query in milliseconds.
-   * Overrides the timeout for the client.
-   */
-  query_timeout_ms?: number;
-  /**
-   * The max number of times to retry the query if contention is encountered.
-   * Overrides the optional setting for the client.
-   */
-  max_contention_retries?: number;
-
-  /**
-   * Tags provided back via logging and telemetry.
-   * Overrides the optional setting on the client.
-   */
-  query_tags?: Record<string, string>;
-  /**
-   * A traceparent provided back via logging and telemetry.
-   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
-   * Overrides the optional setting for the client.
-   */
-  traceparent?: string;
-}
+};
 
 /** tagged declares that type information is transmitted and received by the driver. "simple" indicates it is not. */
 export type ValueFormat = "simple" | "tagged";
@@ -147,4 +68,53 @@ export const endpoints: Endpoints = {
   preview: new URL("https://db.fauna-preview.com"),
   local: new URL("http://localhost:8443"),
   localhost: new URL("http://localhost:8443"),
+};
+
+type SharedOptions = {
+  /**
+   * Determines the encoded format expected for the query `arguments` field, and
+   * the `data` field of a successful response.
+   * @remarks **Note, it is very unlikely you need to change this value from its default.**
+   * By default the driver transmits type information over the wire. Fauna also assumes type information is
+   * transmitted by default and thus leaving this value undefined will allow Fauna and the driver to send and
+   * receive type data.
+   *  Type information allows the driver and Fauna to distinguish between types such as int" and "long" which do not
+   * have a standard way of distinguishing in JSON.
+   * Since Fauna assumes typed information is transmitted by default, clients can leave this value undefined to make
+   * full usage of Fauna's primitive types.
+   * You can also explicitly set this to "tagged" to get the typing data sent.
+   * Rare use cases can also deal with standard JSON by setting the value to "simple". Not that the types
+   * enocodable in standard JSON are a subset of the types encodable in the default "tagged" format.
+   * It is not recommended that users use the "simple" format as you will lose the typing of your data. e.g. a "Date"
+   * will no longer be recognized by the Fauna as a "Date", but will instead be treated as a string.
+   */
+  format?: ValueFormat;
+  /**
+   * If true, unconditionally run the query as strictly serialized.
+   * This affects read-only transactions. Transactions which write
+   * will always be strictly serialized.
+   * Overrides the optional setting for the client.
+   */
+  linearized?: boolean;
+  /**
+   * The max number of times to retry the query if contention is encountered.
+   * Overrides the optional setting for the client.
+   */
+  max_contention_retries?: number;
+  /**
+   * Tags provided back via logging and telemetry.
+   * Overrides the optional setting on the client.
+   */
+  query_tags?: Record<string, string>;
+  /**
+   * The timeout to use in this query in milliseconds.
+   * Overrides the timeout for the client.
+   */
+  query_timeout_ms?: number;
+  /**
+   * A traceparent provided back via logging and telemetry.
+   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
+   * Overrides the optional setting for the client.
+   */
+  traceparent?: string;
 };

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -1,5 +1,3 @@
-import { ValueFormat } from "./wire-protocol";
-
 /**
  * Configuration for a client.
  */
@@ -63,6 +61,52 @@ export interface ClientConfiguration {
    */
   traceparent?: string;
 }
+
+export interface QueryRequestOptions {
+  /**
+   * Determines the encoded format expected for the query `arguments` field, and
+   * the `data` field of a successful response.
+   */
+  format?: ValueFormat;
+  /**
+   * The ISO-8601 timestamp of the last transaction the client has previously observed.
+   * This client will track this by default, however, if you wish to override
+   * this value for a given request set this value.
+   */
+  last_txn_ts?: number;
+  /**
+   * If true, unconditionally run the query as strictly serialized.
+   * This affects read-only transactions. Transactions which write
+   * will always be strictly serialized.
+   * Overrides the optional setting for the client.
+   */
+  linearized?: boolean;
+  /**
+   * The timeout to use in this query in milliseconds.
+   * Overrides the timeout for the client.
+   */
+  query_timeout_ms?: number;
+  /**
+   * The max number of times to retry the query if contention is encountered.
+   * Overrides the optional setting for the client.
+   */
+  max_contention_retries?: number;
+
+  /**
+   * Tags provided back via logging and telemetry.
+   * Overrides the optional setting on the client.
+   */
+  query_tags?: Record<string, string>;
+  /**
+   * A traceparent provided back via logging and telemetry.
+   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
+   * Overrides the optional setting for the client.
+   */
+  traceparent?: string;
+}
+
+/** tagged declares that type information is transmitted and received by the driver. "simple" indicates it is not. */
+export type ValueFormat = "simple" | "tagged";
 
 /**
  * An extensible interface for a set of Fauna endpoints.

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -1,7 +1,7 @@
 /**
  * Configuration for a client.
  */
-export type ClientConfiguration = SharedOptions & {
+export type ClientConfiguration = {
   /**
    * The {@link URL} of Fauna to call. See {@link endpoints} for some default options.
    */
@@ -15,6 +15,10 @@ export type ClientConfiguration = SharedOptions & {
    * @see https://docs.fauna.com/fauna/current/security/keys
    */
   secret: string;
+  /**
+   * Default query options that should be applied to all queries from this client.
+   */
+  queryOptions?: QueryRequestOptions;
 };
 
 /**
@@ -23,53 +27,7 @@ export type ClientConfiguration = SharedOptions & {
  * TODO: add any other possible configuration options. On possibility is
  * allowing users to pass in query arguments without using a QueryBuilder here.
  */
-export type QueryRequestOptions = SharedOptions;
-
-/** tagged declares that type information is transmitted and received by the driver. "simple" indicates it is not. */
-export type ValueFormat = "simple" | "tagged";
-
-/**
- * An extensible interface for a set of Fauna endpoints.
- * @remarks Leverage the `[key: string]: URL;` field to extend to other endpoints.
- */
-export interface Endpoints {
-  /** Fauna's cloud endpoint. */
-  cloud: URL;
-  /** Fauna's preview endpoint for testing new features - requires beta access. */
-  preview: URL;
-  /**
-   * An endpoint for interacting with local instance of Fauna (e.g. one running in a local docker container).
-   */
-  local: URL;
-  /**
-   * An alias for local.
-   */
-  localhost: URL;
-  /**
-   * Any other endpoint you want your client to support. For example, if you run all requests through a proxy
-   * configure it here. Most clients will not need to leverage this ability.
-   */
-  [key: string]: URL;
-}
-
-/**
- * A extensible set of endpoints for calling Fauna.
- * @remarks Most clients will will not need to extend this set.
- * @example
- * ## To Extend
- * ```typescript
- *   // add to the endpoints constant
- *   endpoints.myProxyEndpoint = new URL("https://my.proxy.url");
- * ```
- */
-export const endpoints: Endpoints = {
-  cloud: new URL("https://db.fauna.com"),
-  preview: new URL("https://db.fauna-preview.com"),
-  local: new URL("http://localhost:8443"),
-  localhost: new URL("http://localhost:8443"),
-};
-
-type SharedOptions = {
+export type QueryRequestOptions = {
   /**
    * Determines the encoded format expected for the query `arguments` field, and
    * the `data` field of a successful response.
@@ -116,4 +74,52 @@ type SharedOptions = {
    * Overrides the optional setting for the client.
    */
   traceparent?: string;
+};
+
+/**
+ * Determines the encoded format expected for the query `arguments` field, and
+ * the `data` field of a successful response. "simple" indicates that type
+ * information is not transmitted and will not be received.
+ */
+export type ValueFormat = "simple" | "tagged";
+
+/**
+ * An extensible interface for a set of Fauna endpoints.
+ * @remarks Leverage the `[key: string]: URL;` field to extend to other endpoints.
+ */
+export interface Endpoints {
+  /** Fauna's cloud endpoint. */
+  cloud: URL;
+  /** Fauna's preview endpoint for testing new features - requires beta access. */
+  preview: URL;
+  /**
+   * An endpoint for interacting with local instance of Fauna (e.g. one running in a local docker container).
+   */
+  local: URL;
+  /**
+   * An alias for local.
+   */
+  localhost: URL;
+  /**
+   * Any other endpoint you want your client to support. For example, if you run all requests through a proxy
+   * configure it here. Most clients will not need to leverage this ability.
+   */
+  [key: string]: URL;
+}
+
+/**
+ * A extensible set of endpoints for calling Fauna.
+ * @remarks Most clients will will not need to extend this set.
+ * @example
+ * ## To Extend
+ * ```typescript
+ *   // add to the endpoints constant
+ *   endpoints.myProxyEndpoint = new URL("https://my.proxy.url");
+ * ```
+ */
+export const endpoints: Endpoints = {
+  cloud: new URL("https://db.fauna.com"),
+  preview: new URL("https://db.fauna-preview.com"),
+  local: new URL("http://localhost:8443"),
+  localhost: new URL("http://localhost:8443"),
 };

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -17,14 +17,13 @@ export type ClientConfiguration = SharedOptions & {
   secret: string;
 };
 
-export type QueryRequestOptions = SharedOptions & {
-  /**
-   * The ISO-8601 timestamp of the last transaction the client has previously observed.
-   * This client will track this by default, however, if you wish to override
-   * this value for a given request set this value.
-   */
-  last_txn_ts?: number;
-};
+/**
+ * Query options that are not also statically configurable in the client
+ *
+ * TODO: add any other possible configuration options. On possibility is
+ * allowing users to pass in query arguments without using a QueryBuilder here.
+ */
+export type QueryRequestOptions = SharedOptions;
 
 /** tagged declares that type information is transmitted and received by the driver. "simple" indicates it is not. */
 export type ValueFormat = "simple" | "tagged";

--- a/src/client.ts
+++ b/src/client.ts
@@ -241,13 +241,13 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
         "x-typecheck": "false",
       };
       this.#setHeaders(
-        { ...this.clientConfiguration, ...queryRequest },
+        { ...this.clientConfiguration.queryOptions, ...queryRequest },
         headers
       );
 
       const isTaggedFormat =
-        (this.#clientConfiguration.format ?? "tagged") === "tagged" ||
-        queryRequest.format === "tagged";
+        (this.#clientConfiguration.queryOptions?.format ?? "tagged") ===
+          "tagged" || queryRequest.format === "tagged";
       const queryArgs = isTaggedFormat
         ? TaggedTypeFormat.encode(queryRequest.arguments)
         : queryRequest.arguments;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   type ClientConfiguration,
   type Endpoints,
   endpoints,
+  type QueryRequestOptions,
 } from "./client-configuration";
 export {
   AuthenticationError,
@@ -26,7 +27,6 @@ export {
   type QueryInfo,
   type QueryInterpolation,
   type QueryRequest,
-  type QueryRequestHeaders,
   type QueryStats,
   type QuerySuccess,
   type Span,

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -1,14 +1,14 @@
+import { QueryRequestOptions } from "./client-configuration";
 import { TaggedTypeFormat } from "./tagged-type";
 import type {
   JSONObject,
   JSONValue,
   QueryInterpolation,
   QueryRequest,
-  QueryRequestHeaders,
 } from "./wire-protocol";
 
 export interface QueryBuilder {
-  toQuery: (headers?: QueryRequestHeaders) => QueryRequest;
+  toQuery: (options?: QueryRequestOptions) => QueryRequest;
 }
 
 export const isQueryBuilder = (obj: any): obj is QueryBuilder =>
@@ -63,7 +63,7 @@ class TemplateQueryBuilder implements QueryBuilder {
   /**
    * Converts this TemplateQueryBuilder to a {@link QueryRequest} you can send
    * to Fauna.
-   * @param requestHeaders - optional {@link QueryRequestHeaders} to include
+   * @param requestOptions - optional {@link QueryRequestOptions} to include
    *   in the request (and thus override the defaults in your {@link ClientConfiguration}.
    *   If not passed in, no headers will be set as overrides.
    * @returns a {@link QueryRequest}.
@@ -76,11 +76,11 @@ class TemplateQueryBuilder implements QueryBuilder {
    *  { query: { fql: ["'foo'.length == ", { value: { "@int": "8" } }, ""] }}
    * ```
    */
-  toQuery(requestHeaders: QueryRequestHeaders = {}): QueryRequest {
-    return { ...this.#render(requestHeaders), ...requestHeaders };
+  toQuery(requestOptions: QueryRequestOptions = {}): QueryRequest {
+    return { ...this.#render(requestOptions), ...requestOptions };
   }
 
-  #render(requestHeaders: QueryRequestHeaders): QueryRequest {
+  #render(requestOptions: QueryRequestOptions): QueryRequest {
     if (this.#queryFragments.length === 1) {
       return { query: { fql: [this.#queryFragments[0]] }, arguments: {} };
     }
@@ -96,7 +96,7 @@ class TemplateQueryBuilder implements QueryBuilder {
         const arg = this.#queryArgs[i];
         let subQuery: string | QueryInterpolation;
         if (isQueryBuilder(arg)) {
-          const request = arg.toQuery(requestHeaders);
+          const request = arg.toQuery(requestOptions);
           subQuery = request.query;
           resultArgs = { ...resultArgs, ...request.arguments };
         } else {

--- a/src/wire-protocol/index.ts
+++ b/src/wire-protocol/index.ts
@@ -1,0 +1,2 @@
+export * from "./request";
+export * from "./response";

--- a/src/wire-protocol/index.ts
+++ b/src/wire-protocol/index.ts
@@ -1,2 +1,29 @@
 export * from "./request";
 export * from "./response";
+
+/**
+ * A type to describe plain JSON object
+ * @remarks Requiring plain JSON values as request arguments makes it a
+ * Typescript error to provide a Class instance as an argument. This is
+ * necessary because the driver does not have a way to ensure results are
+ * encoded beack into the provided Class.
+ */
+export type JSONObject = {
+  [key: string]: JSONValue;
+};
+
+/**
+ * A type to describe plain JSON values
+ * @remarks Requiring plain JSON values as request arguments makes it a
+ * Typescript error to provide a Class instance as an argument. This is
+ * necessary because the driver does not have a way to ensure results are
+ * encoded beack into the provided Class.
+ */
+export type JSONValue =
+  | null
+  | string
+  | number
+  | bigint
+  | boolean
+  | JSONObject
+  | Array<JSONValue>;

--- a/src/wire-protocol/request.ts
+++ b/src/wire-protocol/request.ts
@@ -1,4 +1,4 @@
-
+import { JSONObject, JSONValue } from ".";
 import { fql } from "../query-builder";
 
 /**
@@ -57,30 +57,3 @@ export type ValueFragment = { value: JSONValue };
  * ```
  */
 export type FQLFragment = { fql: (string | QueryInterpolation)[] };
-
-/**
- * A type to describe plain JSON object
- * @remarks Requiring plain JSON values as request arguments makes it a
- * Typescript error to provide a Class instance as an argument. This is
- * necessary because the driver does not have a way to ensure results are
- * encoded beack into the provided Class.
- */
-export type JSONObject = {
-  [key: string]: JSONValue;
-};
-
-/**
- * A type to describe plain JSON values
- * @remarks Requiring plain JSON values as request arguments makes it a
- * Typescript error to provide a Class instance as an argument. This is
- * necessary because the driver does not have a way to ensure results are
- * encoded beack into the provided Class.
- */
-export type JSONValue =
-  | null
-  | string
-  | number
-  | bigint
-  | boolean
-  | JSONObject
-  | Array<JSONValue>;

--- a/src/wire-protocol/request.ts
+++ b/src/wire-protocol/request.ts
@@ -1,4 +1,5 @@
-import { fql } from "./query-builder";
+
+import { fql } from "../query-builder";
 
 /**
  * A request to make to Fauna.
@@ -53,94 +54,6 @@ export interface QueryRequestHeaders {
 /** tagged declares that type information is transmitted and received by the driver. "simple" indicates it is not. */
 export declare type ValueFormat = "simple" | "tagged";
 
-export type QueryStats = {
-  /** The amount of Transactional Compute Ops consumed by the query. */
-  compute_ops: number;
-  /** The amount of Transactional Read Ops consumed by the query. */
-  read_ops: number;
-  /** The amount of Transactional Write Ops consumed by the query. */
-  write_ops: number;
-  /** The query run time in milliseconds. */
-  query_time_ms: number;
-  /** The amount of data read from storage, in bytes. */
-  storage_bytes_read: number;
-  /** The amount of data written to storage, in bytes. */
-  storage_bytes_written: number;
-  /** The number of times the transaction was retried due to write contention. */
-  contention_retries: number;
-};
-
-export type QueryInfo = {
-  /** The last transaction timestamp of the query. A Unix epoch in microseconds. */
-  txn_ts: number;
-  /** A readable summary of any warnings or logs emitted by the query. */
-  summary?: string;
-  /** The value of the x-query-tags header, if it was provided. */
-  query_tags: Record<string, string>;
-  /** Stats on query performance and cost */
-  stats: QueryStats;
-};
-
-export type QuerySuccess<T> = QueryInfo & {
-  /**
-   * The result of the query. The data is any valid JSON value.
-   * @remarks
-   * data is type parameterized so that you can treat it as a
-   * certain type if you are using typescript.
-   */
-  data: T;
-  /** The query's inferred static result type. */
-  static_type?: string;
-};
-
-/**
- * A failed query response. Integrations which only want to report a human
- * readable version of the failure can simply print out the "summary" field.
- */
-export type QueryFailure = QueryInfo & {
-  /**
-   * The result of the query resulting in
-   */
-  error: {
-    /** A predefined code which indicates the type of error. See XXX for a list of error codes. */
-    code: string;
-    /** A short, human readable description of the error */
-    message: string;
-    /**
-     * A machine readable description of any constraint failures encountered by the query.
-     * Present only if this query encountered constraint failures.
-     */
-    constraint_failures?: Array<ConstraintFailure>;
-  };
-};
-
-/**
- * A constraint failure triggered by a query.
- */
-export type ConstraintFailure = {
-  /** Description of the constraint failure */
-  message: string;
-  /** Name of the failed constraint */
-  name?: string;
-  /** Path into the write input data to which the failure applies */
-  paths?: Array<number | string>;
-};
-
-export type QueryResponse<T> = QuerySuccess<T> | QueryFailure;
-
-export const isQuerySuccess = (res: any): res is QuerySuccess<any> =>
-  res instanceof Object && "data" in res;
-
-export const isQueryFailure = (res: any): res is QueryFailure =>
-  res instanceof Object &&
-  "error" in res &&
-  res.error instanceof Object &&
-  "code" in res.error &&
-  "message" in res.error;
-
-export const isQueryResponse = (res: any): res is QueryResponse<any> =>
-  isQueryResponse(res) || isQueryFailure(res);
-
 /**
  * A piece of an interpolated query. Interpolated queries can be safely composed
  * together without concern of query string injection.
@@ -184,29 +97,6 @@ export type ValueFragment = { value: JSONValue };
  * ```
  */
 export type FQLFragment = { fql: (string | QueryInterpolation)[] };
-
-/**
- * A source span indicating a segment of FQL.
- */
-export interface Span {
-  /**
-   * A string identifier of the FQL source. For example, if performing
-   * a raw query against the API this would be *query*.
-   */
-  src: string;
-  /**
-   * The span's starting index within the src, inclusive.
-   */
-  start: number;
-  /**
-   * The span's ending index within the src, inclusive.
-   */
-  end: number;
-  /**
-   * The name of the enclosing function, if applicable.
-   */
-  function: string;
-}
 
 /**
  * All objects returned from Fauna are valid JSON objects.

--- a/src/wire-protocol/request.ts
+++ b/src/wire-protocol/request.ts
@@ -4,7 +4,7 @@ import { fql } from "../query-builder";
 /**
  * A request to make to Fauna.
  */
-export interface QueryRequest extends QueryRequestHeaders {
+export interface QueryRequest {
   /** The query */
   query: string | QueryInterpolation;
 
@@ -13,46 +13,6 @@ export interface QueryRequest extends QueryRequestHeaders {
    */
   arguments?: JSONObject;
 }
-
-export interface QueryRequestHeaders {
-  /**
-   * Determines the encoded format expected for the query `arguments` field, and
-   * the `data` field of a successful response.
-   */
-  format?: ValueFormat;
-  /**
-   * If true, unconditionally run the query as strictly serialized.
-   * This affects read-only transactions. Transactions which write
-   * will always be strictly serialized.
-   * Overrides the optional setting for the client.
-   */
-  linearized?: boolean;
-  /**
-   * The timeout to use in this query in milliseconds.
-   * Overrides the timeout for the client.
-   */
-  query_timeout_ms?: number;
-  /**
-   * The max number of times to retry the query if contention is encountered.
-   * Overrides the optional setting for the client.
-   */
-  max_contention_retries?: number;
-
-  /**
-   * Tags provided back via logging and telemetry.
-   * Overrides the optional setting on the client.
-   */
-  query_tags?: Record<string, string>;
-  /**
-   * A traceparent provided back via logging and telemetry.
-   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
-   * Overrides the optional setting for the client.
-   */
-  traceparent?: string;
-}
-
-/** tagged declares that type information is transmitted and received by the driver. "simple" indicates it is not. */
-export declare type ValueFormat = "simple" | "tagged";
 
 /**
  * A piece of an interpolated query. Interpolated queries can be safely composed

--- a/src/wire-protocol/request.ts
+++ b/src/wire-protocol/request.ts
@@ -99,14 +99,22 @@ export type ValueFragment = { value: JSONValue };
 export type FQLFragment = { fql: (string | QueryInterpolation)[] };
 
 /**
- * All objects returned from Fauna are valid JSON objects.
+ * A type to describe plain JSON object
+ * @remarks Requiring plain JSON values as request arguments makes it a
+ * Typescript error to provide a Class instance as an argument. This is
+ * necessary because the driver does not have a way to ensure results are
+ * encoded beack into the provided Class.
  */
 export type JSONObject = {
   [key: string]: JSONValue;
 };
 
 /**
- * All values returned from Fauna are valid JSON values.
+ * A type to describe plain JSON values
+ * @remarks Requiring plain JSON values as request arguments makes it a
+ * Typescript error to provide a Class instance as an argument. This is
+ * necessary because the driver does not have a way to ensure results are
+ * encoded beack into the provided Class.
  */
 export type JSONValue =
   | null

--- a/src/wire-protocol/response.ts
+++ b/src/wire-protocol/response.ts
@@ -6,23 +6,6 @@ import { JSONValue } from ".";
  */
 export type QueryResponse<T extends JSONValue> = QuerySuccess<T> | QueryFailure;
 
-export type QueryStats = {
-  /** The amount of Transactional Compute Ops consumed by the query. */
-  compute_ops: number;
-  /** The amount of Transactional Read Ops consumed by the query. */
-  read_ops: number;
-  /** The amount of Transactional Write Ops consumed by the query. */
-  write_ops: number;
-  /** The query run time in milliseconds. */
-  query_time_ms: number;
-  /** The amount of data read from storage, in bytes. */
-  storage_bytes_read: number;
-  /** The amount of data written to storage, in bytes. */
-  storage_bytes_written: number;
-  /** The number of times the transaction was retried due to write contention. */
-  contention_retries: number;
-};
-
 export type QuerySuccess<T> = QueryInfo & {
   /**
    * The result of a successful query. The data is any valid JSON value.
@@ -79,6 +62,23 @@ export type QueryInfo = {
   query_tags: Record<string, string>;
   /** Stats on query performance and cost */
   stats: QueryStats;
+};
+
+export type QueryStats = {
+  /** The amount of Transactional Compute Ops consumed by the query. */
+  compute_ops: number;
+  /** The amount of Transactional Read Ops consumed by the query. */
+  read_ops: number;
+  /** The amount of Transactional Write Ops consumed by the query. */
+  write_ops: number;
+  /** The query run time in milliseconds. */
+  query_time_ms: number;
+  /** The amount of data read from storage, in bytes. */
+  storage_bytes_read: number;
+  /** The amount of data written to storage, in bytes. */
+  storage_bytes_written: number;
+  /** The number of times the transaction was retried due to write contention. */
+  contention_retries: number;
 };
 
 /**

--- a/src/wire-protocol/response.ts
+++ b/src/wire-protocol/response.ts
@@ -1,8 +1,10 @@
+import { JSONValue } from ".";
+
 /**
  * The result of a query to Fauna.
  * @see {@link QuerySuccess} and {@link QueryFailure} for additional information.
  */
-export type QueryResponse<T> = QuerySuccess<T> | QueryFailure;
+export type QueryResponse<T extends JSONValue> = QuerySuccess<T> | QueryFailure;
 
 export type QueryStats = {
   /** The amount of Transactional Compute Ops consumed by the query. */

--- a/src/wire-protocol/response.ts
+++ b/src/wire-protocol/response.ts
@@ -1,0 +1,116 @@
+/**
+ * The result of a query to Fauna.
+ * @see {@link QuerySuccess} and {@link QueryFailure} for additional information.
+ */
+export type QueryResponse<T> = QuerySuccess<T> | QueryFailure;
+
+export type QueryStats = {
+  /** The amount of Transactional Compute Ops consumed by the query. */
+  compute_ops: number;
+  /** The amount of Transactional Read Ops consumed by the query. */
+  read_ops: number;
+  /** The amount of Transactional Write Ops consumed by the query. */
+  write_ops: number;
+  /** The query run time in milliseconds. */
+  query_time_ms: number;
+  /** The amount of data read from storage, in bytes. */
+  storage_bytes_read: number;
+  /** The amount of data written to storage, in bytes. */
+  storage_bytes_written: number;
+  /** The number of times the transaction was retried due to write contention. */
+  contention_retries: number;
+};
+
+export type QuerySuccess<T> = QueryInfo & {
+  /**
+   * The result of a successful query. The data is any valid JSON value.
+   * @remarks
+   * data is type parameterized so that you can treat it as a
+   * certain type if you are using typescript.
+   * @see {@link QueryInfo} for additional details
+   */
+  data: T;
+  /** The query's inferred static result type. */
+  static_type?: string;
+};
+
+/**
+ * A failed query response. Integrations which only want to report a human
+ * readable version of the failure can simply print out the "summary" field.
+ * @see {@link QueryInfo} and {@link ConstraintFailure} for additional details
+ */
+export type QueryFailure = QueryInfo & {
+  /**
+   * The result of the query resulting in
+   */
+  error: {
+    /** A predefined code which indicates the type of error. See XXX for a list of error codes. */
+    code: string;
+    /** A short, human readable description of the error */
+    message: string;
+    /**
+     * A machine readable description of any constraint failures encountered by the query.
+     * Present only if this query encountered constraint failures.
+     */
+    constraint_failures?: Array<ConstraintFailure>;
+  };
+};
+
+/**
+ * A constraint failure triggered by a query.
+ */
+export type ConstraintFailure = {
+  /** Description of the constraint failure */
+  message: string;
+  /** Name of the failed constraint */
+  name?: string;
+  /** Path into the write input data to which the failure applies */
+  paths?: Array<number | string>;
+};
+
+export type QueryInfo = {
+  /** The last transaction timestamp of the query. A Unix epoch in microseconds. */
+  txn_ts: number;
+  /** A readable summary of any warnings or logs emitted by the query. */
+  summary?: string;
+  /** The value of the x-query-tags header, if it was provided. */
+  query_tags: Record<string, string>;
+  /** Stats on query performance and cost */
+  stats: QueryStats;
+};
+
+/**
+ * A source span indicating a segment of FQL.
+ */
+export interface Span {
+  /**
+   * A string identifier of the FQL source. For example, if performing
+   * a raw query against the API this would be *query*.
+   */
+  src: string;
+  /**
+   * The span's starting index within the src, inclusive.
+   */
+  start: number;
+  /**
+   * The span's ending index within the src, inclusive.
+   */
+  end: number;
+  /**
+   * The name of the enclosing function, if applicable.
+   */
+  function: string;
+}
+
+export const isQuerySuccess = (res: any): res is QuerySuccess<any> =>
+  res instanceof Object && "data" in res;
+
+export const isQueryFailure = (res: any): res is QueryFailure =>
+  res instanceof Object &&
+  "error" in res &&
+  res.error instanceof Object &&
+  "code" in res.error &&
+  "message" in res.error;
+
+export const isQueryResponse = (res: any): res is QueryResponse<any> =>
+  isQueryResponse(res) || isQueryFailure(res);


### PR DESCRIPTION
Ticket(s): [FE-3105](https://faunadb.atlassian.net/browse/FE-3105)

This PR shuffles types about how I have come to view them. I hope that it can be a good step toward clarifying the mental model for users of the driver.

## Problem
- Request and response types can be cleanly separated into different modules
- `QueryRequest` extends `QueryRequestHeaders`, but `QueryRequestHeaders` fields are not actually sent over the wire, which muddies the types.

## Solution
Separate `QueryRequest` and `QueryRequestHeaders` so we can enforce that only a QueryRequest provided to the HTTPClient and thus over the wire. Move `QueryRequestHeaders` out of the wire-protocol module.

## Result
### Separate types into multiple files
Created separate files for request and response types. They are still in a folder called `wire-protocol' so imports don't actually change.

### Query Options
`QueryRequestHeaders` was also renamed to `QueryRequestOptions` to reflect that they could be any options (though they happen to currently only include specific header values).

Instead of duplicate the same fields in `ClientConfiguration`, moved those into an embedded, optional `queryOptions` field that is a `QueryRequestOptions` object. I documented that these are the options sent be default for each query. This way, we have a consistent story about what these options are: they are defined in a single place, and you can provide some of the options as client defaults, and you can also provide any of the options per query.

Embedding the query options breaks the existing API. It makes client configuration (when you need to set query options) a little more verbose, but I think makes it more clear what you are doing.

Also, this separation also makes type enforcement work better. Before, when client figuration was essentially `ClientOptions & QueryOptions` but there are some places (like `Client.#setHeaders`) that you only want the query options.

### JSON types

Also noted that `JSONObject` and `JSONValue` are necessary because we are not handling encoding/decoding of user classes.

[FE-3105]: https://faunadb.atlassian.net/browse/FE-3105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ