### PR TITLE
Remove last_txn_ts from request API

### DIFF
--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -70,10 +70,9 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
     const addFiveMinutes = expectedTxnTime + 5 * 60 * 1000 * 1000;
     client.lastTxnTs = addFiveMinutes;
     expect(client.lastTxnTs).toBe(addFiveMinutes);
-    // setting txn time back in history should fail
-    expect(() => {
-      client.lastTxnTs = expectedTxnTime;
-    }).toThrow();
+    // setting to the past keeps the more recent ts.
+    client.lastTxnTs = expectedTxnTime;
+    expect(client.lastTxnTs).toBe(addFiveMinutes);
   });
 
   type HeaderTestInput = {

--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -83,20 +83,19 @@ if (Collection.byName('Customers') == null) {\
     });
     expect(resultOne.txn_ts).not.toBeUndefined();
     expectedLastTxn = resultOne.txn_ts;
+    myClient.lastTxnTs = resultOne.txn_ts;
     const resultTwo = await myClient.query(
       fql`
-        if (Collection.byName('Orders') == null) {\
-          Collection.create({ name: 'Orders' })\
-        }
-      `,
-      {
-        last_txn_ts: resultOne.txn_ts,
+      if (Collection.byName('Orders') == null) {\
+        Collection.create({ name: 'Orders' })\
       }
+      `
     );
     expect(resultTwo.txn_ts).not.toBeUndefined();
     expect(resultTwo.txn_ts).not.toEqual(resultOne.txn_ts);
+    myClient.lastTxnTs = 0;
+    expectedLastTxn = resultTwo.txn_ts;
     const resultThree = await myClient.query({
-      last_txn_ts: resultOne.txn_ts,
       query:
         "\
 if (Collection.byName('Products') == null) {\

--- a/__tests__/unit/query-builder.test.ts
+++ b/__tests__/unit/query-builder.test.ts
@@ -141,7 +141,6 @@ describe("fql method producing QueryBuilders", () => {
     const innerQueryBuilder = fql`Math.add(${num}, 3)`;
     const queryBuilder = fql`${str}.length == ${innerQueryBuilder}`;
     const queryRequest = queryBuilder.toQuery({
-      last_txn_ts: 1640995200000000,
       linearized: true,
       query_timeout_ms: 600,
       max_contention_retries: 4,
@@ -149,7 +148,6 @@ describe("fql method producing QueryBuilders", () => {
       traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00",
     });
     expect(queryRequest).toMatchObject({
-      last_txn_ts: 1640995200000000,
       linearized: true,
       query_timeout_ms: 600,
       max_contention_retries: 4,

--- a/src/client.ts
+++ b/src/client.ts
@@ -88,7 +88,8 @@ export class Client {
    * @returns the last transaction time seen by this client, or undefined if this client has not seen a transaction time.
    */
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
+  // @ts-ignore it's okay that #lastTxnTs could be undefined on get, but we want
+  //   to enforce that the user never intentionally set it to undefined.
   get lastTxnTs(): number | undefined {
     return this.#lastTxnTs;
   }
@@ -98,10 +99,7 @@ export class Client {
    * @throws Error if lastTxnTs is before the current lastTxn of the driver
    */
   set lastTxnTs(ts: number) {
-    if (this.lastTxnTs !== undefined && ts < this.lastTxnTs) {
-      throw new Error("Must be greater than current value");
-    }
-    this.#lastTxnTs = ts;
+    this.#lastTxnTs = this.#lastTxnTs ? Math.max(ts, this.#lastTxnTs) : ts;
   }
 
   /**
@@ -299,7 +297,6 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
       if (
         [
           "format",
-          "last_txn_ts",
           "query_timeout_ms",
           "linearized",
           "max_contention_retries",
@@ -313,8 +310,6 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
           headerValue = Object.entries(entry[1])
             .map((tag) => tag.join("="))
             .join(",");
-        } else if ("last_txn_ts" === entry[0]) {
-          headerValue = entry[1];
         } else {
           if (typeof entry[1] === "string") {
             headerValue = entry[1];

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -21,12 +21,6 @@ export interface QueryRequestHeaders {
    */
   format?: ValueFormat;
   /**
-   * The ISO-8601 timestamp of the last transaction the client has previously observed.
-   * This client will track this by default, however, if you wish to override
-   * this value for a given request set this value.
-   */
-  last_txn_ts?: number;
-  /**
    * If true, unconditionally run the query as strictly serialized.
    * This affects read-only transactions. Transactions which write
    * will always be strictly serialized.


### PR DESCRIPTION
Ticket(s): [FE-3118](https://faunadb.atlassian.net/browse/FE-3118)

## Problem
Per stand up, drivers should align on last_txn_ts semantics and remove the option from the request API.

## Solution
Remove the option from the request API. Setting lastTxnTs through the Client should not throw an Error, but instead take the larger value of lastTxnTs or the user input.

[FE-3118]: https://faunadb.atlassian.net/browse/FE-3118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ