### PR TITLE
Endpoint as default and remove preview

### DIFF
--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -44,8 +44,7 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
   it("endpoints is extensible", async () => {
     endpoints["my-alternative-port"] = new URL("http://localhost:7443");
     expect(endpoints).toEqual({
-      cloud: new URL("https://db.fauna.com"),
-      preview: new URL("https://db.fauna-preview.com"),
+      default: new URL("https://db.fauna.com"),
       local: new URL("http://localhost:8443"),
       localhost: new URL("http://localhost:8443"),
       "my-alternative-port": new URL("http://localhost:7443"),

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -75,10 +75,8 @@ export interface ClientConfiguration {
  * @remarks Leverage the `[key: string]: URL;` field to extend to other endpoints.
  */
 export interface Endpoints {
-  /** Fauna's cloud endpoint. */
-  cloud: URL;
-  /** Fauna's preview endpoint for testing new features - requires beta access. */
-  preview: URL;
+  /** Fauna's default endpoint. */
+  default: URL;
   /**
    * An endpoint for interacting with local instance of Fauna (e.g. one running in a local docker container).
    */
@@ -105,8 +103,7 @@ export interface Endpoints {
  * ```
  */
 export const endpoints: Endpoints = {
-  cloud: new URL("https://db.fauna.com"),
-  preview: new URL("https://db.fauna-preview.com"),
+  default: new URL("https://db.fauna.com"),
   local: new URL("http://localhost:8443"),
   localhost: new URL("http://localhost:8443"),
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,7 +33,7 @@ const defaultClientConfiguration: Pick<
   ClientConfiguration,
   "endpoint" | "max_conns"
 > = {
-  endpoint: endpoints.cloud,
+  endpoint: endpoints.default,
   max_conns: 10,
 };
 


### PR DESCRIPTION

## Solution
* Update the default endpoint to be called default
* Remove preview endpoint

## Result

## Out of scope
* Update the demo package

## Testing
yarn test
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
