### PR TITLE
Client accepts only fql output as input

### DIFF
--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -2,6 +2,7 @@ import { getClient } from "../client";
 import { Client } from "../../src/client";
 import { endpoints } from "../../src/client-configuration";
 import { HTTPClient, getDefaultHTTPClient } from "../../src/http-client";
+import { fql } from "../../src/query-builder";
 
 // save a copy
 const PROCESS_ENV = { ...process.env };
@@ -55,7 +56,7 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
       secret: "secret",
       query_timeout_ms: 60_000,
     });
-    const result = await client.query<number>({ query: '"taco".length' });
+    const result = await client.query<number>(fql`"taco".length`);
     expect(result.data).toEqual(4);
     expect(result.txn_ts).toBeDefined();
   });
@@ -114,7 +115,7 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
         },
         httpClient
       );
-      await client.query<number>({ query: '"taco".length' });
+      await client.query<number>(fql`"taco".length`);
     }
   );
 });

--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -24,13 +24,11 @@ describe("last_txn_ts tracking in client", () => {
       httpClient
     );
 
-    const resultOne = await myClient.query({
-      query:
-        "\
-if (Collection.byName('Customers') == null) {\
-  Collection.create({ name: 'Customers' })\
-}",
-    });
+    const resultOne = await myClient.query(fql`
+      if (Collection.byName('Customers') == null) {
+        Collection.create({ name: 'Customers' })
+      }
+    `);
     expect(resultOne.txn_ts).not.toBeUndefined();
     expectedLastTxn = resultOne.txn_ts;
     const resultTwo = await myClient.query(
@@ -42,13 +40,11 @@ if (Collection.byName('Customers') == null) {\
     expect(resultTwo.txn_ts).not.toBeUndefined();
     expect(resultTwo.txn_ts).not.toEqual(resultOne.txn_ts);
     expectedLastTxn = resultTwo.txn_ts;
-    const resultThree = await myClient.query({
-      query:
-        "\
-if (Collection.byName('Products') == null) {\
-  Collection.create({ name: 'Products' })\
-}",
-    });
+    const resultThree = await myClient.query(fql`
+      if (Collection.byName('Products') == null) {
+        Collection.create({ name: 'Products' })
+      }
+    `);
     expect(resultThree.txn_ts).not.toBeUndefined();
     expect(resultThree.txn_ts).not.toEqual(resultTwo.txn_ts);
   });
@@ -74,13 +70,11 @@ if (Collection.byName('Products') == null) {\
       httpClient
     );
 
-    const resultOne = await myClient.query({
-      query:
-        "\
-if (Collection.byName('Customers') == null) {\
-  Collection.create({ name: 'Customers' })\
-}",
-    });
+    const resultOne = await myClient.query(fql`
+      if (Collection.byName('Customers') == null) {\
+        Collection.create({ name: 'Customers' })\
+      }
+    `);
     expect(resultOne.txn_ts).not.toBeUndefined();
     expectedLastTxn = resultOne.txn_ts;
     myClient.lastTxnTs = resultOne.txn_ts as number;
@@ -89,19 +83,17 @@ if (Collection.byName('Customers') == null) {\
       if (Collection.byName('Orders') == null) {\
         Collection.create({ name: 'Orders' })\
       }
-      `
+    `
     );
     expect(resultTwo.txn_ts).not.toBeUndefined();
     expect(resultTwo.txn_ts).not.toEqual(resultOne.txn_ts);
     myClient.lastTxnTs = 0;
     expectedLastTxn = resultTwo.txn_ts;
-    const resultThree = await myClient.query({
-      query:
-        "\
-if (Collection.byName('Products') == null) {\
-  Collection.create({ name: 'Products' })\
-}",
-    });
+    const resultThree = await myClient.query(fql`
+      if (Collection.byName('Products') == null) {\
+        Collection.create({ name: 'Products' })\
+      }
+    `);
     expect(resultThree.txn_ts).not.toBeUndefined();
     expect(resultThree.txn_ts).not.toEqual(resultTwo.txn_ts);
   });

--- a/__tests__/integration/template-format.test.ts
+++ b/__tests__/integration/template-format.test.ts
@@ -85,8 +85,8 @@ describe("query using template format", () => {
   it("succeeds with nested expressions", async () => {
     const str = "foo";
     const num = 6;
-    const innerQueryBuilder = fql`(${num} - 3)`;
-    const queryBuilder = fql`${str}.length == ${innerQueryBuilder}`;
+    const innerQuery = fql`(${num} - 3)`;
+    const queryBuilder = fql`${str}.length == ${innerQuery}`;
     const response = await client.query(queryBuilder);
     expect(response.data).toBe(true);
   });
@@ -98,8 +98,8 @@ describe("query using template format", () => {
     const otherNum = 3;
     const deepFirst = fql`(${str} + ${otherStr})`;
     const deeperBuilder = fql`(${num} + 3)`;
-    const innerQueryBuilder = fql`(${deeperBuilder} - ${otherNum})`;
-    const queryBuilder = fql`${deepFirst}.length == ${innerQueryBuilder}`;
+    const innerQuery = fql`(${deeperBuilder} - ${otherNum})`;
+    const queryBuilder = fql`${deepFirst}.length == ${innerQuery}`;
     const response = await client.query(queryBuilder);
     expect(response.data).toBe(true);
   });

--- a/__tests__/unit/query-builder.test.ts
+++ b/__tests__/unit/query-builder.test.ts
@@ -1,6 +1,6 @@
 import { fql } from "../../src/query-builder";
 
-describe("fql method producing QueryBuilders", () => {
+describe("fql method producing Querys", () => {
   it("parses with no variables", () => {
     const queryBuilder = fql`'foo'.length`;
     const queryRequest = queryBuilder.toQuery();
@@ -94,8 +94,8 @@ describe("fql method producing QueryBuilders", () => {
   it("parses nested expressions", () => {
     const str = "baz";
     const num = 17;
-    const innerQueryBuilder = fql`Math.add(${num}, 3)`;
-    const queryBuilder = fql`${str}.length == ${innerQueryBuilder}`;
+    const innerQuery = fql`Math.add(${num}, 3)`;
+    const queryBuilder = fql`${str}.length == ${innerQuery}`;
     const queryRequest = queryBuilder.toQuery();
     expect(queryRequest.query).toEqual({
       fql: [
@@ -114,8 +114,8 @@ describe("fql method producing QueryBuilders", () => {
     const otherNum = 3;
     const deepFirst = fql`(${str} + ${otherStr})`;
     const deeperBuilder = fql`Math.add(${num}, 3)`;
-    const innerQueryBuilder = fql`Math.add(${deeperBuilder}, ${otherNum})`;
-    const queryBuilder = fql`${deepFirst}.length == ${innerQueryBuilder}`;
+    const innerQuery = fql`Math.add(${deeperBuilder}, ${otherNum})`;
+    const queryBuilder = fql`${deepFirst}.length == ${innerQuery}`;
     const queryRequest = queryBuilder.toQuery();
     expect(queryRequest.query).toEqual({
       fql: [
@@ -138,8 +138,8 @@ describe("fql method producing QueryBuilders", () => {
   it("adds headers if passed in", () => {
     const str = "baz";
     const num = 17;
-    const innerQueryBuilder = fql`Math.add(${num}, 3)`;
-    const queryBuilder = fql`${str}.length == ${innerQueryBuilder}`;
+    const innerQuery = fql`Math.add(${num}, 3)`;
+    const queryBuilder = fql`${str}.length == ${innerQuery}`;
     const queryRequest = queryBuilder.toQuery({
       linearized: true,
       query_timeout_ms: 600,

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -12,6 +12,7 @@ import {
   ThrottlingError,
 } from "../../src/errors";
 import { FetchClient } from "../../src/http-client";
+import { fql } from "../../src/query-builder";
 
 const client = getClient(
   {
@@ -44,7 +45,7 @@ describe("query", () => {
         status: httpStatus,
       });
       try {
-        await client.query({ query: "'foo'.length" });
+        await client.query(fql`'foo'.length`);
       } catch (e) {
         if (e instanceof ServiceError) {
           expect(e).toBeInstanceOf(expectedErrorType);
@@ -82,7 +83,7 @@ describe("query", () => {
         }
       );
       try {
-        await client.query({ query: "'foo'.length" });
+        await client.query(fql`'foo'.length`);
       } catch (e) {
         if (e instanceof ServiceError) {
           expect(e).toBeInstanceOf(expectedErrorType);
@@ -118,7 +119,7 @@ describe("query", () => {
       );
 
       try {
-        await client.query({ query: "'foo'.length" });
+        await client.query(fql`'foo'.length`);
       } catch (e) {
         if (e instanceof ServiceError) {
           expect(e).toBeInstanceOf(expectedErrorType);
@@ -135,7 +136,7 @@ describe("query", () => {
     // axios mock adapater currently has a bug that cannot match
     // routes on clients using a baseURL. As such we use onAny() in these tests.
     fetchMock.mockResponse(JSON.stringify({ data: 3, summary: "the summary" }));
-    const actual = await client.query({ query: "'foo'.length" });
+    const actual = await client.query(fql`'foo'.length`);
     expect(actual.data).toEqual(3);
     expect(actual.summary).toEqual("the summary");
   });
@@ -147,7 +148,7 @@ describe("query", () => {
   //   mockAxios.onAny().timeout();
 
   //   try {
-  //     await client.query({ query: "'foo'.length" });
+  //     await client.query(fql`'foo'.length`);
   //   } catch (e) {
   //     if (e instanceof NetworkError) {
   //       expect(e.message).toEqual(
@@ -165,7 +166,7 @@ describe("query", () => {
   //   // routes on clients using a baseURL. As such we use onAny() in these tests.
   //   mockAxios.onAny().networkError();
   //   try {
-  //     await client.query({ query: "'foo'.length" });
+  //     await client.query(fql`'foo'.length`);
   //   } catch (e) {
   //     if (e instanceof NetworkError) {
   //       expect(e.message).toEqual(
@@ -200,7 +201,7 @@ describe("query", () => {
   //       throw { code: errorCode };
   //     });
   //     try {
-  //       await client.query({ query: "'foo'.length" });
+  //       await client.query(fql`'foo'.length`);
   //     } catch (e) {
   //       if (e instanceof NetworkError) {
   //         expect(e.message).toEqual(
@@ -220,7 +221,7 @@ describe("query", () => {
   //     throw { request: { status: 0 } };
   //   });
   //   try {
-  //     await client.query({ query: "'foo'.length" });
+  //     await client.query(fql`'foo'.length`);
   //   } catch (e) {
   //     if (e instanceof NetworkError) {
   //       expect(e.message).toEqual(

--- a/src/client.ts
+++ b/src/client.ts
@@ -113,7 +113,7 @@ export class Client {
 
   /**
    * Queries Fauna.
-   * @param request - a {@link QueryRequest} or {@link Query} to build a request with.
+   * @param request - a {@link Query} to execute in Fauna.
    *  Note, you can embed header fields in this object; if you do that there's no need to
    *  pass the headers parameter.
    * @param headers - optional {@link QueryRequestHeaders} to apply on top of the request input.

--- a/src/client.ts
+++ b/src/client.ts
@@ -117,7 +117,7 @@ export class Client {
    *  Note, you can embed header fields in this object; if you do that there's no need to
    *  pass the headers parameter.
    * @param headers - optional {@link QueryRequestHeaders} to apply on top of the request input.
-   *   Values in this headers parameter take precedence over the same values in the request
+   *   Values in this headers parameter take precedence over the same values in the {@link ClientConfiguration}.
    *   parameter. This field is primarily intended to be used when you pass a Query as
    *   the parameter.
    * @returns Promise&lt;{@link QuerySuccess}&gt;.

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import {
   ServiceTimeoutError,
   ThrottlingError,
 } from "./errors";
-import type { QueryBuilder } from "./query-builder";
+import type { Query } from "./query-builder";
 import {
   isQueryFailure,
   isQuerySuccess,
@@ -113,12 +113,12 @@ export class Client {
 
   /**
    * Queries Fauna.
-   * @param request - a {@link QueryRequest} or {@link QueryBuilder} to build a request with.
+   * @param request - a {@link QueryRequest} or {@link Query} to build a request with.
    *  Note, you can embed header fields in this object; if you do that there's no need to
    *  pass the headers parameter.
    * @param headers - optional {@link QueryRequestHeaders} to apply on top of the request input.
    *   Values in this headers parameter take precedence over the same values in the request
-   *   parameter. This field is primarily intended to be used when you pass a QueryBuilder as
+   *   parameter. This field is primarily intended to be used when you pass a Query as
    *   the parameter.
    * @returns Promise&lt;{@link QuerySuccess}&gt;.
    * @throws {@link ServiceError} Fauna emitted an error. The ServiceError will be
@@ -136,12 +136,9 @@ export class Client {
    * due to an internal error.
    */
   async query<T = any>(
-    request: QueryRequest | QueryBuilder,
+    request: Query,
     headers?: QueryRequestHeaders
   ): Promise<QuerySuccess<T>> {
-    if ("query" in request) {
-      return this.#query({ ...request, ...headers });
-    }
     return this.#query(request.toQuery(headers));
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -118,8 +118,6 @@ export class Client {
    *  pass the headers parameter.
    * @param headers - optional {@link QueryRequestHeaders} to apply on top of the request input.
    *   Values in this headers parameter take precedence over the same values in the {@link ClientConfiguration}.
-   *   parameter. This field is primarily intended to be used when you pass a Query as
-   *   the parameter.
    * @returns Promise&lt;{@link QuerySuccess}&gt;.
    * @throws {@link ServiceError} Fauna emitted an error. The ServiceError will be
    *   one of ServiceError's child classes if the error can be further categorized,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export {
   ServiceTimeoutError,
   ThrottlingError,
 } from "./errors";
-export { type QueryBuilder, fql } from "./query-builder";
+export { type Query, fql } from "./query-builder";
 export {
   type JSONObject,
   type JSONValue,

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -201,7 +201,7 @@ export type ValueFragment = { value: JSONValue };
  * A piece of an interpolated query. Interpolated Queries can be safely composed
  * together without concern of query string injection.
  * @remarks A FQLFragment is created when calling the {@link fql} tagged
- * template function and can be passed as an argument to other QueryBuilders.
+ * template function and can be passed as an argument to other Querys.
  * @example
  * ```typescript
  *  const num = 17;


### PR DESCRIPTION
Ticket(s): [FE-3301](https://faunadb.atlassian.net/browse/FE-3301)

## Problem
We want to push users toward best practice by requiring them to use the `fql` function.

## Solution
Eliminate the `QueryBuilder` interface. Rename `TemplateQueryBuilder` to `Query`. Check if arguments are also `Query` instances with `instanceof` instead of a predicate function to check for the interface.

Client.query only accepts a `Query` instance.

## Out of scope

## Testing
Removed all tests that specifically intended to exercise passing `QueryRequest` to `Client.query`. Fixed other tests to use `fql` function.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3301]: https://faunadb.atlassian.net/browse/FE-3301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ