### PR TITLE
Close with reference counting to protect the global node http2 client

### DIFF
--- a/__tests__/client.ts
+++ b/__tests__/client.ts
@@ -6,10 +6,7 @@ export const getClient = (
   config?: Partial<ClientConfiguration>,
   httpClient?: HTTPClient
 ) => {
-  const secret = process.env["FAUNA_SECRET"] ?? "secret";
-  const endpoint = process.env["FAUNA_ENDPOINT"]
-    ? new URL(process.env["FAUNA_ENDPOINT"])
-    : endpoints.local;
+  const { secret, endpoint } = getDefaultSecretAndEndpoint();
   return new Client(
     {
       secret,
@@ -19,3 +16,11 @@ export const getClient = (
     httpClient
   );
 };
+
+export function getDefaultSecretAndEndpoint() {
+  const secret = process.env["FAUNA_SECRET"] ?? "secret";
+  const endpoint = process.env["FAUNA_ENDPOINT"]
+    ? new URL(process.env["FAUNA_ENDPOINT"])
+    : endpoints.local;
+  return { secret, endpoint };
+}

--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -21,8 +21,6 @@ describe("ClientConfiguration", () => {
   });
 
   it("Client respectes passed in client configuration over defaults", () => {
-    process.env["FAUNA_SECRET"] = "foo";
-    const client = new Client({ secret: "bar", query_timeout_ms: 10 });
     // TODO: when the Client accepts an http client add a mock that validates
     //   the configuration changes were applied.
   });
@@ -59,6 +57,7 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
     const result = await client.query<number>(fql`"taco".length`);
     expect(result.data).toEqual(4);
     expect(result.txn_ts).toBeDefined();
+    client.close();
   });
 
   it("client allows txn time to be set", async () => {
@@ -73,6 +72,7 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
     // setting to the past keeps the more recent ts.
     client.lastTxnTs = expectedTxnTime;
     expect(client.lastTxnTs).toBe(addFiveMinutes);
+    client.close();
   });
 
   type HeaderTestInput = {
@@ -105,6 +105,8 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
           );
           return getDefaultHTTPClient().request(req);
         },
+
+        close() {},
       };
 
       const client = getClient(
@@ -126,6 +128,8 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
         expect(req.url).toBe("http://localhost:8443/query/1");
         return getDefaultHTTPClient().request(req);
       },
+
+      close() {},
     };
 
     const client1 = getClient(

--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -14,6 +14,8 @@ describe("last_txn_ts tracking in client", () => {
         }
         return getDefaultHTTPClient().request(req);
       },
+
+      close() {},
     };
 
     const myClient = getClient(
@@ -60,6 +62,8 @@ describe("last_txn_ts tracking in client", () => {
         }
         return getDefaultHTTPClient().request(req);
       },
+
+      close() {},
     };
 
     const myClient = getClient(

--- a/__tests__/integration/doc.test.ts
+++ b/__tests__/integration/doc.test.ts
@@ -17,6 +17,10 @@ const client = getClient({
 
 let testDoc: Document;
 
+afterAll(() => {
+  client.close();
+});
+
 describe("querying for doc types", () => {
   beforeAll(async () => {
     await client.query(fql`

--- a/__tests__/integration/existing-collection.test.ts
+++ b/__tests__/integration/existing-collection.test.ts
@@ -32,6 +32,10 @@ const authorsData = [
   },
 ];
 
+afterAll(() => {
+  client.close();
+});
+
 beforeAll(async () => {
   /**
    * The intent of these tests is to run against an already existing collection and so

--- a/__tests__/integration/page.test.ts
+++ b/__tests__/integration/page.test.ts
@@ -7,20 +7,11 @@ const client = getClient({
   query_timeout_ms: 60_000,
 });
 
-let testDoc: Document;
+afterAll(() => {
+  client.close();
+});
 
 describe("querying for set", () => {
-  beforeAll(async () => {
-    await client.query(fql`
-      if (Collection.byName("DocTest") == null) {
-        Collection.create({ name: "DocTest" })
-      }
-    `);
-
-    const result = await client.query<Document>(fql`DocTest.create({})`);
-    testDoc = result.data;
-  });
-
   it("can round-trip Page", async () => {
     const set = new Page<number>({ data: [1, 2, 3], after: "1234" });
 

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -38,6 +38,10 @@ const dummyResponse: HTTPResponse = {
   status: 200,
 };
 
+afterAll(() => {
+  client.close();
+});
+
 describe("query", () => {
   it("Can query an FQL-x endpoint", async () => {
     const result = await client.query<number>(fql`"taco".length`);
@@ -117,6 +121,7 @@ describe("query", () => {
           });
           return dummyResponse;
         },
+        close() {},
       };
       const clientConfiguration: Partial<ClientConfiguration> = {
         format: "tagged",
@@ -256,6 +261,7 @@ describe("query", () => {
       async request(req) {
         throw new Error("boom!");
       },
+      close() {},
     };
     const badClient = getClient(
       {
@@ -266,7 +272,7 @@ describe("query", () => {
     );
     try {
       await badClient.query<number>(fql`foo`);
-    } catch (e) {
+    } catch (e: any) {
       if (e instanceof ClientError) {
         expect(e.cause).toBeDefined();
         expect(e.message).toEqual(

--- a/__tests__/integration/template-format.test.ts
+++ b/__tests__/integration/template-format.test.ts
@@ -6,6 +6,10 @@ const client = getClient({
   query_timeout_ms: 60_000,
 });
 
+afterAll(() => {
+  client.close();
+});
+
 describe("query using template format", () => {
   it("succeeds with no arguments", async () => {
     const queryBuilder = fql`"hello world"`;

--- a/__tests__/unit/client.test.ts
+++ b/__tests__/unit/client.test.ts
@@ -1,0 +1,20 @@
+import { getClient } from "../client";
+import { fql } from "../../src/query-builder";
+import { ClientClosedError } from "../../src/errors";
+
+describe("Client", () => {
+  it("Refuses further rquests after close", async () => {
+    expect.assertions(1);
+    const client = getClient();
+    client.close();
+    try {
+      await client.query(fql`'nah'`);
+    } catch (e) {
+      if (e instanceof ClientClosedError) {
+        expect(e.message).toEqual(
+          "Your client is closed. No further requests can be issued."
+        );
+      }
+    }
+  });
+});

--- a/__tests__/unit/fetch-client.test.ts
+++ b/__tests__/unit/fetch-client.test.ts
@@ -1,4 +1,6 @@
 import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
+import { Client } from "../../src/client";
+import { endpoints } from "../../src/client-configuration";
 enableFetchMocks();
 
 import { NetworkError } from "../../src/errors";
@@ -8,6 +10,7 @@ import {
   HTTPResponse,
   isHTTPResponse,
 } from "../../src/http-client";
+import { fql } from "../../src/query-builder";
 import { QueryFailure, QuerySuccess } from "../../src/wire-protocol";
 
 let fetchClient: FetchClient;
@@ -32,6 +35,10 @@ const dummyStats = {
 describe("fetch client", () => {
   beforeAll(() => {
     fetchClient = new FetchClient();
+  });
+
+  afterAll(() => {
+    fetchClient.close();
   });
 
   beforeEach(() => {

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -14,6 +14,10 @@ import {
 import { FetchClient } from "../../src/http-client";
 import { fql } from "../../src/query-builder";
 
+afterAll(() => {
+  client.close();
+});
+
 const client = getClient(
   {
     max_conns: 5,

--- a/src/client.ts
+++ b/src/client.ts
@@ -118,7 +118,7 @@ export class Client {
   }
 
   /**
-   * Closes the underlying HTTP client. Subsquent query calls
+   * Closes the underlying HTTP client. Subsquent query or close calls
    * will fail.
    */
   close() {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -202,6 +202,20 @@ export class ClientError extends FaunaError {
 }
 
 /**
+ * An error thrown if you try to call the client after it has been closed.
+ */
+export class ClientClosedError extends FaunaError {
+  constructor(message: string, options?: { cause: any }) {
+    super(message, options);
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ClientClosedError);
+    }
+    this.name = "ClientClosedError";
+  }
+}
+
+/**
  * An error representing a failure due to the network.
  * This indicates Fauna was never reached.
  */

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -40,4 +40,9 @@ export class FetchClient implements HTTPClient {
       headers: responseHeaders,
     };
   }
+
+  /** {@inheritDoc HTTPClient.close} */
+  close() {
+    // no actions at this time
+  }
 }

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -43,7 +43,7 @@ export interface HTTPClient {
 
   /**
    * Flags the calling {@link Client} as no longer
-   * referencing this HTTPClient. Once no processes reference this client
+   * referencing this HTTPClient. Once no {@link Client} instances reference this HTTPClient
    * the underlying resources will be closed.
    * It is expected that calls to this method are _only_ made by a {@link Client}
    * instantiation. The behavior of direct calls is undefined.

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -42,8 +42,14 @@ export interface HTTPClient {
   request(req: HTTPRequest): Promise<HTTPResponse>;
 
   /**
-   * Closes the HTTPClient. Subsequent requests will
-   * fail.
+   * Flags the calling {@link Client} as no longer
+   * referencing this HTTPClient. Once no processes reference this client
+   * the underlying resources will be closed.
+   * It is expected that calls to this method are _only_ made by a {@link Client}
+   * instantiation. The behavior of direct calls is undefined.
+   * @remarks
+   * For some HTTPClients, such as the {@link FetchClient}, this method
+   * is a no-op as there is no shared resource to close.
    */
   close(): void;
 }

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -40,6 +40,12 @@ export interface HTTPClient {
    * @returns A Promise&lt;{@link HTTPResponse}&gt;
    */
   request(req: HTTPRequest): Promise<HTTPResponse>;
+
+  /**
+   * Closes the HTTPClient. Subsequent requests will
+   * fail.
+   */
+  close(): void;
 }
 
 export const getDefaultHTTPClient = () =>

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -61,7 +61,6 @@ export class NodeHTTP2Client implements HTTPClient {
     }
     this.#numberOfUsers--;
     if (this.#numberOfUsers === 0) {
-      this.#numberOfUsers = 0;
       for (const sessionWrapper of this.#sessionMap.values()) {
         sessionWrapper.close();
       }

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -55,11 +55,11 @@ export class NodeHTTP2Client implements HTTPClient {
 
   /** {@inheritDoc HTTPClient.close} */
   close() {
+    // defend against redundant close calls
     if (this.isClosed()) {
       return;
     }
     this.#numberOfUsers--;
-    // defend against redundant close calls
     if (this.#numberOfUsers === 0) {
       this.#numberOfUsers = 0;
       for (const sessionWrapper of this.#sessionMap.values()) {


### PR DESCRIPTION
## Problem
- customers need a way to close their clients

## Solution
- expose a close method
- for the shared HTTP/2 client in node use reference counting to only close when no more processes are using the global http2 connection.
## Result
- close available to users

## Testing

- full suite
- added tests to show we're tracking references, can recreate on global pool after all are closed.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
