### PR TITLE
Date time wrappers

### DIFF
--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -5,7 +5,7 @@ import {
   LONG_MIN,
   LONG_MAX,
 } from "../../src/tagged-type";
-import { FaunaDate, FaunaTime } from "../../src/values";
+import { DateStub, TimeStub } from "../../src/values";
 
 describe("tagged format", () => {
   it("can be decoded", () => {
@@ -55,18 +55,18 @@ describe("tagged format", () => {
     expect(result.bug_doc).toStrictEqual(bugs_doc);
     expect(result.name).toEqual("fir");
     expect(result.age).toEqual(200);
-    expect(result.birthdate).toBeInstanceOf(FaunaDate);
+    expect(result.birthdate).toBeInstanceOf(DateStub);
     expect(result.circumference).toEqual(3.82);
-    expect(result.created_at).toBeInstanceOf(FaunaTime);
+    expect(result.created_at).toBeInstanceOf(TimeStub);
     expect(result.extras.nest.num_sticks).toEqual(58);
     expect(result.extras.nest["@extras"].egg.fertilized).toBe(false);
     expect(result.measurements).toHaveLength(2);
     expect(result.measurements[0].id).toEqual(1);
     expect(result.measurements[0].employee).toEqual(3);
-    expect(result.measurements[0].time).toBeInstanceOf(FaunaTime);
+    expect(result.measurements[0].time).toBeInstanceOf(TimeStub);
     expect(result.measurements[1].id).toEqual(2);
     expect(result.measurements[1].employee).toEqual(5);
-    expect(result.measurements[1].time).toBeInstanceOf(FaunaTime);
+    expect(result.measurements[1].time).toBeInstanceOf(TimeStub);
     expect(result.molecules).toEqual(BigInt("999999999999999999"));
     expect(result.null).toBeNull();
     expect(result.set).toStrictEqual(set);
@@ -75,14 +75,14 @@ describe("tagged format", () => {
   it("can be encoded", () => {
     let result = JSON.stringify(
       TaggedTypeFormat.encode({
-        child: { more: { itsworking: FaunaDate.from("1983-04-15") } },
-        date: FaunaDate.from("1923-05-13"),
+        child: { more: { itsworking: DateStub.from("1983-04-15") } },
+        date: DateStub.from("1923-05-13"),
         double: 4.14,
         int: 32,
         name: "Hello, World",
         null: null,
         number: 48,
-        time: FaunaTime.from("2023-01-30T16:27:45.204243-05:00"),
+        time: TimeStub.from("2023-01-30T16:27:45.204243-05:00"),
         datetime: new Date("2023-01-30T16:27:45.204243-05:00"),
         extra: [
           {
@@ -95,7 +95,7 @@ describe("tagged format", () => {
           },
         ],
         "@foobar": {
-          date: FaunaDate.from("1888-08-08"),
+          date: DateStub.from("1888-08-08"),
         },
       })
     );
@@ -111,8 +111,8 @@ describe("tagged format", () => {
 
   it("handles conflicts", () => {
     var result = TaggedTypeFormat.encode({
-      date: { "@date": FaunaDate.from("2022-11-01") },
-      time: { "@time": FaunaTime.from("2022-11-02T05:00:00.000Z") },
+      date: { "@date": DateStub.from("2022-11-01") },
+      time: { "@time": TimeStub.from("2022-11-02T05:00:00.000Z") },
       int: { "@int": 1 },
       long: { "@long": BigInt("99999999999999999") },
       double: { "@double": 1.99 },

--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -1,4 +1,3 @@
-import { getClient } from "../client";
 import {
   TaggedTypeFormat,
   DocumentReference,
@@ -6,13 +5,7 @@ import {
   LONG_MIN,
   LONG_MAX,
 } from "../../src/tagged-type";
-import { fql } from "../../src/query-builder";
-import { ClientError } from "../../src/errors";
-
-const client = getClient({
-  max_conns: 5,
-  query_timeout_ms: 60_000,
-});
+import { FaunaDate, FaunaTime } from "../../src/values";
 
 describe("tagged format", () => {
   it("can be decoded", () => {
@@ -62,18 +55,18 @@ describe("tagged format", () => {
     expect(result.bug_doc).toStrictEqual(bugs_doc);
     expect(result.name).toEqual("fir");
     expect(result.age).toEqual(200);
-    expect(result.birthdate).toBeInstanceOf(Date);
+    expect(result.birthdate).toBeInstanceOf(FaunaDate);
     expect(result.circumference).toEqual(3.82);
-    expect(result.created_at).toBeInstanceOf(Date);
+    expect(result.created_at).toBeInstanceOf(FaunaTime);
     expect(result.extras.nest.num_sticks).toEqual(58);
     expect(result.extras.nest["@extras"].egg.fertilized).toBe(false);
     expect(result.measurements).toHaveLength(2);
     expect(result.measurements[0].id).toEqual(1);
     expect(result.measurements[0].employee).toEqual(3);
-    expect(result.measurements[0].time).toBeInstanceOf(Date);
+    expect(result.measurements[0].time).toBeInstanceOf(FaunaTime);
     expect(result.measurements[1].id).toEqual(2);
     expect(result.measurements[1].employee).toEqual(5);
-    expect(result.measurements[1].time).toBeInstanceOf(Date);
+    expect(result.measurements[1].time).toBeInstanceOf(FaunaTime);
     expect(result.molecules).toEqual(BigInt("999999999999999999"));
     expect(result.null).toBeNull();
     expect(result.set).toStrictEqual(set);
@@ -82,14 +75,15 @@ describe("tagged format", () => {
   it("can be encoded", () => {
     let result = JSON.stringify(
       TaggedTypeFormat.encode({
-        child: { more: { itsworking: new Date("1983-04-15") } },
-        date: new Date("1923-05-13"),
+        child: { more: { itsworking: FaunaDate.from("1983-04-15") } },
+        date: FaunaDate.from("1923-05-13"),
         double: 4.14,
         int: 32,
         name: "Hello, World",
         null: null,
         number: 48,
-        time: new Date("2023-01-30T16:27:45.204243-05:00"),
+        time: FaunaTime.from("2023-01-30T16:27:45.204243-05:00"),
+        datetime: new Date("2023-01-30T16:27:45.204243-05:00"),
         extra: [
           {
             id: 1,
@@ -101,7 +95,7 @@ describe("tagged format", () => {
           },
         ],
         "@foobar": {
-          date: new Date("1888-08-08"),
+          date: FaunaDate.from("1888-08-08"),
         },
       })
     );
@@ -117,8 +111,8 @@ describe("tagged format", () => {
 
   it("handles conflicts", () => {
     var result = TaggedTypeFormat.encode({
-      date: { "@date": new Date("2022-11-01T00:00:00.000Z") },
-      time: { "@time": new Date("2022-11-02T05:00:00.000Z") },
+      date: { "@date": FaunaDate.from("2022-11-01") },
+      time: { "@time": FaunaTime.from("2022-11-02T05:00:00.000Z") },
       int: { "@int": 1 },
       long: { "@long": BigInt("99999999999999999") },
       double: { "@double": 1.99 },
@@ -190,9 +184,9 @@ describe("tagged format", () => {
       const encoded = TaggedTypeFormat.encode(input);
       const encodedKey = Object.keys(encoded)[0];
       expect(encodedKey).toEqual(tag);
-      const result = await client.query(fql`${input}`);
-      expect(typeof result.data).toEqual(expectedType);
-      expect(result.data.toString()).toEqual(expected.toString());
+      const decoded = TaggedTypeFormat.decode(JSON.stringify(encoded));
+      expect(typeof decoded).toBe(expectedType);
+      expect(decoded).toEqual(expected);
     }
   );
 
@@ -203,17 +197,6 @@ describe("tagged format", () => {
     ${Number.NEGATIVE_INFINITY} | ${"NEGATIVE_INFINITY"}
     ${Number.POSITIVE_INFINITY} | ${"POSITIVE_INFINITY"}
   `("Throws if BigInt value is $testCase", async ({ input }) => {
-    expect.assertions(2);
-    try {
-      const result = await client.query({
-        query: "foo",
-        arguments: { foo: input },
-      });
-    } catch (e) {
-      if (e instanceof ClientError) {
-        expect(e.cause).toBeDefined();
-        expect(e.cause).toBeInstanceOf(RangeError);
-      }
-    }
+    expect(() => TaggedTypeFormat.encode(input)).toThrow();
   });
 });

--- a/__tests__/unit/values.test.ts
+++ b/__tests__/unit/values.test.ts
@@ -1,0 +1,109 @@
+import { FaunaDate, FaunaTime } from "../../src/values";
+
+type TestCase<I, O> = {
+  input: I;
+  expected: O;
+  testCase: string;
+};
+
+describe("values", () => {
+  it.each`
+    input                          | expected                       | testCase
+    ${"2023-03-08T00:00:00Z"}      | ${"2023-03-08T00:00:00Z"}      | ${"Z"}
+    ${"2023-03-07T16:00:00-08:00"} | ${"2023-03-07T16:00:00-08:00"} | ${"- timezone"}
+    ${"2023-03-09T02:00:00+08:00"} | ${"2023-03-09T02:00:00+08:00"} | ${"+ timezone"}
+    ${"2023-03-08T00:00:00"}       | ${"2023-03-08T00:00:00"}       | ${"no timezone"}
+    ${"2023-03-08"}                | ${"2023-03-08"}                | ${"no time"}
+  `(
+    "can construct FaunaTime from strings: $testCase",
+    async ({ input, expected, testCase }: TestCase<string, string>) => {
+      testCase;
+      const value = FaunaTime.from(input);
+      expect(value).toBeInstanceOf(FaunaTime);
+      expect(value.value).toBe(expected);
+    }
+  );
+
+  it.each`
+    input                          | expected        | testCase
+    ${"2023-03-08T00:00:00Z"}      | ${"2023-03-08"} | ${"Z"}
+    ${"2023-03-07T16:00:00-08:00"} | ${"2023-03-08"} | ${"- timezone"}
+    ${"2023-03-09T02:00:00+08:00"} | ${"2023-03-08"} | ${"+ timezone"}
+    ${"2023-03-08T00:00:00"}       | ${"2023-03-08"} | ${"no timezone"}
+    ${"2023-03-08"}                | ${"2023-03-08"} | ${"no time"}
+  `(
+    "can construct FaunaDate from strings: $testCase",
+    async ({ input, expected, testCase }: TestCase<string, string>) => {
+      testCase;
+      const value = FaunaDate.from(input);
+      expect(value).toBeInstanceOf(FaunaDate);
+      expect(value.value).toBe(expected);
+    }
+  );
+
+  it.each`
+    input                                    | expected                                         | testCase
+    ${new Date("2023-03-08T00:00:00Z")}      | ${"2023-03-08T00:00:00.000Z"}                    | ${"Z"}
+    ${new Date("2023-03-07T16:00:00-08:00")} | ${"2023-03-08T00:00:00.000Z"}                    | ${"- timezone"}
+    ${new Date("2023-03-09T02:00:00+08:00")} | ${"2023-03-08T18:00:00.000Z"}                    | ${"+ timezone"}
+    ${new Date("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00").toISOString()} | ${"no timezone"}
+    ${new Date("2023-03-08")}                | ${"2023-03-08T00:00:00.000Z"}                    | ${"no time"}
+  `(
+    "can construct FaunaTime from Date: $testCase",
+    async ({ input, expected, testCase }: TestCase<Date, string>) => {
+      testCase;
+      const value = FaunaTime.fromDate(input);
+      expect(value).toBeInstanceOf(FaunaTime);
+      expect(value.value).toBe(expected);
+    }
+  );
+
+  it.each`
+    input                                    | expected                                                      | testCase
+    ${new Date("2023-03-08T00:00:00Z")}      | ${"2023-03-08"}                                               | ${"Z"}
+    ${new Date("2023-03-07T16:00:00-08:00")} | ${"2023-03-08"}                                               | ${"- timezone"}
+    ${new Date("2023-03-09T02:00:00+08:00")} | ${"2023-03-08"}                                               | ${"+ timezone"}
+    ${new Date("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00").toISOString().slice(0, 10)} | ${"no timezone"}
+    ${new Date("2023-03-08")}                | ${"2023-03-08"}                                               | ${"no time"}
+  `(
+    "can construct FaunaDate from Date: $testCase",
+    async ({ input, expected, testCase }: TestCase<Date, string>) => {
+      testCase;
+      const value = FaunaDate.fromDate(input);
+      expect(value).toBeInstanceOf(FaunaDate);
+      expect(value.value).toBe(expected);
+    }
+  );
+
+  it.each`
+    input                                          | expected                                | testCase
+    ${FaunaTime.from("2023-03-08T00:00:00Z")}      | ${new Date("2023-03-08T00:00:00.000Z")} | ${"Z"}
+    ${FaunaTime.from("2023-03-07T16:00:00-08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"- timezone"}
+    ${FaunaTime.from("2023-03-09T02:00:00+08:00")} | ${new Date("2023-03-08T18:00:00.000Z")} | ${"+ timezone"}
+    ${FaunaTime.from("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00")}      | ${"no timezone"}
+    ${FaunaTime.from("2023-03-08")}                | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no time"}
+  `(
+    "can deconstruct FaunaTime into a Date: $testCase",
+    async ({ input, expected, testCase }: TestCase<FaunaTime, Date>) => {
+      testCase;
+      const date = input.toDate();
+      expect(date).toEqual(expected);
+    }
+  );
+
+  it.each`
+    input                                          | expected                                | testCase
+    ${FaunaDate.from("2023-03-08T00:00:00Z")}      | ${new Date("2023-03-08T00:00:00.000Z")} | ${"Z"}
+    ${FaunaDate.from("2023-03-07T16:00:00-08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"- timezone"}
+    ${FaunaDate.from("2023-03-09T02:00:00+08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"+ timezone"}
+    ${FaunaDate.from("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no timezone"}
+    ${FaunaDate.from("2023-03-08")}                | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no time"}
+  `(
+    "can deconstruct FaunaDate into a Date: $testCase",
+    async ({ input, expected, testCase }: TestCase<FaunaDate, Date>) => {
+      testCase;
+      const date = input.toDate();
+      expect(date).toEqual(expected);
+    }
+  );
+});

--- a/__tests__/unit/values.test.ts
+++ b/__tests__/unit/values.test.ts
@@ -1,4 +1,4 @@
-import { FaunaDate, FaunaTime } from "../../src/values";
+import { DateStub, TimeStub } from "../../src/values";
 
 type TestCase<I, O> = {
   input: I;
@@ -15,11 +15,11 @@ describe("values", () => {
     ${"2023-03-08T00:00:00"}       | ${"2023-03-08T00:00:00"}       | ${"no timezone"}
     ${"2023-03-08"}                | ${"2023-03-08"}                | ${"no time"}
   `(
-    "can construct FaunaTime from strings: $testCase",
+    "can construct TimeStub from strings: $testCase",
     async ({ input, expected, testCase }: TestCase<string, string>) => {
       testCase;
-      const value = FaunaTime.from(input);
-      expect(value).toBeInstanceOf(FaunaTime);
+      const value = TimeStub.from(input);
+      expect(value).toBeInstanceOf(TimeStub);
       expect(value.value).toBe(expected);
     }
   );
@@ -32,11 +32,11 @@ describe("values", () => {
     ${"2023-03-08T00:00:00"}       | ${"2023-03-08"} | ${"no timezone"}
     ${"2023-03-08"}                | ${"2023-03-08"} | ${"no time"}
   `(
-    "can construct FaunaDate from strings: $testCase",
+    "can construct DateStub from strings: $testCase",
     async ({ input, expected, testCase }: TestCase<string, string>) => {
       testCase;
-      const value = FaunaDate.from(input);
-      expect(value).toBeInstanceOf(FaunaDate);
+      const value = DateStub.from(input);
+      expect(value).toBeInstanceOf(DateStub);
       expect(value.value).toBe(expected);
     }
   );
@@ -49,11 +49,11 @@ describe("values", () => {
     ${new Date("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00").toISOString()} | ${"no timezone"}
     ${new Date("2023-03-08")}                | ${"2023-03-08T00:00:00.000Z"}                    | ${"no time"}
   `(
-    "can construct FaunaTime from Date: $testCase",
+    "can construct TimeStub from Date: $testCase",
     async ({ input, expected, testCase }: TestCase<Date, string>) => {
       testCase;
-      const value = FaunaTime.fromDate(input);
-      expect(value).toBeInstanceOf(FaunaTime);
+      const value = TimeStub.fromDate(input);
+      expect(value).toBeInstanceOf(TimeStub);
       expect(value.value).toBe(expected);
     }
   );
@@ -66,25 +66,25 @@ describe("values", () => {
     ${new Date("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00").toISOString().slice(0, 10)} | ${"no timezone"}
     ${new Date("2023-03-08")}                | ${"2023-03-08"}                                               | ${"no time"}
   `(
-    "can construct FaunaDate from Date: $testCase",
+    "can construct DateStub from Date: $testCase",
     async ({ input, expected, testCase }: TestCase<Date, string>) => {
       testCase;
-      const value = FaunaDate.fromDate(input);
-      expect(value).toBeInstanceOf(FaunaDate);
+      const value = DateStub.fromDate(input);
+      expect(value).toBeInstanceOf(DateStub);
       expect(value.value).toBe(expected);
     }
   );
 
   it.each`
-    input                                          | expected                                | testCase
-    ${FaunaTime.from("2023-03-08T00:00:00Z")}      | ${new Date("2023-03-08T00:00:00.000Z")} | ${"Z"}
-    ${FaunaTime.from("2023-03-07T16:00:00-08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"- timezone"}
-    ${FaunaTime.from("2023-03-09T02:00:00+08:00")} | ${new Date("2023-03-08T18:00:00.000Z")} | ${"+ timezone"}
-    ${FaunaTime.from("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00")}      | ${"no timezone"}
-    ${FaunaTime.from("2023-03-08")}                | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no time"}
+    input                                         | expected                                | testCase
+    ${TimeStub.from("2023-03-08T00:00:00Z")}      | ${new Date("2023-03-08T00:00:00.000Z")} | ${"Z"}
+    ${TimeStub.from("2023-03-07T16:00:00-08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"- timezone"}
+    ${TimeStub.from("2023-03-09T02:00:00+08:00")} | ${new Date("2023-03-08T18:00:00.000Z")} | ${"+ timezone"}
+    ${TimeStub.from("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00")}      | ${"no timezone"}
+    ${TimeStub.from("2023-03-08")}                | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no time"}
   `(
-    "can deconstruct FaunaTime into a Date: $testCase",
-    async ({ input, expected, testCase }: TestCase<FaunaTime, Date>) => {
+    "can deconstruct TimeStub into a Date: $testCase",
+    async ({ input, expected, testCase }: TestCase<TimeStub, Date>) => {
       testCase;
       const date = input.toDate();
       expect(date).toEqual(expected);
@@ -92,15 +92,15 @@ describe("values", () => {
   );
 
   it.each`
-    input                                          | expected                                | testCase
-    ${FaunaDate.from("2023-03-08T00:00:00Z")}      | ${new Date("2023-03-08T00:00:00.000Z")} | ${"Z"}
-    ${FaunaDate.from("2023-03-07T16:00:00-08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"- timezone"}
-    ${FaunaDate.from("2023-03-09T02:00:00+08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"+ timezone"}
-    ${FaunaDate.from("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no timezone"}
-    ${FaunaDate.from("2023-03-08")}                | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no time"}
+    input                                         | expected                                | testCase
+    ${DateStub.from("2023-03-08T00:00:00Z")}      | ${new Date("2023-03-08T00:00:00.000Z")} | ${"Z"}
+    ${DateStub.from("2023-03-07T16:00:00-08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"- timezone"}
+    ${DateStub.from("2023-03-09T02:00:00+08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"+ timezone"}
+    ${DateStub.from("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no timezone"}
+    ${DateStub.from("2023-03-08")}                | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no time"}
   `(
-    "can deconstruct FaunaDate into a Date: $testCase",
-    async ({ input, expected, testCase }: TestCase<FaunaDate, Date>) => {
+    "can deconstruct DateStub into a Date: $testCase",
+    async ({ input, expected, testCase }: TestCase<DateStub, Date>) => {
       testCase;
       const date = input.toDate();
       expect(date).toEqual(expected);

--- a/__tests__/unit/values.test.ts
+++ b/__tests__/unit/values.test.ts
@@ -20,7 +20,7 @@ describe("values", () => {
       testCase;
       const value = TimeStub.from(input);
       expect(value).toBeInstanceOf(TimeStub);
-      expect(value.value).toBe(expected);
+      expect(value.isoString).toBe(expected);
     }
   );
 
@@ -37,7 +37,7 @@ describe("values", () => {
       testCase;
       const value = DateStub.from(input);
       expect(value).toBeInstanceOf(DateStub);
-      expect(value.value).toBe(expected);
+      expect(value.dateString).toBe(expected);
     }
   );
 
@@ -54,7 +54,7 @@ describe("values", () => {
       testCase;
       const value = TimeStub.fromDate(input);
       expect(value).toBeInstanceOf(TimeStub);
-      expect(value.value).toBe(expected);
+      expect(value.isoString).toBe(expected);
     }
   );
 
@@ -71,7 +71,7 @@ describe("values", () => {
       testCase;
       const value = DateStub.fromDate(input);
       expect(value).toBeInstanceOf(DateStub);
-      expect(value.value).toBe(expected);
+      expect(value.dateString).toBe(expected);
     }
   );
 

--- a/__tests__/unit/values.test.ts
+++ b/__tests__/unit/values.test.ts
@@ -10,10 +10,12 @@ describe("values", () => {
   it.each`
     input                          | expected                       | testCase
     ${"2023-03-08T00:00:00Z"}      | ${"2023-03-08T00:00:00Z"}      | ${"Z"}
-    ${"2023-03-07T16:00:00-08:00"} | ${"2023-03-07T16:00:00-08:00"} | ${"- timezone"}
-    ${"2023-03-09T02:00:00+08:00"} | ${"2023-03-09T02:00:00+08:00"} | ${"+ timezone"}
-    ${"2023-03-08T00:00:00"}       | ${"2023-03-08T00:00:00"}       | ${"no timezone"}
-    ${"2023-03-08"}                | ${"2023-03-08"}                | ${"no time"}
+    ${"2023-03-07T16:00:00-08:00"} | ${"2023-03-07T16:00:00-08:00"} | ${"- HH:MM"}
+    ${"2023-03-07T16:00:00-0800"}  | ${"2023-03-07T16:00:00-0800"}  | ${"- HHMM"}
+    ${"2023-03-09T02:00:00+08:00"} | ${"2023-03-09T02:00:00+08:00"} | ${"+ HH:MM"}
+    ${"2023-03-09T02:00:00+0800"}  | ${"2023-03-09T02:00:00+0800"}  | ${"+ HHMM"}
+    ${"+10000-01-01T00:00:00Z"}    | ${"+10000-01-01T00:00:00Z"}    | ${"+yyyyy"}
+    ${"-6000-01-01T00:00:00Z"}     | ${"-6000-01-01T00:00:00Z"}     | ${"-yyyy"}
   `(
     "can construct TimeStub from strings: $testCase",
     async ({ input, expected, testCase }: TestCase<string, string>) => {
@@ -25,12 +27,9 @@ describe("values", () => {
   );
 
   it.each`
-    input                          | expected        | testCase
-    ${"2023-03-08T00:00:00Z"}      | ${"2023-03-08"} | ${"Z"}
-    ${"2023-03-07T16:00:00-08:00"} | ${"2023-03-08"} | ${"- timezone"}
-    ${"2023-03-09T02:00:00+08:00"} | ${"2023-03-08"} | ${"+ timezone"}
-    ${"2023-03-08T00:00:00"}       | ${"2023-03-08"} | ${"no timezone"}
-    ${"2023-03-08"}                | ${"2023-03-08"} | ${"no time"}
+    input           | expected        | testCase
+    ${"2023-03-08"} | ${"2023-03-08"} | ${"some date"}
+    ${"2004-02-29"} | ${"2004-02-29"} | ${"leap year"}
   `(
     "can construct DateStub from strings: $testCase",
     async ({ input, expected, testCase }: TestCase<string, string>) => {
@@ -42,68 +41,69 @@ describe("values", () => {
   );
 
   it.each`
-    input                                    | expected                                         | testCase
-    ${new Date("2023-03-08T00:00:00Z")}      | ${"2023-03-08T00:00:00.000Z"}                    | ${"Z"}
-    ${new Date("2023-03-07T16:00:00-08:00")} | ${"2023-03-08T00:00:00.000Z"}                    | ${"- timezone"}
-    ${new Date("2023-03-09T02:00:00+08:00")} | ${"2023-03-08T18:00:00.000Z"}                    | ${"+ timezone"}
-    ${new Date("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00").toISOString()} | ${"no timezone"}
-    ${new Date("2023-03-08")}                | ${"2023-03-08T00:00:00.000Z"}                    | ${"no time"}
+    input                          | expected                                         | testCase
+    ${"2023-03-08T00:00:00Z"}      | ${"2023-03-08T00:00:00.000Z"}                    | ${"Z"}
+    ${"2023-03-07T16:00:00-08:00"} | ${"2023-03-08T00:00:00.000Z"}                    | ${"- HH:MM"}
+    ${"2023-03-09T02:00:00+08:00"} | ${"2023-03-08T18:00:00.000Z"}                    | ${"+ HH:MM"}
+    ${"2023-03-08T00:00:00"}       | ${new Date("2023-03-08T00:00:00").toISOString()} | ${"no timezone"}
+    ${"2023-03-08"}                | ${"2023-03-08T00:00:00.000Z"}                    | ${"no time"}
   `(
     "can construct TimeStub from Date: $testCase",
-    async ({ input, expected, testCase }: TestCase<Date, string>) => {
+    async ({ input, expected, testCase }: TestCase<string, string>) => {
       testCase;
-      const value = TimeStub.fromDate(input);
+      const value = TimeStub.fromDate(new Date(input));
       expect(value).toBeInstanceOf(TimeStub);
       expect(value.isoString).toBe(expected);
     }
   );
 
   it.each`
-    input                                    | expected                                                      | testCase
-    ${new Date("2023-03-08T00:00:00Z")}      | ${"2023-03-08"}                                               | ${"Z"}
-    ${new Date("2023-03-07T16:00:00-08:00")} | ${"2023-03-08"}                                               | ${"- timezone"}
-    ${new Date("2023-03-09T02:00:00+08:00")} | ${"2023-03-08"}                                               | ${"+ timezone"}
-    ${new Date("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00").toISOString().slice(0, 10)} | ${"no timezone"}
-    ${new Date("2023-03-08")}                | ${"2023-03-08"}                                               | ${"no time"}
+    input                          | expected                                                      | testCase
+    ${"2023-03-08T00:00:00Z"}      | ${"2023-03-08"}                                               | ${"Z"}
+    ${"2023-03-07T16:00:00-08:00"} | ${"2023-03-08"}                                               | ${"- HH:MM"}
+    ${"2023-03-09T02:00:00+08:00"} | ${"2023-03-08"}                                               | ${"+ HH:MM"}
+    ${"2023-03-08T00:00:00"}       | ${new Date("2023-03-08T00:00:00").toISOString().slice(0, 10)} | ${"no timezone"}
+    ${"2023-03-08"}                | ${"2023-03-08"}                                               | ${"no time"}
   `(
     "can construct DateStub from Date: $testCase",
-    async ({ input, expected, testCase }: TestCase<Date, string>) => {
+    async ({ input, expected, testCase }: TestCase<string, string>) => {
       testCase;
-      const value = DateStub.fromDate(input);
+      const value = DateStub.fromDate(new Date(input));
       expect(value).toBeInstanceOf(DateStub);
       expect(value.dateString).toBe(expected);
     }
   );
 
   it.each`
-    input                                         | expected                                | testCase
-    ${TimeStub.from("2023-03-08T00:00:00Z")}      | ${new Date("2023-03-08T00:00:00.000Z")} | ${"Z"}
-    ${TimeStub.from("2023-03-07T16:00:00-08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"- timezone"}
-    ${TimeStub.from("2023-03-09T02:00:00+08:00")} | ${new Date("2023-03-08T18:00:00.000Z")} | ${"+ timezone"}
-    ${TimeStub.from("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00")}      | ${"no timezone"}
-    ${TimeStub.from("2023-03-08")}                | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no time"}
+    input                          | expected                       | testCase
+    ${"2023-03-08T00:00:00Z"}      | ${"2023-03-08T00:00:00Z"}      | ${"Z"}
+    ${"2023-03-07T16:00:00-08:00"} | ${"2023-03-07T16:00:00-08:00"} | ${"- HH:MM"}
+    ${"2023-03-07T16:00:00-0800"}  | ${"2023-03-07T16:00:00-0800"}  | ${"- HHMM"}
+    ${"2023-03-09T02:00:00+08:00"} | ${"2023-03-09T02:00:00+08:00"} | ${"+ HH:MM"}
+    ${"2023-03-09T02:00:00+0800"}  | ${"2023-03-09T02:00:00+0800"}  | ${"+ HHMM"}
+    ${"+010000-01-01T00:00:00Z"}   | ${"+010000-01-01T00:00:00Z"}   | ${"+yyyyy"}
+    ${"-006000-01-01T00:00:00Z"}   | ${"-006000-01-01T00:00:00Z"}   | ${"-yyyy"}
   `(
     "can deconstruct TimeStub into a Date: $testCase",
-    async ({ input, expected, testCase }: TestCase<TimeStub, Date>) => {
+    async ({ input, expected, testCase }: TestCase<string, string>) => {
       testCase;
-      const date = input.toDate();
-      expect(date).toEqual(expected);
+      const timeStub = TimeStub.from(input);
+      const date = timeStub.toDate();
+      expect(date).toEqual(new Date(expected));
     }
   );
 
   it.each`
-    input                                         | expected                                | testCase
-    ${DateStub.from("2023-03-08T00:00:00Z")}      | ${new Date("2023-03-08T00:00:00.000Z")} | ${"Z"}
-    ${DateStub.from("2023-03-07T16:00:00-08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"- timezone"}
-    ${DateStub.from("2023-03-09T02:00:00+08:00")} | ${new Date("2023-03-08T00:00:00.000Z")} | ${"+ timezone"}
-    ${DateStub.from("2023-03-08T00:00:00")}       | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no timezone"}
-    ${DateStub.from("2023-03-08")}                | ${new Date("2023-03-08T00:00:00.000Z")} | ${"no time"}
+    input           | expected        | testCase
+    ${"2023-03-08"} | ${"2023-03-08"} | ${"some date"}
+    ${"2004-02-29"} | ${"2004-02-29"} | ${"leap year"}
   `(
     "can deconstruct DateStub into a Date: $testCase",
-    async ({ input, expected, testCase }: TestCase<DateStub, Date>) => {
+    async ({ input, expected, testCase }: TestCase<string, string>) => {
       testCase;
-      const date = input.toDate();
-      expect(date).toEqual(expected);
+      const dateStub = DateStub.from(input);
+      const date = dateStub.toDate();
+      expect(date).toEqual(new Date(expected));
     }
   );
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -167,7 +167,7 @@ export class ServiceTimeoutError extends ServiceError {
  * prior to sending the request.
  */
 export class ClientError extends Error {
-  constructor(message: string, options: { cause: any }) {
+  constructor(message: string, options?: { cause: any }) {
     super(message, options);
     // Maintains proper stack trace for where our error was thrown (only available on V8)
     if (Error.captureStackTrace) {

--- a/src/regex.ts
+++ b/src/regex.ts
@@ -1,0 +1,38 @@
+// Date and Time expressions
+
+const yearpart = /(?:\d{4}|[\u2212-]\d{4,}|\+\d{5,})/;
+const monthpart = /(?:0[1-9]|1[0-2])/;
+const daypart = /(?:0[1-9]|[12]\d|3[01])/;
+const hourpart = /(?:[01][0-9]|2[0-3])/;
+const minsecpart = /(?:[0-5][0-9])/;
+const decimalpart = /(?:\.\d+)/;
+
+const datesplit = new RegExp(
+  `(${yearpart.source}-(${monthpart.source})-(${daypart.source}))`
+);
+
+const timesplit = new RegExp(
+  `(${hourpart.source}:${minsecpart.source}:${minsecpart.source}${decimalpart.source}?)`
+);
+
+const zonesplit = new RegExp(
+  `([zZ]|[+\u2212-]${hourpart.source}(?::?${minsecpart.source}|:${minsecpart.source}:${minsecpart.source}))`
+);
+
+/**
+ * Matches the subset of ISO8601 dates that Fauna can accept. Cannot include any
+ * time part
+ */
+export const plaindate = new RegExp(`^${datesplit.source}$`);
+
+/**
+ * Matches a valid ISO8601 date and can have anything trailing after.
+ */
+export const startsWithPlaindate = new RegExp(`^${datesplit.source}`);
+
+/**
+ * Matches the subset of ISO8601 times that Fauna can accept.
+ */
+export const datetime = new RegExp(
+  `^${datesplit.source}T${timesplit.source}${zonesplit.source}$`
+);

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -132,8 +132,8 @@ export class TaggedTypeEncoded {
     date: (dateValue: Date): TaggedTime => ({
       "@time": dateValue.toISOString(),
     }),
-    faunadate: (value: DateStub): TaggedDate => ({ "@date": value.value }),
-    faunatime: (value: TimeStub): TaggedTime => ({ "@time": value.value }),
+    faunadate: (value: DateStub): TaggedDate => ({ "@date": value.dateString }),
+    faunatime: (value: TimeStub): TaggedTime => ({ "@time": value.isoString }),
   };
 
   constructor(input: any) {

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -1,4 +1,4 @@
-import { FaunaDate, FaunaTime } from "./values";
+import { DateStub, TimeStub } from "./values";
 
 /** A reference to a built in Fauna module; e.g. Date */
 export type Module = string;
@@ -51,9 +51,9 @@ export class TaggedTypeFormat {
       } else if (value["@double"]) {
         return Number(value["@double"]);
       } else if (value["@date"]) {
-        return FaunaDate.from(value["@date"]);
+        return DateStub.from(value["@date"]);
       } else if (value["@time"]) {
-        return FaunaTime.from(value["@time"]);
+        return TimeStub.from(value["@time"]);
       } else if (value["@object"]) {
         return value["@object"];
       }
@@ -132,8 +132,8 @@ export class TaggedTypeEncoded {
     date: (dateValue: Date): TaggedTime => ({
       "@time": dateValue.toISOString(),
     }),
-    faunadate: (value: FaunaDate): TaggedDate => ({ "@date": value.value }),
-    faunatime: (value: FaunaTime): TaggedTime => ({ "@time": value.value }),
+    faunadate: (value: DateStub): TaggedDate => ({ "@date": value.value }),
+    faunatime: (value: TimeStub): TaggedTime => ({ "@time": value.value }),
   };
 
   constructor(input: any) {
@@ -157,9 +157,9 @@ export class TaggedTypeEncoded {
           this.result = this.#encodeMap["array"](input);
         } else if (input instanceof Date) {
           this.result = this.#encodeMap["date"](input);
-        } else if (input instanceof FaunaDate) {
+        } else if (input instanceof DateStub) {
           this.result = this.#encodeMap["faunadate"](input);
-        } else if (input instanceof FaunaTime) {
+        } else if (input instanceof TimeStub) {
           this.result = this.#encodeMap["faunatime"](input);
         } else {
           this.result = this.#encodeMap["object"](input);

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -1,3 +1,5 @@
+import { FaunaDate, FaunaTime } from "./values";
+
 /** A reference to a built in Fauna module; e.g. Date */
 export type Module = string;
 /** A reference to a document in Fauna */
@@ -49,9 +51,9 @@ export class TaggedTypeFormat {
       } else if (value["@double"]) {
         return Number(value["@double"]);
       } else if (value["@date"]) {
-        return new Date(value["@date"] + "T00:00:00.000Z");
+        return FaunaDate.from(value["@date"]);
       } else if (value["@time"]) {
-        return new Date(value["@time"]);
+        return FaunaTime.from(value["@time"]);
       } else if (value["@object"]) {
         return value["@object"];
       }
@@ -127,18 +129,11 @@ export class TaggedTypeEncoded {
       for (const i in input) _out.push(TaggedTypeFormat.encode(input[i]));
       return _out;
     },
-    date: (dateValue: Date): TaggedDate | TaggedTime => {
-      if (
-        dateValue.getUTCHours() == 0 &&
-        dateValue.getUTCMinutes() == 0 &&
-        dateValue.getUTCSeconds() == 0 &&
-        dateValue.getUTCMilliseconds() == 0
-      ) {
-        return { "@date": dateValue.toISOString().split("T")[0] };
-      }
-
-      return { "@time": dateValue.toISOString() };
-    },
+    date: (dateValue: Date): TaggedTime => ({
+      "@time": dateValue.toISOString(),
+    }),
+    faunadate: (value: FaunaDate): TaggedDate => ({ "@date": value.value }),
+    faunatime: (value: FaunaTime): TaggedTime => ({ "@time": value.value }),
   };
 
   constructor(input: any) {
@@ -162,6 +157,10 @@ export class TaggedTypeEncoded {
           this.result = this.#encodeMap["array"](input);
         } else if (input instanceof Date) {
           this.result = this.#encodeMap["date"](input);
+        } else if (input instanceof FaunaDate) {
+          this.result = this.#encodeMap["faunadate"](input);
+        } else if (input instanceof FaunaTime) {
+          this.result = this.#encodeMap["faunatime"](input);
         } else {
           this.result = this.#encodeMap["object"](input);
         }

--- a/src/values.ts
+++ b/src/values.ts
@@ -1,21 +1,166 @@
 /**
- * An Instant represents a fixed point in time (called "exact time"), without
- * regard to calendar or location, e.g. July 20, 1969, at 20:17 UTC.
+ * An wrapper around the Fauna `Time` type. It, represents a fixed point in time
+ * without regard to calendar or location, e.g. July 20, 1969, at 20:17 UTC.
  *
- * @remarks This class follows the TC39 proposal for `Temporal.Instant`. See the
- * proposal here: https://tc39.es/proposal-temporal/docs/index.html.
- * Since fauna has both `Time` and `Date` data types, we want to make a clear
- * distinction between them and avoid using the native `Date` class.
+ * @remarks The Javascript `Date` type most closely resembles a Fauna `Time`,
+ * not a Fauna `Date`. However, Fauna stores `Time` values with nanosecond
+ * precision, while Javascript `Date` values only have millisecond precision.
+ * This FaunaTime class preserves precision by storing the original string value
+ * and should be used whenever possible to pass `Time` values back to Fauna.
+ * Converting to a Javascript date before sending to Fauna could result in loss
+ * of precision.
+ *
+ * TODO: link to beta docs for `Time` type
  */
-class FaunaTime {}
+export class FaunaTime {
+  readonly #value: string;
+
+  /**
+   * @remarks constructor is private to enforce using factory functions
+   */
+  private constructor(isoString: string) {
+    this.#value = isoString;
+  }
+
+  /**
+   * Creates a new {@link FaunaTime} from an ISO date string
+   * @param item - An ISO date string.
+   * @returns A new {@link FaunaTime}
+   * @throws TypeError if a string is not provided, or RangeError if item
+   * is not a valid date
+   */
+  static from(item: string): FaunaTime {
+    if (typeof item !== "string") {
+      throw new TypeError(
+        `Expected string but received ${typeof item}: ${item}`
+      );
+    }
+    const validatedDate = new Date(item);
+    if (validatedDate.toString() === "Invalid Date") {
+      throw new RangeError(
+        `Expected a valid date string but received '${item}'`
+      );
+    }
+
+    return new FaunaTime(item);
+  }
+
+  /**
+   * Creates a new {@link FaunaTime} from a Javascript `Date`
+   * @param isoString - A Javascript `Date`
+   * @returns A new {@link FaunaTime}
+   */
+  static fromDate(date: Date): FaunaTime {
+    return new FaunaTime(date.toISOString());
+  }
+
+  /**
+   * Get the underlying string value
+   */
+  get value(): string {
+    return this.#value;
+  }
+
+  /**
+   * Get a copy of the `FaunaTime` converted to a Javascript `Date`. Does not
+   * mutate the existing `FaunaTime` value.
+   * @returns A `Date`
+   */
+  toDate(): Date {
+    return new Date(this.#value);
+  }
+
+  /**
+   * Override default JSON output
+   * @returns the string representation of the Fauna Time
+   */
+  toJSON(): string {
+    return this.#value;
+  }
+}
 
 /**
- * A Temporal.PlainDate object represents a calendar date that is not associated
- * with a particular time or time zone, e.g. August 24th, 2006.
+ * A wrapper aroud the Fauna `Date` type. It represents a calendar date that is
+ * not associated with a particular time or time zone, e.g. August 24th, 2006.
  *
- * @remarks This class follows the TC39 proposal for `Temporal.PlainDate`. See the
- * proposal here: https://tc39.es/proposal-temporal/docs/index.html.
- * Since fauna has both `Time` and `Date` data types, we want to make a clear
- * distinction between them and avoid using the native `Date` class.
+ * @remarks The Javascript `Date` type always has a time associated with it, but
+ * Fauna's `Date` type does not. When converting from a Fauna `Date` to a
+ * Javascript `Date`, we set time to 00:00:00 UTC. When converting a Javascript
+ * `Date` or time string to Fauna `Date`, we convert to UTC first. Care should
+ * be taken to specify the desired date, since Javascript `Date`s use local
+ * timezone info by default.
+ *
+ * TODO: link to beta docs for `Date` type
  */
-class FaunaDate {}
+export class FaunaDate {
+  readonly #value: string;
+
+  /**
+   * @remarks constructor is private to enforce using factory functions
+   */
+  private constructor(dateString: string) {
+    this.#value = dateString;
+  }
+
+  /**
+   * Creates a new {@link FaunaDate} from a date string
+   * @param item - A date string. The time is converted to UTC before saving the
+   * date.
+   * @returns A new {@link FaunaDate}
+   * @throws TypeError if a string is not provided, or RangeError if item
+   * is not a valid date
+   */
+  static from(item: string): FaunaDate {
+    if (typeof item !== "string") {
+      throw new TypeError(
+        `Expected string but received ${typeof item}: ${item}`
+      );
+    }
+    const validatedDate = new Date(item);
+    if (validatedDate.toString() === "Invalid Date") {
+      throw new RangeError(
+        `Expected a valid date string but received '${item}'`
+      );
+    }
+
+    return new FaunaDate(validatedDate.toISOString().slice(0, 10));
+  }
+
+  /**
+   * Creates a new {@link FaunaDate} from a Javascript `Date`
+   * @param isoString - A Javascript `Date`. The time is converted to UTC before
+   * saving the date.
+   * @returns A new {@link FaunaDate}
+   */
+  static fromDate(date: Date): FaunaDate {
+    if (!(date instanceof Date)) {
+      throw new TypeError(`Expected Date but received ${typeof date}: ${date}`);
+    }
+
+    return new FaunaDate(date.toISOString().slice(0, 10));
+  }
+
+  /**
+   * Get the underlying string value
+   */
+  get value(): string {
+    return this.#value;
+  }
+
+  /**
+   * Get a copy of the `FaunaTime` converted to a Javascript `Date`. Does not
+   * mutate the existing `FaunaTime` value.
+   * @returns A `Date`
+   */
+  toDate(): Date {
+    return new Date(this.#value + "T00:00:00Z");
+  }
+
+  /**
+   * Override default JSON output
+   * @returns the string representation of the Fauna Time
+   */
+  toJSON(): string {
+    return this.#value;
+  }
+}

--- a/src/values.ts
+++ b/src/values.ts
@@ -13,13 +13,13 @@
  * TODO: link to beta docs for `Time` type
  */
 export class TimeStub {
-  readonly #value: string;
+  readonly #isoString: string;
 
   /**
    * @remarks constructor is private to enforce using factory functions
    */
   private constructor(isoString: string) {
-    this.#value = isoString;
+    this.#isoString = isoString;
   }
 
   /**
@@ -57,8 +57,8 @@ export class TimeStub {
   /**
    * Get the underlying string value
    */
-  get value(): string {
-    return this.#value;
+  get isoString(): string {
+    return this.#isoString;
   }
 
   /**
@@ -67,7 +67,7 @@ export class TimeStub {
    * @returns A `Date`
    */
   toDate(): Date {
-    return new Date(this.#value);
+    return new Date(this.#isoString);
   }
 
   /**
@@ -75,7 +75,7 @@ export class TimeStub {
    * @returns the string representation of the Fauna Time
    */
   toJSON(): string {
-    return this.#value;
+    return this.#isoString;
   }
 }
 
@@ -93,13 +93,13 @@ export class TimeStub {
  * TODO: link to beta docs for `Date` type
  */
 export class DateStub {
-  readonly #value: string;
+  readonly #dateString: string;
 
   /**
    * @remarks constructor is private to enforce using factory functions
    */
   private constructor(dateString: string) {
-    this.#value = dateString;
+    this.#dateString = dateString;
   }
 
   /**
@@ -143,8 +143,8 @@ export class DateStub {
   /**
    * Get the underlying string value
    */
-  get value(): string {
-    return this.#value;
+  get dateString(): string {
+    return this.#dateString;
   }
 
   /**
@@ -153,7 +153,7 @@ export class DateStub {
    * @returns A `Date`
    */
   toDate(): Date {
-    return new Date(this.#value + "T00:00:00Z");
+    return new Date(this.#dateString + "T00:00:00Z");
   }
 
   /**
@@ -161,6 +161,6 @@ export class DateStub {
    * @returns the string representation of the Fauna Time
    */
   toJSON(): string {
-    return this.#value;
+    return this.#dateString;
   }
 }

--- a/src/values.ts
+++ b/src/values.ts
@@ -5,14 +5,14 @@
  * @remarks The Javascript `Date` type most closely resembles a Fauna `Time`,
  * not a Fauna `Date`. However, Fauna stores `Time` values with nanosecond
  * precision, while Javascript `Date` values only have millisecond precision.
- * This FaunaTime class preserves precision by storing the original string value
+ * This TimeStub class preserves precision by storing the original string value
  * and should be used whenever possible to pass `Time` values back to Fauna.
  * Converting to a Javascript date before sending to Fauna could result in loss
  * of precision.
  *
  * TODO: link to beta docs for `Time` type
  */
-export class FaunaTime {
+export class TimeStub {
   readonly #value: string;
 
   /**
@@ -23,13 +23,13 @@ export class FaunaTime {
   }
 
   /**
-   * Creates a new {@link FaunaTime} from an ISO date string
+   * Creates a new {@link TimeStub} from an ISO date string
    * @param item - An ISO date string.
-   * @returns A new {@link FaunaTime}
+   * @returns A new {@link TimeStub}
    * @throws TypeError if a string is not provided, or RangeError if item
    * is not a valid date
    */
-  static from(item: string): FaunaTime {
+  static from(item: string): TimeStub {
     if (typeof item !== "string") {
       throw new TypeError(
         `Expected string but received ${typeof item}: ${item}`
@@ -42,16 +42,16 @@ export class FaunaTime {
       );
     }
 
-    return new FaunaTime(item);
+    return new TimeStub(item);
   }
 
   /**
-   * Creates a new {@link FaunaTime} from a Javascript `Date`
+   * Creates a new {@link TimeStub} from a Javascript `Date`
    * @param isoString - A Javascript `Date`
-   * @returns A new {@link FaunaTime}
+   * @returns A new {@link TimeStub}
    */
-  static fromDate(date: Date): FaunaTime {
-    return new FaunaTime(date.toISOString());
+  static fromDate(date: Date): TimeStub {
+    return new TimeStub(date.toISOString());
   }
 
   /**
@@ -62,8 +62,8 @@ export class FaunaTime {
   }
 
   /**
-   * Get a copy of the `FaunaTime` converted to a Javascript `Date`. Does not
-   * mutate the existing `FaunaTime` value.
+   * Get a copy of the `TimeStub` converted to a Javascript `Date`. Does not
+   * mutate the existing `TimeStub` value.
    * @returns A `Date`
    */
   toDate(): Date {
@@ -92,7 +92,7 @@ export class FaunaTime {
  *
  * TODO: link to beta docs for `Date` type
  */
-export class FaunaDate {
+export class DateStub {
   readonly #value: string;
 
   /**
@@ -103,14 +103,14 @@ export class FaunaDate {
   }
 
   /**
-   * Creates a new {@link FaunaDate} from a date string
+   * Creates a new {@link DateStub} from a date string
    * @param item - A date string. The time is converted to UTC before saving the
    * date.
-   * @returns A new {@link FaunaDate}
+   * @returns A new {@link DateStub}
    * @throws TypeError if a string is not provided, or RangeError if item
    * is not a valid date
    */
-  static from(item: string): FaunaDate {
+  static from(item: string): DateStub {
     if (typeof item !== "string") {
       throw new TypeError(
         `Expected string but received ${typeof item}: ${item}`
@@ -123,21 +123,21 @@ export class FaunaDate {
       );
     }
 
-    return new FaunaDate(validatedDate.toISOString().slice(0, 10));
+    return new DateStub(validatedDate.toISOString().slice(0, 10));
   }
 
   /**
-   * Creates a new {@link FaunaDate} from a Javascript `Date`
+   * Creates a new {@link DateStub} from a Javascript `Date`
    * @param isoString - A Javascript `Date`. The time is converted to UTC before
    * saving the date.
-   * @returns A new {@link FaunaDate}
+   * @returns A new {@link DateStub}
    */
-  static fromDate(date: Date): FaunaDate {
+  static fromDate(date: Date): DateStub {
     if (!(date instanceof Date)) {
       throw new TypeError(`Expected Date but received ${typeof date}: ${date}`);
     }
 
-    return new FaunaDate(date.toISOString().slice(0, 10));
+    return new DateStub(date.toISOString().slice(0, 10));
   }
 
   /**
@@ -148,8 +148,8 @@ export class FaunaDate {
   }
 
   /**
-   * Get a copy of the `FaunaTime` converted to a Javascript `Date`. Does not
-   * mutate the existing `FaunaTime` value.
+   * Get a copy of the `TimeStub` converted to a Javascript `Date`. Does not
+   * mutate the existing `TimeStub` value.
    * @returns A `Date`
    */
   toDate(): Date {

--- a/src/values.ts
+++ b/src/values.ts
@@ -73,7 +73,13 @@ export class TimeStub {
    * @returns A `Date`
    */
   toDate(): Date {
-    return new Date(this.#isoString);
+    const date = new Date(this.#isoString);
+    if (date.toString() === "Invalid Date") {
+      throw new RangeError(
+        "Fauna Date could not be converted to Javascript Date"
+      );
+    }
+    return date;
   }
 
   /**
@@ -169,7 +175,13 @@ export class DateStub {
    * @returns A `Date`
    */
   toDate(): Date {
-    return new Date(this.#dateString + "T00:00:00Z");
+    const date = new Date(this.#dateString + "T00:00:00Z");
+    if (date.toString() === "Invalid Date") {
+      throw new RangeError(
+        "Fauna Date could not be converted to Javascript Date"
+      );
+    }
+    return date;
   }
 
   /**


### PR DESCRIPTION
Ticket(s): [FE-3080](https://faunadb.atlassian.net/browse/FE-3080)

## Problem
Fauna's `Time` type can store nanosecond precision. Javascript `Date` can only store milliseconds.

There is no built in type for "plain" dates in JS. Closest thing is using a `Date` with time set to 00:00:00 UTC. So Javascript `Date` is not well suited to store Fauna `Date` values.

## Solution
Provide our own type, very simple wrappers a la v4 driver. Stores the exact encoded string value. 

Native Javascript `Date`s are always encoded as a Fauna `Time`.

Users may still need JS `Date`s to do date/time things with it, so they may lose precision when converting to and from.

## Result

## Out of scope

## Testing
Added a unit tests for constructing and deconstructing FaunaTime and FaunaDate. Updated tests for encoding and decoding.

[FE-3080]: https://faunadb.atlassian.net/browse/FE-3080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ