### PR TITLE
Decode new format for @doc @ref and @set

### DIFF
--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -18,7 +18,9 @@ describe("tagged format", () => {
   it("can be decoded", () => {
     const allTypes: string = `{
       "bugs_coll": { "@mod": "Bugs" },
-      "bug": { "@doc": "Bugs:123" },
+      "bug_ref_string": { "@doc": "Bugs:123" },
+      "bug_ref_object": { "@ref": { "coll": "Bugs", "id": "123" } },
+      "bug_doc": { "@doc": { "coll": "Bugs", "id": "123" } },
       "name": "fir",
       "age": { "@int": "200" },
       "birthdate": { "@date": "1823-02-08" },
@@ -45,15 +47,19 @@ describe("tagged format", () => {
         }
       ],
       "molecules": { "@long": "999999999999999999" },
-      "null": null
+      "null": null,
+      "set": { "@set": { "data": ["a", "b"] } }
     }`;
 
     const bugs_mod: Module = "Bugs";
-    const bugs_doc: DocumentReference = "Bugs:123";
+    const bugs_doc: DocumentReference = { coll: "Bugs", id: "123" };
+    const set = { data: ["a", "b"] };
 
     const result = TaggedTypeFormat.decode(allTypes);
     expect(result.bugs_coll).toBe(bugs_mod);
-    expect(result.bug).toBe(bugs_doc);
+    expect(result.bug_ref_string).toStrictEqual(bugs_doc);
+    expect(result.bug_ref_object).toStrictEqual(bugs_doc);
+    expect(result.bug_doc).toStrictEqual(bugs_doc);
     expect(result.name).toEqual("fir");
     expect(result.age).toEqual(200);
     expect(result.birthdate).toBeInstanceOf(Date);
@@ -70,6 +76,7 @@ describe("tagged format", () => {
     expect(result.measurements[1].time).toBeInstanceOf(Date);
     expect(result.molecules).toEqual(BigInt("999999999999999999"));
     expect(result.null).toBeNull();
+    expect(result.set).toStrictEqual(set);
   });
 
   it("can be encoded", () => {

--- a/__tests__/functional/tagged-format.test.ts
+++ b/__tests__/functional/tagged-format.test.ts
@@ -19,8 +19,8 @@ describe("tagged format", () => {
     const allTypes: string = `{
       "bugs_coll": { "@mod": "Bugs" },
       "bug_ref_string": { "@doc": "Bugs:123" },
-      "bug_ref_object": { "@ref": { "coll": "Bugs", "id": "123" } },
-      "bug_doc": { "@doc": { "coll": "Bugs", "id": "123" } },
+      "bug_ref_object": { "@ref": { "coll": { "@mod": "Bugs" }, "id": "123" } },
+      "bug_doc": { "@doc": { "coll": { "@mod": "Bugs" }, "id": "123" } },
       "name": "fir",
       "age": { "@int": "200" },
       "birthdate": { "@date": "1823-02-08" },

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -1,7 +1,10 @@
 /** A reference to a built in Fauna module; e.g. Date */
 export type Module = string;
 /** A reference to a document in Fauna */
-export type DocumentReference = string;
+export type DocumentReference = {
+  coll: Module;
+  id: string;
+};
 
 /**
  * TaggedType provides the encoding/decoding of the Fauna Tagged Type formatting
@@ -29,7 +32,16 @@ export class TaggedTypeFormat {
       if (value["@mod"]) {
         return value["@mod"] as Module;
       } else if (value["@doc"]) {
-        return value["@doc"] as DocumentReference;
+        if (typeof value["@doc"] === "string") {
+          const [modName, id] = value["@doc"].split(":");
+          return { coll: modName, id: id } as DocumentReference;
+        }
+        // if not a docref string, then it is an object.
+        return value["@doc"];
+      } else if (value["@ref"]) {
+        return value["@ref"] as DocumentReference;
+      } else if (value["@set"]) {
+        return value["@set"];
       } else if (value["@int"]) {
         return Number(value["@int"]);
       } else if (value["@long"]) {


### PR DESCRIPTION
Ticket(s): [FE-3124](https://faunadb.atlassian.net/browse/FE-3124)

## Problem
Core will be shipping wire protocol changes and we need to handle these as follows:

Drivers continue to encode per the current protocol. On decode:
- If @doc tag and it’s an object, strip the tag
- If @doc tag and it’s a string, build a doc reference from it
- If @set tag, strip it
- if @ref tag, build a doc reference

## Solution
The minimal change to decode @doc, @ref and @set to plain js object. We can decode into more complex classes but can do that after the actual protocol changes land.

## Out of scope
Once the change is deployed, drivers can update to encode to the new protocol and use @set to build iterators

## Testing
Added tests for @ref and @set. Updated tests for @doc and added the case where @doc is an object.

[FE-3124]: https://faunadb.atlassian.net/browse/FE-3124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ