### PR TITLE
Extend Error type to include an `abort` field

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -142,7 +142,7 @@ describe("query", () => {
   it("throws a QueryCheckError if the query is invalid", async () => {
     expect.assertions(4);
     try {
-      await client.query<number>(fql`happy little fox`);
+      await client.query(fql`happy little fox`);
     } catch (e) {
       if (e instanceof QueryCheckError) {
         expect(e.httpStatus).toEqual(400);
@@ -156,7 +156,7 @@ describe("query", () => {
   it("throws a QueryRuntimeError if the query hits a runtime error", async () => {
     expect.assertions(3);
     try {
-      await client.query<number>(fql`"taco".length + "taco"`);
+      await client.query(fql`"taco".length + "taco"`);
     } catch (e) {
       if (e instanceof QueryRuntimeError) {
         expect(e.httpStatus).toEqual(400);
@@ -169,7 +169,7 @@ describe("query", () => {
   it("Includes constraint failures when present", async () => {
     expect.assertions(6);
     try {
-      await client.query<number>(
+      await client.query(
         fql`Function.create({"name": "double", "body": "x => x * 2"})`
       );
     } catch (e) {
@@ -211,7 +211,7 @@ describe("query", () => {
       query_timeout_ms: 1,
     });
     try {
-      await badClient.query<number>(fql`Collection.create({ name: 'Wah' })`);
+      await badClient.query(fql`Collection.create({ name: 'Wah' })`);
     } catch (e) {
       if (e instanceof QueryTimeoutError) {
         expect(e.message).toEqual(
@@ -236,7 +236,7 @@ describe("query", () => {
       query_timeout_ms: 60,
     });
     try {
-      await badClient.query<number>(fql`Collection.create({ name: 'Wah' })`);
+      await badClient.query(fql`Collection.create({ name: 'Wah' })`);
     } catch (e) {
       if (e instanceof AuthenticationError) {
         expect(e.message).toBeDefined();
@@ -260,7 +260,7 @@ describe("query", () => {
       query_timeout_ms: 60,
     });
     try {
-      await badClient.query<number>(fql`"taco".length;`);
+      await badClient.query(fql`"taco".length;`);
     } catch (e) {
       if (e instanceof NetworkError) {
         expect(e.message).toEqual(
@@ -287,7 +287,7 @@ describe("query", () => {
       httpClient
     );
     try {
-      await badClient.query<number>(fql`foo`);
+      await badClient.query(fql`foo`);
     } catch (e: any) {
       if (e instanceof ClientError) {
         expect(e.cause).toBeDefined();
@@ -307,7 +307,7 @@ describe("query", () => {
       query_timeout_ms: 60,
     });
     try {
-      await badClient.query<number>(fql`foo`);
+      await badClient.query(fql`foo`);
     } catch (e) {
       if (e instanceof ProtocolError) {
         expect(e.httpStatus).toBeGreaterThanOrEqual(400);

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -188,6 +188,22 @@ describe("query", () => {
     }
   });
 
+  it("Includes abort when present", async () => {
+    expect.assertions(4);
+    try {
+      await client.query(fql`abort("oops")`);
+    } catch (e) {
+      if (e instanceof ServiceError) {
+        expect(e.httpStatus).toEqual(400);
+        // WIP: core is changing the code from "aborted" to "abort"
+        // expect(e.code).toEqual("abort");
+        expect(e.code).toBeDefined();
+        expect(e.queryInfo?.summary).toBeDefined();
+        expect(e.abort).toBeDefined();
+      }
+    }
+  });
+
   it("throws a QueryTimeoutError if the query times out", async () => {
     expect.assertions(4);
     const badClient = getClient({

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,7 @@ import type {
   ConstraintFailure,
   QueryFailure,
   QueryInfo,
+  QueryValue,
 } from "./wire-protocol";
 
 /**
@@ -28,6 +29,12 @@ export class ServiceError extends FaunaError {
    */
   readonly code: string;
   /**
+   * The user provided value passed to the originating `abort()` call.
+   * Present only when the query encountered an `abort()` call, which is denoted
+   * by the error code `"abort"`
+   */
+  readonly abort?: QueryValue;
+  /**
    * Details about the query sent along with the response
    */
   readonly queryInfo?: QueryInfo;
@@ -47,6 +54,7 @@ export class ServiceError extends FaunaError {
 
     this.name = "ServiceError";
     this.code = failure.error.code;
+    this.abort = failure.error.abort;
     this.httpStatus = httpStatus;
 
     const info: QueryInfo = {

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -139,6 +139,12 @@ export type QueryFailure = QueryInfo & {
      * Present only if this query encountered constraint failures.
      */
     constraint_failures?: Array<ConstraintFailure>;
+    /**
+     * The user provided value passed to the originating `abort()` call.
+     * Present only when the query encountered an `abort()` call, which is
+     * denoted by the error code `"abort"`
+     */
+    abort?: QueryValue;
   };
 };
 


### PR DESCRIPTION
Ticket(s): [INT-329](https://faunadb.atlassian.net/browse/INT-329)

## Problem
Query failures due to calling the `abort()` FQL function contain an `abort` field, but that field is not saved to `ServiceError`.

## Solution
Save the `abort` field in `ServiceError` if provided.

## Out of scope
Core is changing the error code from "aborted" to "abort". I added a note in the test that we can be more specific once that is changed.

## Testing
Added a new test for abort.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
