### PR TITLE
Support decorated format. Fix linting errors

### DIFF
--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,4 +1,3 @@
-import type { Client } from "../client";
 import { QueryRequest } from "../wire-protocol";
 import { FetchClient } from "./fetch-client";
 export { FetchClient } from "./fetch-client";

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,3 +1,6 @@
+/* eslint-disable */
+import type { Client } from "../client";
+/* eslint-enable */
 import { QueryRequest } from "../wire-protocol";
 import { FetchClient } from "./fetch-client";
 export { FetchClient } from "./fetch-client";

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { Client } from "../client";
-/* eslint-enable */
 import { QueryRequest } from "../wire-protocol";
 import { FetchClient } from "./fetch-client";
 export { FetchClient } from "./fetch-client";

--- a/src/values/date-time.ts
+++ b/src/values/date-time.ts
@@ -1,5 +1,6 @@
 import { ClientError } from "../errors";
 import * as PARSE from "../regex";
+
 /**
  * An wrapper around the Fauna `Time` type. It, represents a fixed point in time
  * without regard to calendar or location, e.g. July 20, 1969, at 20:17 UTC.

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -1,6 +1,5 @@
-/* eslint-disable */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { fql } from "./query-builder";
-/* eslint-enable */
 
 /**
  * A request to make to Fauna.

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -1,5 +1,3 @@
-import { fql } from "./query-builder";
-
 /**
  * A request to make to Fauna.
  */
@@ -56,8 +54,19 @@ export interface QueryRequestHeaders {
   typecheck?: boolean;
 }
 
-/** tagged declares that type information is transmitted and received by the driver. "simple" indicates it is not. */
-export declare type ValueFormat = "simple" | "tagged";
+/**
+ * tagged declares that type information is transmitted and received by the driver.
+ * "simple" indicates it is not - pure JSON is used.
+ * "decorated" will cause the service output to be shown in FQL syntax that could
+ * hypothetically be used to query Fauna. This is intended to support CLI and
+ * REPL like tools.
+ * @example
+ * ```typescript
+ * // example of decorated output
+ * { time: Time("2012-01-01T00:00:00Z") }
+ * ```
+ */
+export declare type ValueFormat = "simple" | "tagged" | "decorated";
 
 export type QueryStats = {
   /** The amount of Transactional Compute Ops consumed by the query. */

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -1,3 +1,7 @@
+/* eslint-disable */
+import { fql } from "./query-builder";
+/* eslint-enable */
+
 /**
  * A request to make to Fauna.
  */


### PR DESCRIPTION
Ticket(s): FE-3212

## Problem
- decorated wire format supports REPLs and CLIs
- we are building a REPL in the dashboard
## Solution
- include the decorated format
## Result
- dashboard can show decorated output on its REPL

