### PR TITLE
Fix QueryStats and QueryInfo types and tests

### DIFF
--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -83,7 +83,7 @@ if (Collection.byName('Customers') == null) {\
     });
     expect(resultOne.txn_ts).not.toBeUndefined();
     expectedLastTxn = resultOne.txn_ts;
-    myClient.lastTxnTs = resultOne.txn_ts;
+    myClient.lastTxnTs = resultOne.txn_ts as number;
     const resultTwo = await myClient.query(
       fql`
       if (Collection.byName('Orders') == null) {\

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -71,13 +71,13 @@ describe.each`
     expect(result.summary).toBeDefined();
     expect(result.txn_ts).toBeDefined();
     expect(result.stats).toBeDefined();
-    expect(result.stats.compute_ops).toBeDefined();
-    expect(result.stats.contention_retries).toBeDefined();
-    expect(result.stats.query_time_ms).toBeDefined();
-    expect(result.stats.read_ops).toBeDefined();
-    expect(result.stats.storage_bytes_read).toBeDefined();
-    expect(result.stats.storage_bytes_write).toBeDefined();
-    expect(result.stats.write_ops).toBeDefined();
+    expect(result.stats?.compute_ops).toBeDefined();
+    expect(result.stats?.contention_retries).toBeDefined();
+    expect(result.stats?.query_time_ms).toBeDefined();
+    expect(result.stats?.read_ops).toBeDefined();
+    expect(result.stats?.storage_bytes_read).toBeDefined();
+    expect(result.stats?.storage_bytes_write).toBeDefined();
+    expect(result.stats?.write_ops).toBeDefined();
   });
 
   it("Can query with arguments", async () => {

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -11,7 +11,7 @@ import {
   QueryTimeoutError,
   ServiceError,
 } from "../../src/errors";
-import { HTTPClient, getDefaultHTTPClient } from "../../src/http-client";
+import { HTTPClient, HTTPResponse } from "../../src/http-client";
 import { fql } from "../../src/query-builder";
 import { type QueryRequest, QuerySuccess } from "../../src/wire-protocol";
 
@@ -36,18 +36,17 @@ async function doQuery<T>(
   return client.query(fql(queryTsa));
 }
 
-const dummyResponse = {
+const dummyResponse: HTTPResponse = {
   body: JSON.stringify({
     data: "",
     txn_ts: 0,
-    query_tags: {},
     stats: {
       compute_ops: 0,
       read_ops: 0,
       write_ops: 0,
       query_time_ms: 0,
       storage_bytes_read: 0,
-      storage_bytes_written: 0,
+      storage_bytes_write: 0,
       contention_retries: 0,
     },
   }),
@@ -69,7 +68,16 @@ describe.each`
     );
 
     expect(result.data).toEqual(4);
+    expect(result.summary).toBeDefined();
     expect(result.txn_ts).toBeDefined();
+    expect(result.stats).toBeDefined();
+    expect(result.stats.compute_ops).toBeDefined();
+    expect(result.stats.contention_retries).toBeDefined();
+    expect(result.stats.query_time_ms).toBeDefined();
+    expect(result.stats.read_ops).toBeDefined();
+    expect(result.stats.storage_bytes_read).toBeDefined();
+    expect(result.stats.storage_bytes_write).toBeDefined();
+    expect(result.stats.write_ops).toBeDefined();
   });
 
   it("Can query with arguments", async () => {
@@ -85,6 +93,21 @@ describe.each`
     }
     expect(result.data).toEqual(4);
     expect(result.txn_ts).toBeDefined();
+  });
+
+  it("Can query with tags", async () => {
+    let result: QuerySuccess<string>;
+    let query_tags = {
+      project: "teapot",
+      hello: "world",
+      testing: "foobar",
+    };
+    if (queryType === "QueryRequest") {
+      result = await client.query({ query: `"foo"` }, { query_tags });
+    } else {
+      result = await client.query(fql`"foo"`, { query_tags });
+    }
+    expect(result.query_tags).toStrictEqual(query_tags);
   });
 
   type HeaderTestInput = {

--- a/__tests__/unit/fetch-client.test.ts
+++ b/__tests__/unit/fetch-client.test.ts
@@ -1,17 +1,14 @@
 import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
 enableFetchMocks();
 
-import {NetworkError} from '../../src/errors'
+import { NetworkError } from "../../src/errors";
 import {
   FetchClient,
   HTTPRequest,
   HTTPResponse,
   isHTTPResponse,
 } from "../../src/http-client";
-import {
-  QueryFailure,
-  QuerySuccess,
-} from "../../src/wire-protocol";
+import { QueryFailure, QuerySuccess } from "../../src/wire-protocol";
 
 let fetchClient: FetchClient;
 
@@ -28,7 +25,7 @@ const dummyStats = {
   write_ops: 0,
   query_time_ms: 0,
   storage_bytes_read: 0,
-  storage_bytes_written: 0,
+  storage_bytes_write: 0,
   contention_retries: 0,
 };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -24,7 +24,6 @@ import {
 } from "./wire-protocol";
 import {
   getDefaultHTTPClient,
-  HTTPResponse,
   isHTTPResponse,
   type HTTPClient,
 } from "./http-client";
@@ -255,7 +254,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
         data: requestData,
       });
 
-      let parsedResponse: HTTPResponse;
+      let parsedResponse;
       try {
         parsedResponse = {
           ...fetchResponse,
@@ -263,6 +262,12 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
             ? TaggedTypeFormat.decode(fetchResponse.body)
             : JSON.parse(fetchResponse.body),
         };
+        if (parsedResponse.body.query_tags) {
+          const tags_array = (parsedResponse.body.query_tags as string)
+            .split(",")
+            .map((tag) => tag.split("="));
+          parsedResponse.body.query_tags = Object.fromEntries(tags_array);
+        }
       } catch (error: unknown) {
         throw new ProtocolError({
           message: `Error parsing response as JSON: ${error}`,

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -78,13 +78,13 @@ export type QueryStats = {
 
 export type QueryInfo = {
   /** The last transaction timestamp of the query. A Unix epoch in microseconds. */
-  txn_ts: number;
+  txn_ts?: number;
   /** A readable summary of any warnings or logs emitted by the query. */
-  summary: string;
+  summary?: string;
   /** The value of the x-query-tags header, if it was provided. */
   query_tags?: Record<string, string>;
   /** Stats on query performance and cost */
-  stats: QueryStats;
+  stats?: QueryStats;
 };
 
 export type QuerySuccess<T> = QueryInfo & {

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -71,7 +71,7 @@ export type QueryStats = {
   /** The amount of data read from storage, in bytes. */
   storage_bytes_read: number;
   /** The amount of data written to storage, in bytes. */
-  storage_bytes_written: number;
+  storage_bytes_write: number;
   /** The number of times the transaction was retried due to write contention. */
   contention_retries: number;
 };
@@ -80,9 +80,9 @@ export type QueryInfo = {
   /** The last transaction timestamp of the query. A Unix epoch in microseconds. */
   txn_ts: number;
   /** A readable summary of any warnings or logs emitted by the query. */
-  summary?: string;
+  summary: string;
   /** The value of the x-query-tags header, if it was provided. */
-  query_tags: Record<string, string>;
+  query_tags?: Record<string, string>;
   /** Stats on query performance and cost */
   stats: QueryStats;
 };


### PR DESCRIPTION
Ticket(s): [FE-3109](https://faunadb.atlassian.net/browse/FE-3109)

## Problem
In `QueryStats`, `storage_bytes_written` should be `storage_bytes_write`

The fields for `QueryInfo` are incorrectly specified as required/optional.

`QueryInfo.query_tags` is not decoded correctly. It comes back exactly how the header is sent, e.g. 

```
"project=teapot,hello=world,testing=foobar"
```

## Solution
Align types with the core spec.

Add decoding of `query_tags` if received.

## Testing
Added new test for `query_tags`.

[FE-3109]: https://faunadb.atlassian.net/browse/FE-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ