### PR TITLE
FE-3150 Add constraint_failures to wire protocol.

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -9,6 +9,7 @@ import {
   QueryCheckError,
   QueryRuntimeError,
   QueryTimeoutError,
+  ServiceError,
 } from "../../src/errors";
 import { HTTPClient, getDefaultHTTPClient } from "../../src/http-client";
 import { fql } from "../../src/query-builder";
@@ -178,16 +179,16 @@ describe.each`
   });
 
   it("Includes constraint failures when present", async () => {
-    expect.assertions(3);
+    expect.assertions(6);
     try {
       await doQuery<number>(
         queryType,
-        getTsa`Function.create({"name": "double", "body": "x => x * 2"`,
-        'Function.create({"name": "double", "body": "x => x * 2"',
+        getTsa`Function.create({"name": "double", "body": "x => x * 2"})`,
+        'Function.create({"name": "double", "body": "x => x * 2"})',
         client
       );
     } catch (e) {
-      if (e instanceof QueryRuntimeError) {
+      if (e instanceof ServiceError) {
         expect(e.httpStatus).toEqual(400);
         expect(e.code).toEqual("constraint_failure");
         expect(e.summary).toBeDefined();

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import { QueryFailure } from "./wire-protocol";
+import type { ConstraintFailure, QueryFailure } from "./wire-protocol";
 
 /**
  * An error representing a query failure returned by Fauna.
@@ -19,6 +19,11 @@ export class ServiceError extends Error {
    * where message does not suffice.
    */
   readonly summary?: string;
+  /**
+   * A machine readable description of any constraint failures encountered by the query.
+   * Present only if this query encountered constraint failures.
+   */
+  readonly constraint_failures?: Array<ConstraintFailure>;
 
   constructor(failure: QueryFailure, httpStatus: number) {
     super(failure.error.message);
@@ -33,6 +38,9 @@ export class ServiceError extends Error {
     this.httpStatus = httpStatus;
     if (failure.summary) {
       this.summary = failure.summary;
+    }
+    if (failure.error.constraint_failures !== undefined) {
+      this.constraint_failures = failure.error.constraint_failures;
     }
   }
 }

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -105,8 +105,20 @@ export type QueryFailure = QueryInfo & {
   error: {
     /** A predefined code which indicates the type of error. See XXX for a list of error codes. */
     code: string;
-    /** description: A short, human readable description of the error */
+    /** A short, human readable description of the error */
     message: string;
+    /**
+     * A machine readable description of any constraint failures encountered by the query.
+     * Present only if this query encountered constraint failures.
+     */
+    constraint_failures?: Array<{
+      /** Description of the constraint failure */
+      message: string;
+      /** Name of the failed constraint */
+      name: string;
+      /** Path into the write input data to which the failure applies */
+      path: number | string;
+    }>;
   };
 };
 

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -111,15 +111,20 @@ export type QueryFailure = QueryInfo & {
      * A machine readable description of any constraint failures encountered by the query.
      * Present only if this query encountered constraint failures.
      */
-    constraint_failures?: Array<{
-      /** Description of the constraint failure */
-      message: string;
-      /** Name of the failed constraint */
-      name: string;
-      /** Path into the write input data to which the failure applies */
-      path: number | string;
-    }>;
+    constraint_failures?: Array<ConstraintFailure>;
   };
+};
+
+/**
+ * A constraint failure triggered by a query.
+ */
+export type ConstraintFailure = {
+  /** Description of the constraint failure */
+  message: string;
+  /** Name of the failed constraint */
+  name?: string;
+  /** Path into the write input data to which the failure applies */
+  paths?: Array<number | string>;
 };
 
 export type QueryResponse<T> = QuerySuccess<T> | QueryFailure;


### PR DESCRIPTION
Ticket(s): FE-3150

## Problem
- While fixing dashboard bugs noticed we are not including `constraint_failures` in our wire protocol.
- Same is true across all drivers
  - https://github.com/fauna/fauna-go/blob/fqlx-beta/error.go
  - https://github.com/fauna/fauna-python/blob/main/fauna/errors.py

## Solution
- Include optional constraint_failures array on `QueryFailure` wire model

## Result
- clients, such as the dashboard, can detect constraint_failures

## Testing
Verifying tests still pass.