### PR TITLE
Store all QueryInfo fields in ServiceError

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -199,7 +199,7 @@ describe.each`
         expect(e.httpStatus).toEqual(400);
         expect(e.message).toBeDefined();
         expect(e.code).toBeDefined();
-        expect(e.summary).toBeDefined();
+        expect(e.queryInfo?.summary).toBeDefined();
       }
     }
   });
@@ -217,7 +217,7 @@ describe.each`
       if (e instanceof QueryRuntimeError) {
         expect(e.httpStatus).toEqual(400);
         expect(e.code).toEqual("invalid_argument");
-        expect(e.summary).toBeDefined();
+        expect(e.queryInfo?.summary).toBeDefined();
       }
     }
   });
@@ -235,7 +235,7 @@ describe.each`
       if (e instanceof ServiceError) {
         expect(e.httpStatus).toEqual(400);
         expect(e.code).toEqual("constraint_failure");
-        expect(e.summary).toBeDefined();
+        expect(e.queryInfo?.summary).toBeDefined();
         if (e.constraint_failures !== undefined) {
           expect(e.constraint_failures.length).toEqual(1);
           for (let constraintFailure of e.constraint_failures) {
@@ -295,7 +295,7 @@ describe.each`
         expect(e.message).toBeDefined();
         expect(e.code).toEqual("unauthorized");
         expect(e.httpStatus).toEqual(401);
-        expect(e.summary).toBeUndefined();
+        expect(e.queryInfo?.summary).toBeUndefined();
       }
     }
   });

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -89,7 +89,7 @@ describe("query", () => {
           expect(e.message).toEqual(expectedErrorFields.message);
           expect(e.httpStatus).toEqual(httpStatus);
           expect(e.code).toEqual(expectedErrorFields.code);
-          expect(e.summary).toEqual(expectedErrorFields.summary);
+          expect(e.queryInfo?.summary).toEqual(expectedErrorFields.summary);
         }
       }
     }
@@ -125,7 +125,7 @@ describe("query", () => {
           expect(e.message).toEqual(expectedErrorFields.message);
           expect(e.httpStatus).toEqual(httpStatus);
           expect(e.code).toEqual(expectedErrorFields.code);
-          expect(e.summary).toEqual("the summary");
+          expect(e.queryInfo?.summary).toEqual("the summary");
         }
       }
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -48,18 +48,16 @@ export class ServiceError extends FaunaError {
     this.name = "ServiceError";
     this.code = failure.error.code;
     this.httpStatus = httpStatus;
-    if (failure.summary) {
-      const info: QueryInfo = {
-        txn_ts: failure.txn_ts,
-        summary: failure.summary,
-        query_tags: failure.query_tags,
-        stats: failure.stats,
-      };
-      this.queryInfo = info;
-    }
-    if (failure.error.constraint_failures !== undefined) {
-      this.constraint_failures = failure.error.constraint_failures;
-    }
+
+    const info: QueryInfo = {
+      txn_ts: failure.txn_ts,
+      summary: failure.summary,
+      query_tags: failure.query_tags,
+      stats: failure.stats,
+    };
+    this.queryInfo = info;
+
+    this.constraint_failures = failure.error.constraint_failures;
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,8 @@
-import type { ConstraintFailure, QueryFailure } from "./wire-protocol";
+import type {
+  ConstraintFailure,
+  QueryFailure,
+  QueryInfo,
+} from "./wire-protocol";
 
 /**
  * A common error base class for all other errors.
@@ -24,10 +28,9 @@ export class ServiceError extends FaunaError {
    */
   readonly code: string;
   /**
-   * A summary of the error in a human readable form. Only present
-   * where message does not suffice.
+   * Details about the query sent along with the response
    */
-  readonly summary?: string;
+  readonly queryInfo?: QueryInfo;
   /**
    * A machine readable description of any constraint failures encountered by the query.
    * Present only if this query encountered constraint failures.
@@ -46,7 +49,13 @@ export class ServiceError extends FaunaError {
     this.code = failure.error.code;
     this.httpStatus = httpStatus;
     if (failure.summary) {
-      this.summary = failure.summary;
+      const info: QueryInfo = {
+        txn_ts: failure.txn_ts,
+        summary: failure.summary,
+        query_tags: failure.query_tags,
+        stats: failure.stats,
+      };
+      this.queryInfo = info;
     }
     if (failure.error.constraint_failures !== undefined) {
       this.constraint_failures = failure.error.constraint_failures;


### PR DESCRIPTION
Ticket(s): [FE-3109](https://faunadb.atlassian.net/browse/FE-3109)

## Problem
Fauna will possible send any of the QueryInfo fields with a QueryFailure. The corresponding ServiceError class currently only stores the `summary` field.

## Solution
Replace the `ServiceError.summary` field with a QueryInfo object.

## Result
Added a new `ServiceError.queryInfo` field that is the QueryInfo object.

## Out of scope
N/A

## Testing
Updated tests to check for `error.queryInfo.summary` instead of `error.summary`.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3109]: https://faunadb.atlassian.net/browse/FE-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ