### PR TITLE
Test domain types and fix encoding

### DIFF
--- a/__tests__/integration/doc.test.ts
+++ b/__tests__/integration/doc.test.ts
@@ -1,0 +1,128 @@
+import { getClient } from "../client";
+import { fql } from "../../src/query-builder";
+import {
+  Document,
+  DocumentT,
+  DocumentReference,
+  Module,
+  NamedDocument,
+  NamedDocumentReference,
+  TimeStub,
+} from "../../src/values";
+
+const client = getClient({
+  max_conns: 5,
+  query_timeout_ms: 60_000,
+});
+
+let testDoc: Document;
+
+describe("querying for doc types", () => {
+  beforeAll(async () => {
+    await client.query(fql`
+      [
+        if (Collection.byName("DocTest") == null) {
+          Collection.create({ name: "DocTest" })
+        },
+        if (Collection.byName("DocTest2") == null) {
+          Collection.create({ name: "DocTest2" })
+        }
+      ]
+    `);
+
+    const result = await client.query<Document>(fql`DocTest.create({})`);
+    testDoc = result.data;
+  });
+
+  it("can round-trip Module", async () => {
+    const mod = new Module("DocTest");
+
+    const queryBuilder = fql`${mod}`;
+    const result = await client.query<Module>(queryBuilder);
+
+    expect(result.data).toBeInstanceOf(Module);
+    expect(result.data.name).toBe("DocTest");
+  });
+
+  it("can round-trip DocumentReference", async () => {
+    const mod = new Module("DocTest");
+    const ref = new DocumentReference({ id: "101", coll: mod });
+
+    const queryBuilder = fql`${ref}`;
+    const result = await client.query<DocumentReference>(queryBuilder);
+
+    expect(result.data).toBeInstanceOf(DocumentReference);
+    expect(result.data.id).toBe("101");
+    expect(result.data.coll.name).toBe("DocTest");
+  });
+
+  it("can round-trip Document", async () => {
+    const queryBuilder = fql`${testDoc}`;
+    const result = await client.query<Document>(queryBuilder);
+
+    expect(result.data).toBeInstanceOf(Document);
+    expect(result.data.id).toBe(testDoc.id);
+    expect(result.data.coll.name).toBe(testDoc.coll.name);
+    expect(result.data.ts.isoString).toBe(testDoc.ts.isoString);
+  });
+
+  it("can round-trip NamedDocumentReference", async () => {
+    const mod = new Module("Collection");
+    const ref = new NamedDocumentReference({ name: "DocTest", coll: mod });
+
+    const queryBuilder = fql`${ref}`;
+    const result = await client.query<NamedDocumentReference>(queryBuilder);
+
+    expect(result.data).toBeInstanceOf(NamedDocumentReference);
+    expect(result.data.name).toBe("DocTest");
+    expect(result.data.coll.name).toBe("Collection");
+  });
+
+  it("can round-trip NamedDocument", async () => {
+    const mod = new Module("Collection");
+    const doc = new NamedDocument({
+      name: "DocTest",
+      coll: mod,
+      ts: TimeStub.from("2023-10-16T00:00:00Z"),
+    });
+
+    const queryBuilder = fql`${doc}`;
+    const result = await client.query<NamedDocument>(queryBuilder);
+
+    expect(result.data).toBeInstanceOf(NamedDocument);
+    expect(result.data.name).toBe("DocTest");
+    expect(result.data.coll.name).toBe("Collection");
+    expect(result.data.ts).toBeDefined();
+  });
+
+  it("get doc types from FQL", async () => {
+    type MyResult = {
+      module: Module;
+      document: DocumentT<{
+        documentReference: DocumentReference;
+        namedDocumentReference: NamedDocumentReference;
+      }>;
+      namedDocument: NamedDocument;
+    };
+
+    const queryBuilder = fql`{
+      module: DocTest,
+      document: DocTest.create({
+        documentReference: DocTest.create({}),
+        namedDocumentReference: DocTest2.definition,
+      }),
+      namedDocument: DocTest.definition
+    }`;
+    const result = await client.query<MyResult>(queryBuilder);
+
+    expect(result.data.module).toBeInstanceOf(Module);
+    expect(result.data.document).toBeInstanceOf(Document);
+    expect(result.data.document.documentReference).toBeInstanceOf(
+      DocumentReference
+    );
+    expect(result.data.document.namedDocumentReference).toBeInstanceOf(
+      NamedDocumentReference
+    );
+    expect(result.data.namedDocument).toBeInstanceOf(NamedDocument);
+  });
+});

--- a/__tests__/integration/set.test.ts
+++ b/__tests__/integration/set.test.ts
@@ -1,0 +1,39 @@
+import { getClient } from "../client";
+import { fql } from "../../src/query-builder";
+import { Set } from "../../src/values";
+
+const client = getClient({
+  max_conns: 5,
+  query_timeout_ms: 60_000,
+});
+
+let testDoc: Document;
+
+describe("querying for set", () => {
+  beforeAll(async () => {
+    await client.query(fql`
+      if (Collection.byName("DocTest") == null) {
+        Collection.create({ name: "DocTest" })
+      }
+    `);
+
+    const result = await client.query<Document>(fql`DocTest.create({})`);
+    testDoc = result.data;
+  });
+
+  it("can round-trip Set", async () => {
+    const set = new Set<number>({ data: [1, 2, 3], after: "1234" });
+
+    const queryBuilder = fql`${set}`;
+    // WIP: core does not accept `@set` tagged values
+    // const result = await client.query<Set<number>>(queryBuilder);
+    const result = await client.query<{ data: number[]; after: string }>(
+      queryBuilder
+    );
+
+    // WIP: core does not accept `@set` tagged values
+    // expect(result.data).toBeInstanceOf(Set);
+    expect(result.data.data).toStrictEqual([1, 2, 3]);
+    expect(result.data.after).toBe("1234");
+  });
+});

--- a/__tests__/unit/set.test.ts
+++ b/__tests__/unit/set.test.ts
@@ -1,0 +1,9 @@
+import { Set } from "../../src/values";
+
+describe("Set", () => {
+  it("can be constructed directly", () => {
+    const set = new Set<number>({ data: [1, 2, 3], after: "1234" });
+    expect(set.data).toStrictEqual([1, 2, 3]);
+    expect(set.after).toBe("1234");
+  });
+});

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -31,7 +31,7 @@ export const isQueryBuilder = (obj: any): obj is QueryBuilder =>
  * ```
  */
 export function fql(
-  queryFragments: TemplateStringsArray,
+  queryFragments: ReadonlyArray<string>,
   ...queryArgs: (JSONValue | QueryBuilder)[]
 ): QueryBuilder {
   return new TemplateQueryBuilder(queryFragments, ...queryArgs);
@@ -43,11 +43,11 @@ export function fql(
  * function
  */
 class TemplateQueryBuilder implements QueryBuilder {
-  readonly #queryFragments: TemplateStringsArray;
+  readonly #queryFragments: ReadonlyArray<string>;
   readonly #queryArgs: (JSONValue | QueryBuilder)[];
 
   constructor(
-    queryFragments: TemplateStringsArray,
+    queryFragments: ReadonlyArray<string>,
     ...queryArgs: (JSONValue | QueryBuilder)[]
   ) {
     if (

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -88,7 +88,8 @@ type TaggedLong = { "@long": string };
 type TaggedMod = { "@mod": string };
 type TaggedObject = { "@object": JSONObject };
 type TaggedRef = { "@ref": TaggedRefBase };
-type TaggedSet = { "@set": { data: JSONValue[]; after?: string } };
+// WIP: core does not accept `@set` tagged values
+// type TaggedSet = { "@set": { data: JSONValue[]; after?: string } };
 type TaggedTime = { "@time": string };
 
 export const LONG_MIN = BigInt("-9223372036854775808");
@@ -165,8 +166,11 @@ const encodeMap = {
   namedDocument: (value: NamedDocument): TaggedDoc => ({
     "@doc": { name: value.name, coll: { "@mod": value.coll.name } },
   }),
-  set: (value: Set<any>): TaggedSet => ({
-    "@set": { data: encodeMap["array"](value.data), after: value.after },
+  set: (value: Set<any>) => ({
+    // WIP: core does not accept `@set` tagged values, yet, so just unwrap
+    // "@set": { data: encodeMap["array"](value.data), after: value.after },
+    data: encodeMap["array"](value.data),
+    after: value.after,
   }),
 };
 

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -1,5 +1,15 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { fql } from "./query-builder";
+import {
+  DateStub,
+  Document,
+  DocumentReference,
+  Module,
+  NamedDocument,
+  NamedDocumentReference,
+  Set,
+  TimeStub,
+} from "./values";
 
 /**
  * A request to make to Fauna.
@@ -237,10 +247,20 @@ export type JSONObject = {
  * All values returned from Fauna are valid JSON values.
  */
 export type JSONValue =
+  // plain javascript values
   | null
   | string
   | number
   | bigint
   | boolean
   | JSONObject
-  | Array<JSONValue>;
+  | Array<JSONValue>
+  // fauna-provided classes
+  | DateStub
+  | TimeStub
+  | Module
+  | Document
+  | DocumentReference
+  | NamedDocument
+  | NamedDocumentReference
+  | Set<JSONValue>;


### PR DESCRIPTION
Ticket(s): [FE-3214](https://faunadb.atlassian.net/browse/FE-3214)

## Problem
Did not have tests for domain types and were finding bugs.

- Query input and output are restricted to the `JSONValue` type, but the new classes are not included in it.
- Document and NamedDocument are incorrectly encoded as DocumentReference and NamedDocumentReference.
- Core cannot (yet?) receive values tagged as `@set`

## Solution

- Add new domain classes to `JSONValue`.
- Fix encoding for documents.
- Encode Set by unwrapping it

## Testing
Added tests for all of the new classes.