### PR TITLE
Update health check on integration tests in pipeline to use curl.

### DIFF
--- a/concourse/scripts/docker-compose-fauna.yml
+++ b/concourse/scripts/docker-compose-fauna.yml
@@ -6,11 +6,6 @@ services:
     container_name: faunadb
     ports:
       - "8443:8443"
-    healthcheck:
-      test: ["CMD", "curl", "http://faunadb:8443/ping"]
-      interval: 1s
-      timeout: 3s
-      retries: 30
 
   node-lts:
     image: node:18.15-alpine3.16
@@ -23,8 +18,13 @@ services:
     environment:
       FAUNA_ENDPOINT: http://faunadb:8443
       FAUNA_SECRET: secret
-    entrypoint: /usr/local/bin/yarn
-    command: test:integration
+    command:
+      - /bin/sh
+      - -cxe
+      - |
+        apk add --no-cache curl
+        ./wait-for-it.sh http://faunadb:8443/ping
+        yarn test:integration
 
   node-current:
     image: node:19.8-alpine3.16
@@ -37,5 +37,10 @@ services:
     environment:
       FAUNA_ENDPOINT: http://faunadb:8443
       FAUNA_SECRET: secret
-    entrypoint: /usr/local/bin/yarn
-    command: test:integration
+    command:
+      - /bin/sh
+      - -cxe
+      - |
+        apk add --no-cache curl
+        ./wait-for-it.sh http://faunadb:8443/ping
+        yarn test:integration

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,14 @@
+attempt_counter=0
+max_attempts=100
+
+until $(curl -m 1 --output /dev/null --silent --head --fail $1); do
+  if [ ${attempt_counter} -eq ${max_attempts} ];then
+    echo ""
+    echo "Max attempts reached to $1"
+    exit 1
+  fi
+
+  printf '.'
+  attempt_counter=$(($attempt_counter+1))
+  sleep 5
+done


### PR DESCRIPTION

## Problem
- integ tests are failing regularly in pipeline. Suspect this is because we are querying before the Fauna container is started.
## Solution
- move to a more brute force health check that curls fauna.

## Result
- stabler integ tests 🤞 

## Testing
Ran on docker locally:


```
~/workplace/fauna-js (main_changeFaunaHealthCheck*) » docker-compose -f concourse/scripts/docker-compose-fauna.yml run node-lts                                        1 ↵ cleve@Cleves-MBP
+ ./wait-for-it.sh http://faunadb:8443/ping
...+ yarn test:integration
 yarn run v1.22.19
 $ yarn install; jest --run-in-band ./__tests__/integration
 [1/4] Resolving packages...
 success Already up-to-date.
 $ husky install
husky - git command not found, skipping install
 PASS  __tests__/integration/query.test.ts (8.776 s)
 PASS  __tests__/integration/doc.test.ts
 PASS  __tests__/integration/template-format.test.ts
 PASS  __tests__/integration/client-last-txn-tracking.test.ts
 PASS  __tests__/integration/existing-collection.test.ts
  ● Console

    console.log
      No existing Authors collection found, creating collection and schema.

      at Object.<anonymous> (__tests__/integration/existing-collection.test.ts:49:13)

    console.log
      {
        data: NamedDocument {
          coll: Module { name: 'Collection' },
          name: 'Authors',
          ts: TimeStub { isoString: '2023-03-23T18:33:28.490Z' },
          data: {},
          indexes: { byName: [Object], byGenre: [Object] },
          constraints: [ [Object] ]
        },
        summary: '',
        txn_ts: 1679596408490000,
        stats: {
          compute_ops: 1,
          read_ops: 1,
          write_ops: 3,
          query_time_ms: 293,
          contention_retries: 0,
          storage_bytes_read: 980,
          storage_bytes_write: 1677
        }
      }

      at Object.<anonymous> (__tests__/integration/existing-collection.test.ts:52:13)

 PASS  __tests__/integration/set.test.ts

Test Suites: 6 passed, 6 total
Tests:       62 passed, 62 total
Snapshots:   0 total
Time:        14.041 s
Ran all test suites matching /.\/__tests__\/integration/i.
 Done in 20.18s.
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
~/workplace/fauna-js (main_changeFaunaHealthCheck*) » docker-compose -f concourse/scripts/docker-compose-fauna.yml run node-current                                        cleve@Cleves-MBP
[+] Running 1/0
 ⠿ Container faunadb  Running                                                                                                                                                          0.0s
[+] Running 5/5
 ⠿ node-current Pulled                                                                                                                                                                 6.8s
   ⠿ ef5531b6e74e Already exists                                                                                                                                                       0.0s
   ⠿ 418ff5263da7 Pull complete                                                                                                                                                        4.9s
   ⠿ 5ef6d059c172 Pull complete                                                                                                                                                        5.1s
   ⠿ cfbe7a903d47 Pull complete                                                                                                                                                        5.1s
+ apk add --no-cache curl
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.16/community/x86_64/APKINDEX.tar.gz
(1/5) Installing ca-certificates (20220614-r0)
(2/5) Installing brotli-libs (1.0.9-r6)
(3/5) Installing nghttp2-libs (1.47.0-r0)
(4/5) Installing libcurl (7.83.1-r6)
(5/5) Installing curl (7.83.1-r6)
Executing busybox-1.35.0-r17.trigger
Executing ca-certificates-20220614-r0.trigger
OK: 10 MiB in 21 packages
+ ./wait-for-it.sh http://faunadb:8443/ping
+ yarn test:integration
 yarn run v1.22.19
 $ yarn install; jest --run-in-band ./__tests__/integration
 [1/4] Resolving packages...
 [2/4] Fetching packages...
 [3/4] Linking dependencies...#####################################################################################################################################################] 437/43
 [4/4] Building fresh packages...##################################################################################################################################################] 796/79
 $ husky install
husky - git command not found, skipping install
 PASS  __tests__/integration/query.test.ts (10.885 s)
 PASS  __tests__/integration/doc.test.ts
 PASS  __tests__/integration/template-format.test.ts
 PASS  __tests__/integration/client-last-txn-tracking.test.ts
 PASS  __tests__/integration/existing-collection.test.ts
 PASS  __tests__/integration/set.test.ts

Test Suites: 6 passed, 6 total
Tests:       62 passed, 62 total
Snapshots:   0 total
Time:        15.983 s
Ran all test suites matching /.\/__tests__\/integration/i.
 Done in 83.98s.
```
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
