### PR TITLE
Bump version to release changes to query builder, etc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauna",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A driver to query Fauna databases in browsers, Node.js, and other Javascript runtimes",
   "homepage": "https://fauna.com",
   "bugs": {


### PR DESCRIPTION
# Note

I didn't do a bump such that this is marked breaking since we still haven't gone to private beta. So just incrementing the patch version.

## Problem
- Need to bump version to release items blocking private beta
## Solution
- bump version to release items blocking private beta
## Result
- can release
## Testing
- N/A
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
