### PR TITLE
Fix docs for `set lastTxnTs`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -95,8 +95,9 @@ export class Client {
   }
   /**
    * Sets the last transaction time of this client.
-   * @param ts - the last transaction timestamp to set. If `ts` is less than the
-   *   existing `#lastTxnTs` value, then no change is made.
+   * @param ts - the last transaction timestamp to set, as microseconds since
+   *   the epoch. If `ts` is less than the existing `#lastTxnTs` value, then no
+   *   change is made.
    */
   set lastTxnTs(ts: number) {
     this.#lastTxnTs = this.#lastTxnTs ? Math.max(ts, this.#lastTxnTs) : ts;

--- a/src/client.ts
+++ b/src/client.ts
@@ -95,8 +95,8 @@ export class Client {
   }
   /**
    * Sets the last transaction time of this client.
-   * @param time - the last transaction time to set.
-   * @throws Error if lastTxnTs is before the current lastTxn of the driver
+   * @param ts - the last transaction timestamp to set. If `ts` is less than the
+   *   existing `#lastTxnTs` value, then no change is made.
    */
   set lastTxnTs(ts: number) {
     this.#lastTxnTs = this.#lastTxnTs ? Math.max(ts, this.#lastTxnTs) : ts;


### PR DESCRIPTION
Ticket(s): [FE-3118](https://faunadb.atlassian.net/browse/FE-3118)

## Problem
Docs still talked about the Client.lastTxnTs setter as throwing an error, which we just changed.

[FE-3118]: https://faunadb.atlassian.net/browse/FE-3118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ