### PR TITLE
Update isNode algorithm to check typeof process to avoid ReferenceError in browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauna",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "A driver to query Fauna databases in browsers, Node.js, and other Javascript runtimes",
   "homepage": "https://fauna.com",
   "bugs": {

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -50,4 +50,9 @@ export const getDefaultHTTPClient = () =>
 export const isHTTPResponse = (res: any): res is HTTPResponse =>
   res instanceof Object && "body" in res && "headers" in res && "status" in res;
 
-const isNode = () => process !== undefined && process.release?.name === "node";
+function isNode() {
+  if (typeof process !== "undefined") {
+    return process.release?.name === "node";
+  }
+  return false;
+}


### PR DESCRIPTION


## Problem

- the isNode algorithm is still insufficient. Calling "process" leads to a ReferenceError.

## Solution
- updated algorithm to check the typeof process.

## Result
- have confirmed i can run fauna-js in the browser now.

## Testing
- tested this by setting my local dashboard to depend on my local repo of fauna.

I can now load the views that use FQL X and have also confirmed that this is the source onbox.

I've posted the screenshots to our slack room.
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
