### PR TITLE
Add typecheck configuration option

### DIFF
--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -91,6 +91,7 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
     ${"max_contention_retries"} | ${3}                                                         | ${{ key: "x-max-contention-retries", value: "3" }}
     ${"query_tags"}             | ${{ t1: "v1", t2: "v2" }}                                    | ${{ key: "x-query-tags", value: "t1=v1,t2=v2" }}
     ${"traceparent"}            | ${"00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00"} | ${{ key: "traceparent", value: "00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00" }}
+    ${"typecheck"}              | ${false}                                                     | ${{ key: "x-typecheck", value: "false" }}
   `(
     "Setting clientConfiguration $fieldName leads to it being sent in headers",
     async ({ fieldName, fieldValue, expectedHeader }: HeaderTestInput) => {

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -36,6 +36,25 @@ async function doQuery<T>(
   return client.query(fql(queryTsa));
 }
 
+const dummyResponse = {
+  body: JSON.stringify({
+    data: "",
+    txn_ts: 0,
+    query_tags: {},
+    stats: {
+      compute_ops: 0,
+      read_ops: 0,
+      write_ops: 0,
+      query_time_ms: 0,
+      storage_bytes_read: 0,
+      storage_bytes_written: 0,
+      contention_retries: 0,
+    },
+  }),
+  headers: {},
+  status: 200,
+};
+
 describe.each`
   queryType
   ${"QueryRequest"}
@@ -111,8 +130,7 @@ describe.each`
               expectedHeader.value
             );
           });
-
-          return getDefaultHTTPClient().request(req);
+          return dummyResponse;
         },
       };
       const clientConfiguration: Partial<ClientConfiguration> = {

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -87,6 +87,7 @@ describe.each`
     ${"max_contention_retries"} | ${3}                                                         | ${{ key: "x-max-contention-retries", value: "3" }}
     ${"query_tags"}             | ${{ t1: "v1", t2: "v2" }}                                    | ${{ key: "x-query-tags", value: "t1=v1,t2=v2" }}
     ${"traceparent"}            | ${"00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00"} | ${{ key: "traceparent", value: "00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00" }}
+    ${"typecheck"}              | ${false}                                                     | ${{ key: "x-typecheck", value: "false" }}
   `(
     "respects QueryRequest field $fieldName over ClientConfiguration $fieldName",
     async ({ fieldName, fieldValue, expectedHeader }: HeaderTestInput) => {
@@ -100,6 +101,7 @@ describe.each`
           value: "00-750efa5fb6a131eb2cf4db39f28366cb-000000000000000b-00",
         },
         query_timeout_ms: { key: "x-query-timeout-ms", value: "60" },
+        typecheck: { key: "x-typecheck", value: "true" },
       };
       expectedHeaders[fieldName] = expectedHeader;
       const httpClient: HTTPClient = {
@@ -121,6 +123,7 @@ describe.each`
         max_contention_retries: 7,
         query_tags: { alpha: "beta", gamma: "delta" },
         traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-000000000000000b-00",
+        typecheck: true,
       };
       const myClient = getClient(clientConfiguration, httpClient);
       const headers = { [fieldName]: fieldValue };

--- a/__tests__/unit/query-builder.test.ts
+++ b/__tests__/unit/query-builder.test.ts
@@ -146,6 +146,7 @@ describe("fql method producing QueryBuilders", () => {
       max_contention_retries: 4,
       query_tags: { a: "tag" },
       traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00",
+      typecheck: false,
     });
     expect(queryRequest).toMatchObject({
       linearized: true,
@@ -153,6 +154,7 @@ describe("fql method producing QueryBuilders", () => {
       max_contention_retries: 4,
       query_tags: { a: "tag" },
       traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00",
+      typecheck: false,
     });
     expect(queryRequest.query).toEqual({
       fql: [

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -64,7 +64,8 @@ export interface ClientConfiguration {
   traceparent?: string;
   /**
    * Enable or disable typechecking of the query before evaluation. If no value
-   * is provided, the database defaults using typechecking.
+   * is provided, the value of `typechecked` in the database configuration will
+   * be used.
    */
   typecheck?: boolean;
 }

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -62,6 +62,11 @@ export interface ClientConfiguration {
    * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
    */
   traceparent?: string;
+  /**
+   * Enable or disable typechecking of the query before evaluation. If no value
+   * is provided, the database defaults using typechecking.
+   */
+  typecheck?: boolean;
 }
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -230,8 +230,6 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
     try {
       const headers = {
         Authorization: `Bearer ${this.#clientConfiguration.secret}`,
-        // WIP - typecheck should be user configurable, but hard code for now
-        "x-typecheck": "false",
       };
       this.#setHeaders(
         { ...this.clientConfiguration, ...queryRequest },

--- a/src/client.ts
+++ b/src/client.ts
@@ -302,6 +302,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
           "linearized",
           "max_contention_retries",
           "traceparent",
+          "typecheck",
           "query_tags",
         ].includes(entry[0])
       ) {

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -48,6 +48,11 @@ export interface QueryRequestHeaders {
    * Overrides the optional setting for the client.
    */
   traceparent?: string;
+  /**
+   * Enable or disable typechecking of the query before evaluation. If no value
+   * is provided, the database defaults using typechecking.
+   */
+  typecheck?: boolean;
 }
 
 /** tagged declares that type information is transmitted and received by the driver. "simple" indicates it is not. */

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -50,7 +50,8 @@ export interface QueryRequestHeaders {
   traceparent?: string;
   /**
    * Enable or disable typechecking of the query before evaluation. If no value
-   * is provided, the database defaults using typechecking.
+   * is provided, the value of `typechecked` in the database configuration will
+   * be used.
    */
   typecheck?: boolean;
 }


### PR DESCRIPTION
Ticket(s): [FE-3181](https://faunadb.atlassian.net/browse/FE-3181)

## Problem
We need to expose an option to enable or disable typechecking at the Client and the Query. The default should be that x-typecheck is unset.

## Solution
- Add an optional `typecheck` field to `ClientConfiguration`
- Add an optional `typecheck` field to `QueryRequestHeaders`

## Testing
Extended tests to ensure 
- the client configuration sets a header; and 
- query options sets a header and overrides the client configuration

[FE-3181]: https://faunadb.atlassian.net/browse/FE-3181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ