### PR TITLE
Browser support is crashing because are trying to read from node's http2 package which does not exist. We also are not exporting the FetchClient or NodeHttp2Client to end consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauna",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "A driver to query Fauna databases in browsers, Node.js, and other Javascript runtimes",
   "homepage": "https://fauna.com",
   "bugs": {

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -5,6 +5,7 @@ import { FetchClient } from "./fetch-client";
 import { NodeHTTP2Client } from "./node-http2-client";
 
 export { FetchClient } from "./fetch-client";
+export { NodeHTTP2Client } from "./node-http2-client";
 
 /**
  * An object representing an http request.

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -20,7 +20,7 @@ export class NodeHTTP2Client implements HTTPClient {
 
   static getClient() {
     if (http2 === undefined) {
-      throw new Error("Your platform does support Node's http2 library");
+      throw new Error("Your platform does not support Node's http2 library");
     }
     if (this.#client) {
       return this.#client;

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -4,9 +4,6 @@ import { HTTPClient, HTTPRequest, HTTPResponse } from "./index";
 import { NetworkError } from "../errors";
 import { QueryRequest } from "../wire-protocol";
 
-const { HTTP2_HEADER_PATH, HTTP2_HEADER_METHOD, HTTP2_HEADER_STATUS } =
-  http2.constants;
-
 /**
  * An implementation for {@link HTTPClient} that uses the node http package
  */
@@ -22,6 +19,9 @@ export class NodeHTTP2Client implements HTTPClient {
   private constructor() {}
 
   static getClient() {
+    if (http2 === undefined) {
+      throw new Error("Your platform does support Node's http2 library");
+    }
     if (this.#client) {
       return this.#client;
     }
@@ -128,7 +128,9 @@ class SessionWrapper {
         http2ResponseHeaders: http2.IncomingHttpHeaders &
           http2.IncomingHttpStatusHeader
       ) => {
-        const status = Number(http2ResponseHeaders[HTTP2_HEADER_STATUS]);
+        const status = Number(
+          http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS]
+        );
         let responseData = "";
 
         // append response data to the data string every time we receive new data
@@ -150,8 +152,8 @@ class SessionWrapper {
       try {
         const httpRequestHeaders: http2.OutgoingHttpHeaders = {
           ...requestHeaders,
-          [HTTP2_HEADER_PATH]: this.#pathName,
-          [HTTP2_HEADER_METHOD]: method,
+          [http2.constants.HTTP2_HEADER_PATH]: this.#pathName,
+          [http2.constants.HTTP2_HEADER_METHOD]: method,
         };
 
         req = this.internal

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,3 +43,4 @@ export {
   Page,
   TimeStub,
 } from "./values";
+export { FetchClient, NodeHTTP2Client } from "./http-client";


### PR DESCRIPTION

## Problem
- When using the latest JS driver in the dashboard found that it crashed as it could not resolve the headers we were dereferencing in the NodeHTTP2Module
- Furthermore, some builds (as seen in the platform tests) could not figure out what NodeHttp2Client was as it was not being exported in the build
## Solution
- do not dereference http2 statically
- blow up if a use tries to use a http2 client in a platform that does not have node's http2 library
- export the http clients
## Result
- once this is released i'll be able to test browser + other platform usage with it
## Out of scope
- we need to get platform testing and testing against the build artifacts into the PR and release process; but out of scope here
## Testing
- full suite for now
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
