### PR TITLE
FE-3306 Treat undefined values in QueryValueObject as unprovided. Reject undefined in QueryValue.

### DIFF
--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -215,5 +215,5 @@ const encode = (input: QueryValue): QueryValue => {
         return encodeMap["object"](input);
       }
   }
-  // anything here would be dead code
+  // anything here would be unreachable code
 };

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -136,7 +136,9 @@ const encodeMap = {
       if (k.startsWith("@")) {
         wrapped = true;
       }
-      _out[k] = encode(input[k]);
+      if (input[k] !== undefined) {
+        _out[k] = encode(input[k]);
+      }
     }
     return wrapped ? { "@object": _out } : _out;
   },
@@ -172,6 +174,9 @@ const encodeMap = {
 };
 
 const encode = (input: QueryValue): QueryValue => {
+  if (input === undefined) {
+    throw new TypeError("Passing undefined as a QueryValue is not supported");
+  }
   switch (typeof input) {
     case "bigint":
       return encodeMap["bigint"](input);
@@ -179,6 +184,8 @@ const encode = (input: QueryValue): QueryValue => {
       return encodeMap["string"](input);
     case "number":
       return encodeMap["number"](input);
+    case "boolean":
+      return input;
     case "object":
       if (input == null) {
         return null;
@@ -207,8 +214,6 @@ const encode = (input: QueryValue): QueryValue => {
       } else {
         return encodeMap["object"](input);
       }
-      break;
   }
-  // default to encoding directly as the input
-  return input;
+  // anything here would be dead code
 };


### PR DESCRIPTION
Ticket(s): FE-3306

## Problem

We don't handle undefined values in queries; leading to 400s anytime an undefined value is in user input.


```
       QueryRuntimeError: Invalid request body
          at Client.#getServiceError (/Users/cleve/workplace/fauna-js/src/client.ts:208:16)
          at Client.#getError (/Users/cleve/workplace/fauna-js/src/client.ts:163:37)
          at Client.#query (/Users/cleve/workplace/fauna-js/src/client.ts:278:29)
          at processTicksAndRejections (node:internal/process/task_queues:95:5)
          at Object.<anonymous> (/Users/cleve/workplace/fauna-js/__tests__/integration/query.test.ts:309:26) {
        httpStatus: 400,
        code: 'invalid_request',
        queryInfo: {
          txn_ts: undefined,
          summary: undefined,
          query_tags: undefined,
          stats: undefined
        },
        constraint_failures: undefined
      }
```

This is a problem because using undefined to denote absence is a common JS pattern.

## Solution

- Treat undefined as unprovided when part of an object
- reject it with a TyperError when passed directly as a value. (we take this approach because we cannot look back and determine what part of the query to omit.)

For the 2nd bullet point examine this query:

```typescript
fql`
  { my_undefined_input: ${undefined}, my_other_input: ${1}}
`
```

There's no way for us to "look back" and determine what we should rip out of the query; so instead we reject with a TypeError to save the round trip to core.

Another option would be to treat it the same as null but IMO this would surprise JS users who are used to "undefined" connoting "absence", whereas "null" is used to delete fields on updates in FQL X.

## Result

- undefined is handled early.

## Testing

Full suite (see Github Actions)

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
