### PR TITLE
Include NodeHTTP2Client in browser build - but load node:http2 module in try catch

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "build": "rm -rf dist; yarn build:node; yarn build:browser; yarn build:types",
-    "build:browser": "esbuild src/index.ts --bundle --platform=browser --minify --sourcemap --format=esm --outfile=dist/browser/index.js --external:./src/http-client/node-http2-client",
+    "build:browser": "esbuild src/index.ts --bundle --platform=browser --minify --sourcemap --format=esm --outfile=dist/browser/index.js",
     "build:node": "esbuild src/index.ts --bundle --sourcemap --platform=node --outfile=dist/node/index.js",
     "build:types": "tsc -emitDeclarationOnly --declaration true",
     "lint": "eslint -f unix \"src/**/*.{ts,tsx}\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fauna",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "A driver to query Fauna databases in browsers, Node.js, and other Javascript runtimes",
   "homepage": "https://fauna.com",
   "bugs": {

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -50,9 +50,14 @@ export const getDefaultHTTPClient = () =>
 export const isHTTPResponse = (res: any): res is HTTPResponse =>
   res instanceof Object && "body" in res && "headers" in res && "status" in res;
 
-function isNode() {
-  if (typeof process !== "undefined") {
-    return process.release?.name === "node";
+export function isNode() {
+  if (typeof process !== "undefined" && process.release?.name === "node") {
+    try {
+      require("node:http2");
+      return true;
+    } catch (_) {
+      return false;
+    }
   }
   return false;
 }


### PR DESCRIPTION
Ticket(s): FE-3061

## Problem
- webpack bundled apps cannot use driver as it references the NodeHTTP2Client in an import - despite it being excluded from build


## Solution
- include the NodeHTTP2Client in all builds
- refactor the NodeHTTP2Client to use `require` to pull in the `node:http2` module
- if an error occurs requiring the `node:http2` module throw an error if a user tries to construct a NodeHTTP2Client

## Result
- the JS driver can run on the browser and on the server

## Testing

### Verify no "src" references are in build output, save for the source maps:

```
~/workplace/fauna-js (main_webpackFix) » grep -rl "../src" dist                                                                                                            cleve@Cleves-MBP
dist/browser/index.js.map                
dist/node/index.js.map
-----------------------------------------
```

### Verify NodeHTTPClient is in browser dist



```
grep -r "NodeHTTP2Client" dist/browser
...includes
import { NodeHTTP2Client } from \"./node-http2
-client\"
```

```
grep -r "NodeHTTP2Client" dist/node
... includes
import { NodeHTTP2Client } from \"./node-http2
-client\"
```


### Execution of platform tests
#### Browser
  (Run Finished)

```
       Spec                                              Tests  Passing  Failing  Pending  Skipped  
  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ✔  spec.cy.js                               00:01        1        1        -        -        - │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘
    ✔  All specs passed!                        00:01        1        1        -        -        -  

 ✨  Done in 14.73s.
```
#### Lambda

```
~/workplace/testtools/fauna-driver-platform-tests (main*) » yarn js:aws-lambda:test  
 yarn run v1.22.19
 $ jest -t 'JS Driver on AWS Lambda'
 PASS  __tests__/js-driver.test.ts
  JS Driver on Cloudflare Worker
    ○ skipped should return 200 response
  JS Driver on AWS Lambda
    ✓ should return 200 response (1634 ms)
  JS Driver on Netlify Function
    ○ skipped should return 200 response
  JS Driver on Vercel Function
    ○ skipped should return 200 response

Test Suites: 1 passed, 1 total
Tests:       3 skipped, 1 passed, 4 total
Snapshots:   0 total
Time:        3.838 s, estimated 4 s
Ran all test suites with tests matching "JS Driver on AWS Lambda".
 ✨  Done in 4.76s.
```

#### Netlify

```
 PASS  __tests__/js-driver.test.ts
  JS Driver on Cloudflare Worker
    ○ skipped should return 200 response
  JS Driver on AWS Lambda
    ○ skipped should return 200 response
  JS Driver on Netlify Function
    ✓ should return 200 response (772 ms)
  JS Driver on Vercel Function
    ○ skipped should return 200 response

Test Suites: 1 passed, 1 total
Tests:       3 skipped, 1 passed, 4 total
Snapshots:   0 total
Time:        3.134 s, estimated 4 s
Ran all test suites with tests matching "JS Driver on Netlify Function".
 ✨  Done in 4.11s.
```

#### Vercel
Need to follow up - build is in vercel
#### Cloudflare
```
 PASS  __tests__/js-driver.test.ts
  JS Driver on Cloudflare Worker
    ✓ should return 200 response (333 ms)
  JS Driver on AWS Lambda
    ○ skipped should return 200 response
  JS Driver on Netlify Function
    ○ skipped should return 200 response
  JS Driver on Vercel Function
    ○ skipped should return 200 response

Test Suites: 1 passed, 1 total
Tests:       3 skipped, 1 passed, 4 total
Snapshots:   0 total
Time:        2.617 s, estimated 3 s
Ran all test suites with tests matching "JS Driver on Cloudflare Worker".
 ✨  Done in 3.42s.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
