### PR TITLE
Client can accept endpoints with or without a trailing Slash

### DIFF
--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -118,4 +118,26 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
       await client.query<number>(fql`"taco".length`);
     }
   );
+
+  it("can accept endpoints with or without a trailing slash.", async () => {
+    expect.assertions(2);
+    const httpClient: HTTPClient = {
+      async request(req) {
+        expect(req.url).toBe("http://localhost:8443/query/1");
+        return getDefaultHTTPClient().request(req);
+      },
+    };
+
+    const client1 = getClient(
+      { endpoint: new URL("http://localhost:8443/") },
+      httpClient
+    );
+    await client1.query<number>(fql`"taco".length`);
+
+    const client2 = getClient(
+      { endpoint: new URL("http://localhost:8443") },
+      httpClient
+    );
+    await client2.query<number>(fql`"taco".length`);
+  });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -75,7 +75,10 @@ export class Client {
       ...clientConfiguration,
       secret: this.#getSecret(clientConfiguration),
     };
-    this.#url = `${this.clientConfiguration.endpoint.toString()}query/1`;
+    this.#url = new URL(
+      "/query/1",
+      this.clientConfiguration.endpoint
+    ).toString();
     if (!httpClient) {
       this.#httpClient = getDefaultHTTPClient();
     } else {


### PR DESCRIPTION
Ticket(s): [FE-3293](https://faunadb.atlassian.net/browse/FE-3293)

## Problem
Providing an endpoint without the trailing slash doesn't work

## Solution
Use the `URL` API to append `/query/1` to the endpoint.

## Result
final URL is the same with or without a trailing slash in the endpoint.

## Testing
Added new client configuration test.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3293]: https://faunadb.atlassian.net/browse/FE-3293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ