### PR TITLE
Update precommit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,8 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn build
-yarn lint
-yarn pretty-quick --staged
+if [[ `git status --porcelain -- '*.ts' 'package.json'` ]]; then
+  yarn build
+  yarn lint
+  yarn pretty-quick --staged
+fi


### PR DESCRIPTION
## Problem

Pre-commit hook runs yarn even when making changes that don't require it

## Solution

Only run the `yarn` commands when we make `*.ts` or `package.json` changes

## Result

Pre-commit hook is less annoying

## Out of scope

## Testing

Locally validated

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
