### PR TITLE
Send x-format header by default

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -124,7 +124,6 @@ describe("query", () => {
         close() {},
       };
       const clientConfiguration: Partial<ClientConfiguration> = {
-        format: "tagged",
         max_conns: 5,
         query_timeout_ms: 60,
         linearized: true,

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -11,19 +11,18 @@ export interface ClientConfiguration {
   /**
    * Determines the encoded format expected for the query `arguments` field, and
    * the `data` field of a successful response.
-   * @remarks **Note, it is very unlikely you need to change this value from its default.**
-   * By default the driver transmits type information over the wire. Fauna also assumes type information is
-   * transmitted by default and thus leaving this value undefined will allow Fauna and the driver to send and
-   * receive type data.
-   *  Type information allows the driver and Fauna to distinguish between types such as int" and "long" which do not
+   * @remarks **Note, it is very unlikely you need to change this value from its
+   * default.**
+   * The default format is "tagged", which specifies that the driver transmits
+   * type information over the wire. Type information allows the driver and
+   * Fauna to distinguish between types such as int" and "long" which do not
    * have a standard way of distinguishing in JSON.
-   * Since Fauna assumes typed information is transmitted by default, clients can leave this value undefined to make
-   * full usage of Fauna's primitive types.
-   * You can also explicitly set this to "tagged" to get the typing data sent.
-   * Rare use cases can also deal with standard JSON by setting the value to "simple". Not that the types
-   * enocodable in standard JSON are a subset of the types encodable in the default "tagged" format.
-   * It is not recommended that users use the "simple" format as you will lose the typing of your data. e.g. a "Date"
-   * will no longer be recognized by the Fauna as a "Date", but will instead be treated as a string.
+   * Rare use cases can also deal with standard JSON by setting the value to
+   * "simple". Note that the types enocodable in standard JSON are a subset of
+   * the types encodable in the default "tagged" format.
+   * It is not recommended that users use the "simple" format as you will lose
+   * the typing of your data. e.g. a "Date" will no longer be recognized by the
+   * Fauna as a "Date", but will instead be treated as a string.
    */
   format: ValueFormat;
   /**

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -25,7 +25,7 @@ export interface ClientConfiguration {
    * It is not recommended that users use the "simple" format as you will lose the typing of your data. e.g. a "Date"
    * will no longer be recognized by the Fauna as a "Date", but will instead be treated as a string.
    */
-  format?: ValueFormat;
+  format: ValueFormat;
   /**
    * The maximum number of connections to a make to Fauna.
    */

--- a/src/client.ts
+++ b/src/client.ts
@@ -32,9 +32,10 @@ import { TaggedTypeFormat } from "./tagged-type";
 
 const defaultClientConfiguration: Pick<
   ClientConfiguration,
-  "endpoint" | "max_conns"
+  "endpoint" | "format" | "max_conns"
 > = {
   endpoint: endpoints.default,
+  format: "tagged",
   max_conns: 10,
 };
 
@@ -257,7 +258,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
       );
 
       const isTaggedFormat =
-        (this.#clientConfiguration.format ?? "tagged") === "tagged" ||
+        this.#clientConfiguration.format === "tagged" ||
         queryRequest.format === "tagged";
       const queryArgs = isTaggedFormat
         ? TaggedTypeFormat.encode(queryRequest.arguments)


### PR DESCRIPTION
Ticket(s): [FE-3396](https://faunadb.atlassian.net/browse/FE-3396)

## Problem
In order to make sure that we are providing the best driverless-experience, we need to make sure that drivers are setting the format header so that the default can be the most appropriate for direct API access

## Solution
Make `format` a required client configuration field. Provide a default format.

## Result
Since the client configuration will always have a format, the `x-format` header will always be sent

## Out of scope
N/A

## Testing
tweaked the headers test so that it uses the default client configuration for format (i.e. not explicitly set), so we now test the the header is sent by default.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3396]: https://faunadb.atlassian.net/browse/FE-3396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ