### PR TITLE
FE-3307 Rename JSONValue -> QueryValue and JSONObject -> QueryValueObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,9 @@ The driver is additionally made available to browsers via CDN:
 
 ## Creating queries with the `fql` function
 
-
 The `fql` function is your gateway to building safe, reuseable Fauna queries.
 
-It allows you compose queries from sub-queries and variables native to your program. Variables passed in our treated as unexecutable values in Fauna's API - preventing security issues like injection attacks.
+It allows you compose queries from sub-queries and variables native to your program. Variables passed in are treated as unexecutable values in Fauna's API - preventing security issues like injection attacks.
 
 for example:
 
@@ -151,6 +150,7 @@ This has several advantages:
 The following subsections show some further examples.
 
 ### Pure FQL X via the `fql` function
+
 The `fql` function can also create pure FQL X queries, for example:
 
 ```javascript
@@ -176,7 +176,6 @@ const result = await client.query(fql`
 ```
 
 ### Advanced Composition example using `fql` function
-
 
 ```javascript
 // a reusable FQL X lambda to create Users with validated parameters
@@ -288,7 +287,11 @@ const result = await client.query(SOME_QUERY, options);
 
 ## Client Configuration
 
-The client can be configured for your specific environment. You can also provide query options that will be sent by default with every request
+The driver use's a default ClientConfiguration. We recommend most users stick with the defaults.
+
+If your environment needs different configuration however, the default ClientConfiguration can be overriden.
+
+Furthermore, on each request you can provide query specific configuration that will override the setting in your client for that request only.
 
 ```typescript
 import { Client, endpoints, type ClientConfiguration } from "fauna";
@@ -297,6 +300,8 @@ const config: ClientConfiguration = {
   // configure client
   secret: YOUR_FAUNA_SECRET,
   endpoint: endpoints.default,
+  // note this will change names during the early access beta
+  // to reflect HTTP/2 semantics
   max_conns: 10,
 
   // set default query options

--- a/__tests__/integration/existing-collection.test.ts
+++ b/__tests__/integration/existing-collection.test.ts
@@ -40,17 +40,9 @@ beforeAll(async () => {
    * The actual data creation is fine to execute multiple times due to the presence of the
    * unique constraint in the schema.
    */
-  const collDoesNotExist = (
+  console.log(
     await client.query(fql`
-  Collection.byName("Authors") == null
-  `)
-  ).data;
-  if (collDoesNotExist) {
-    console.log(
-      "No existing Authors collection found, creating collection and schema."
-    );
-    console.log(
-      await client.query(fql`
+  if (Collection.byName("Authors") == null) {
     Collection.create({
       name: "Authors",
       indexes: {
@@ -65,9 +57,11 @@ beforeAll(async () => {
         { unique: [ "firstName", "lastName" ] }
       ]
     })
-    `)
-    );
+  } else {
+    "Authors already exists."
   }
+    `)
+  );
   for (const author of authorsData) {
     try {
       await client.query(fql`

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,8 +20,8 @@ export {
 } from "./errors";
 export { type Query, fql } from "./query-builder";
 export {
-  type JSONObject,
-  type JSONValue,
+  type QueryValueObject,
+  type QueryValue,
   type QueryFailure,
   type QueryInfo,
   type QueryInterpolation,

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -1,7 +1,7 @@
 import { TaggedTypeFormat } from "./tagged-type";
 import type {
-  JSONObject,
-  JSONValue,
+  QueryValueObject,
+  QueryValue,
   QueryInterpolation,
   QueryRequest,
   QueryRequestHeaders,
@@ -11,7 +11,7 @@ import type {
  * Creates a new Query. Accepts template literal inputs.
  * @param queryFragments - a {@link TemplateStringsArray} that constitute
  *   the strings that are the basis of the query.
- * @param queryArgs - an Array\<JSONValue | Query\> that
+ * @param queryArgs - an Array\<QueryValue | Query\> that
  *   constitute the arguments to inject between the queryFragments.
  * @throws Error - if you call this method directly (not using template
  *   literals) and pass invalid construction parameters
@@ -25,7 +25,7 @@ import type {
  */
 export function fql(
   queryFragments: ReadonlyArray<string>,
-  ...queryArgs: (JSONValue | Query)[]
+  ...queryArgs: (QueryValue | Query)[]
 ): Query {
   return new Query(queryFragments, ...queryArgs);
 }
@@ -37,11 +37,11 @@ export function fql(
  */
 export class Query {
   readonly #queryFragments: ReadonlyArray<string>;
-  readonly #queryArgs: (JSONValue | Query)[];
+  readonly #queryArgs: (QueryValue | Query)[];
 
   constructor(
     queryFragments: ReadonlyArray<string>,
-    ...queryArgs: (JSONValue | Query)[]
+    ...queryArgs: (QueryValue | Query)[]
   ) {
     if (
       queryFragments.length === 0 ||
@@ -78,7 +78,7 @@ export class Query {
       return { query: { fql: [this.#queryFragments[0]] }, arguments: {} };
     }
 
-    let resultArgs: JSONObject = {};
+    let resultArgs: QueryValueObject = {};
     const renderedFragments: (string | QueryInterpolation)[] =
       this.#queryFragments.flatMap((fragment, i) => {
         // There will always be one more fragment than there are arguments

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -8,7 +8,7 @@ import {
   TimeStub,
   Page,
 } from "./values";
-import { JSONObject, JSONValue } from "./wire-protocol";
+import { QueryValueObject, QueryValue } from "./wire-protocol";
 
 /**
  * TaggedType provides the encoding/decoding of the Fauna Tagged Type formatting
@@ -81,12 +81,12 @@ type TaggedDouble = { "@double": string };
 type TaggedInt = { "@int": string };
 type TaggedLong = { "@long": string };
 type TaggedMod = { "@mod": string };
-type TaggedObject = { "@object": JSONObject };
+type TaggedObject = { "@object": QueryValueObject };
 type TaggedRef = {
   "@ref": { id: string; coll: TaggedMod } | { name: string; coll: TaggedMod };
 };
 // WIP: core does not accept `@set` tagged values
-// type TaggedSet = { "@set": { data: JSONValue[]; after?: string } };
+// type TaggedSet = { "@set": { data: QueryValue[]; after?: string } };
 type TaggedTime = { "@time": string };
 
 export const LONG_MIN = BigInt("-9223372036854775808");
@@ -128,9 +128,9 @@ const encodeMap = {
   string: (value: string): string => {
     return value;
   },
-  object: (input: JSONObject): TaggedObject | JSONObject => {
+  object: (input: QueryValueObject): TaggedObject | QueryValueObject => {
     let wrapped = false;
-    const _out: JSONObject = {};
+    const _out: QueryValueObject = {};
 
     for (const k in input) {
       if (k.startsWith("@")) {
@@ -140,8 +140,8 @@ const encodeMap = {
     }
     return wrapped ? { "@object": _out } : _out;
   },
-  array: (input: Array<JSONValue>): Array<JSONValue> => {
-    const _out: JSONValue = [];
+  array: (input: Array<QueryValue>): Array<QueryValue> => {
+    const _out: QueryValue = [];
     for (const i in input) _out.push(encode(input[i]));
     return _out;
   },
@@ -171,7 +171,7 @@ const encodeMap = {
   }),
 };
 
-const encode = (input: JSONValue): JSONValue => {
+const encode = (input: QueryValue): QueryValue => {
   switch (typeof input) {
     case "bigint":
       return encodeMap["bigint"](input);

--- a/src/values/doc.ts
+++ b/src/values/doc.ts
@@ -1,4 +1,4 @@
-import { JSONObject } from "../wire-protocol";
+import { QueryValueObject } from "../wire-protocol";
 import { TimeStub } from "./date-time";
 
 /**
@@ -127,7 +127,7 @@ export class NamedDocumentReference {
  * ```
  */
 export class NamedDocument<
-  T extends JSONObject = Record<string, never>
+  T extends QueryValueObject = Record<string, never>
 > extends NamedDocumentReference {
   readonly ts: TimeStub;
   readonly data: T;
@@ -190,4 +190,4 @@ export class Module {
  * @remarks The {@link Document} class cannot be generic because classes cannot
  * extend generic type arguments.
  */
-export type DocumentT<T extends JSONObject> = Document & T;
+export type DocumentT<T extends QueryValueObject> = Document & T;

--- a/src/values/set.ts
+++ b/src/values/set.ts
@@ -1,6 +1,6 @@
-import { JSONValue } from "../wire-protocol";
+import { QueryValue } from "../wire-protocol";
 
-export class Page<T extends JSONValue> {
+export class Page<T extends QueryValue> {
   readonly data: T[];
   readonly after?: string;
 

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -239,8 +239,8 @@ export interface Span {
 /**
  * A QueryValueObject is a plain javascript object where
  * each value is a QueryValue.
- * i.e. these objects can be sent as values
- * in the {@link fql} query creation function and are
+ * i.e. these objects can be set as values
+ * in the {@link fql} query creation function and can be
  * returned in {@link QuerySuccess}.
  */
 export type QueryValueObject = {
@@ -250,8 +250,8 @@ export type QueryValueObject = {
 /**
  * A QueryValue can be sent as a value in a query,
  * and received from query output.
- * i.e. these are the types you can send as values
- * in the {@link fql} query creation function and are
+ * i.e. these are the types you can set as values
+ * in the {@link fql} query creation function and can be
  * returned in {@link QuerySuccess}.
  */
 export type QueryValue =

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -21,7 +21,7 @@ export interface QueryRequest extends QueryRequestHeaders {
   /** Optional arguments. Variables in the query will be initialized to the
    * value associated with an argument key.
    */
-  arguments?: JSONObject;
+  arguments?: QueryValueObject;
 }
 
 export interface QueryRequestHeaders {
@@ -195,7 +195,7 @@ export type QueryInterpolation = FQLFragment | ValueFragment;
  *  { fql: [{ value: { "@int": "17" } }, " + 3"] }
  * ```
  */
-export type ValueFragment = { value: JSONValue };
+export type ValueFragment = { value: QueryValue };
 
 /**
  * A piece of an interpolated query. Interpolated Queries can be safely composed
@@ -237,25 +237,33 @@ export interface Span {
 }
 
 /**
- * All objects returned from Fauna are valid JSON objects.
+ * A QueryValueObject is a plain javascript object where
+ * each value is a QueryValue.
+ * i.e. these objects can be sent as values
+ * in the {@link fql} query creation function and are
+ * returned in {@link QuerySuccess}.
  */
-export type JSONObject = {
-  [key: string]: JSONValue;
+export type QueryValueObject = {
+  [key: string]: QueryValue;
 };
 
 /**
- * All values returned from Fauna are valid JSON values.
+ * A QueryValue can be sent as a value in a query,
+ * and received from query output.
+ * i.e. these are the types you can send as values
+ * in the {@link fql} query creation function and are
+ * returned in {@link QuerySuccess}.
  */
-export type JSONValue =
+export type QueryValue =
   // plain javascript values
   | null
   | string
   | number
   | bigint
   | boolean
-  | JSONObject
-  | Array<JSONValue>
-  // fauna-provided classes
+  | QueryValueObject
+  | Array<QueryValue>
+  // client-provided classes
   | DateStub
   | TimeStub
   | Module
@@ -263,4 +271,4 @@ export type JSONValue =
   | DocumentReference
   | NamedDocument
   | NamedDocumentReference
-  | Page<JSONValue>;
+  | Page<QueryValue>;


### PR DESCRIPTION
Ticket(s): FE-3307

## Problem
- the wire protocol is no longer restricted to plain JSON
- however, our client-side objects and docs still refer to 'json'

## Solution
- rename `JSONValue` -> `QueryValue` and `JSONObject` -> `QueryValueObject`
- clean up docs to not refer to 'json' either.

## Result
- semantically coherent type names

## Out of scope
- fixing up whatever issues sit with this in the demo directory - will handle that in one fell swoop as there's other issues

## Testing
- full suite (see Github Actions)
- grepped the repo for mentions of jsonvalue and jsonobject (case insensitive)

```
~/workplace/fauna-js (main_renameJSON) » grep -ri jsonobject src/ __tests__ README.md                                                                                  1 ↵ cleve@Cleves-MBP
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
~/workplace/fauna-js (main_renameJSON) » grep -ri jsonvalue src/ __tests__ README.md                                                                                   1 ↵ cleve@Cleves-MBP
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
~/workplace/fauna-js (main_renameJSON) » 
```

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
