### PR TITLE
Add AbortError, InvalidRequestError, and ContendedTransactionError classes

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -47,7 +47,7 @@ describe("query", () => {
   it("Can query an FQL-x endpoint", async () => {
     const result = await client.query<number>(fql`"taco".length`);
 
-    expect(result.data).toEqual(4);
+    expect(result.data).toBe(4);
     expect(result.summary).toBeDefined();
     expect(result.txn_ts).toBeDefined();
     expect(result.stats).toBeDefined();
@@ -63,7 +63,7 @@ describe("query", () => {
   it("Can query with arguments", async () => {
     const str = "taco";
     const result = await client.query(fql`${str}.length`);
-    expect(result.data).toEqual(4);
+    expect(result.data).toBe(4);
     expect(result.txn_ts).toBeDefined();
   });
 
@@ -116,9 +116,7 @@ describe("query", () => {
       const httpClient: HTTPClient = {
         async request(req) {
           Object.entries(expectedHeaders).forEach(([_, expectedHeader]) => {
-            expect(req.headers[expectedHeader.key]).toEqual(
-              expectedHeader.value
-            );
+            expect(req.headers[expectedHeader.key]).toBe(expectedHeader.value);
           });
           return dummyResponse;
         },
@@ -145,7 +143,7 @@ describe("query", () => {
       await client.query(fql`happy little fox`);
     } catch (e) {
       if (e instanceof QueryCheckError) {
-        expect(e.httpStatus).toEqual(400);
+        expect(e.httpStatus).toBe(400);
         expect(e.message).toBeDefined();
         expect(e.code).toBeDefined();
         expect(e.queryInfo?.summary).toBeDefined();
@@ -159,8 +157,8 @@ describe("query", () => {
       await client.query(fql`"taco".length + "taco"`);
     } catch (e) {
       if (e instanceof QueryRuntimeError) {
-        expect(e.httpStatus).toEqual(400);
-        expect(e.code).toEqual("invalid_argument");
+        expect(e.httpStatus).toBe(400);
+        expect(e.code).toBe("invalid_argument");
         expect(e.queryInfo?.summary).toBeDefined();
       }
     }
@@ -174,11 +172,11 @@ describe("query", () => {
       );
     } catch (e) {
       if (e instanceof ServiceError) {
-        expect(e.httpStatus).toEqual(400);
-        expect(e.code).toEqual("constraint_failure");
+        expect(e.httpStatus).toBe(400);
+        expect(e.code).toBe("constraint_failure");
         expect(e.queryInfo?.summary).toBeDefined();
         if (e.constraint_failures !== undefined) {
-          expect(e.constraint_failures.length).toEqual(1);
+          expect(e.constraint_failures.length).toBe(1);
           for (let constraintFailure of e.constraint_failures) {
             expect(constraintFailure.message).toBeDefined();
             expect(constraintFailure.paths).toBeDefined();
@@ -194,10 +192,10 @@ describe("query", () => {
       await client.query(fql`abort("oops")`);
     } catch (e) {
       if (e instanceof QueryAbortError) {
-        expect(e.httpStatus).toEqual(400);
-        expect(e.code).toEqual("abort");
+        expect(e.httpStatus).toBe(400);
+        expect(e.code).toBe("abort");
         expect(e.queryInfo?.summary).toBeDefined();
-        expect(e.abort).toEqual("oops");
+        expect(e.abort).toBe("oops");
       }
     }
   });
@@ -215,8 +213,8 @@ describe("query", () => {
         expect(e.message).toEqual(
           expect.stringContaining("aggressive deadline")
         );
-        expect(e.httpStatus).toEqual(440);
-        expect(e.code).toEqual("time_out");
+        expect(e.httpStatus).toBe(440);
+        expect(e.code).toBe("time_out");
       }
     }
 
@@ -238,8 +236,8 @@ describe("query", () => {
     } catch (e) {
       if (e instanceof AuthenticationError) {
         expect(e.message).toBeDefined();
-        expect(e.code).toEqual("unauthorized");
-        expect(e.httpStatus).toEqual(401);
+        expect(e.code).toBe("unauthorized");
+        expect(e.httpStatus).toBe(401);
         expect(e.queryInfo?.summary).toBeUndefined();
       }
     }
@@ -261,9 +259,7 @@ describe("query", () => {
       await badClient.query(fql`"taco".length;`);
     } catch (e) {
       if (e instanceof NetworkError) {
-        expect(e.message).toEqual(
-          "The network connection encountered a problem."
-        );
+        expect(e.message).toBe("The network connection encountered a problem.");
         expect(e.cause).toBeDefined();
       }
     }
@@ -289,7 +285,7 @@ describe("query", () => {
     } catch (e: any) {
       if (e instanceof ClientError) {
         expect(e.cause).toBeDefined();
-        expect(e.message).toEqual(
+        expect(e.message).toBe(
           "A client level error occurred. Fauna was not called."
         );
       }
@@ -337,8 +333,8 @@ describe("query can encode / decode QueryValue correctly", () => {
         ${new Module(collectionName)}.create(${toughInput})`);
     expect(docCreated.data.should_exist).toBeUndefined();
     expect(docCreated.data.nested_object.i_dont_exist).toBeUndefined();
-    expect(docCreated.data.foo).toEqual("bar");
-    expect(docCreated.data.nested_object.i_exist).toEqual(true);
+    expect(docCreated.data.foo).toBe("bar");
+    expect(docCreated.data.nested_object.i_exist).toBe(true);
   });
 
   it("treats undefined as unprovided passed directly as value", async () => {
@@ -364,8 +360,8 @@ describe("query can encode / decode QueryValue correctly", () => {
         })`);
     } catch (e) {
       if (e instanceof TypeError) {
-        expect(e.name).toEqual("TypeError");
-        expect(e.message).toEqual(
+        expect(e.name).toBe("TypeError");
+        expect(e.message).toBe(
           "Passing undefined as a QueryValue is not supported"
         );
       }

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -5,6 +5,7 @@ import {
   ClientError,
   NetworkError,
   ProtocolError,
+  QueryAbortError,
   QueryCheckError,
   QueryRuntimeError,
   QueryTimeoutError,
@@ -187,18 +188,16 @@ describe("query", () => {
     }
   });
 
-  it("Includes abort when present", async () => {
+  it("throws a QueryAbortError is the `abort` function is called", async () => {
     expect.assertions(4);
     try {
       await client.query(fql`abort("oops")`);
     } catch (e) {
-      if (e instanceof ServiceError) {
+      if (e instanceof QueryAbortError) {
         expect(e.httpStatus).toEqual(400);
-        // WIP: core is changing the code from "aborted" to "abort"
-        // expect(e.code).toEqual("abort");
-        expect(e.code).toBeDefined();
+        expect(e.code).toEqual("abort");
         expect(e.queryInfo?.summary).toBeDefined();
-        expect(e.abort).toBeDefined();
+        expect(e.abort).toEqual("oops");
       }
     }
   });

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -5,7 +5,7 @@ import {
   ClientError,
   NetworkError,
   ProtocolError,
-  QueryAbortError,
+  AbortError,
   QueryCheckError,
   QueryRuntimeError,
   QueryTimeoutError,
@@ -186,12 +186,12 @@ describe("query", () => {
     }
   });
 
-  it("throws a QueryAbortError is the `abort` function is called", async () => {
+  it("throws a AbortError is the `abort` function is called", async () => {
     expect.assertions(4);
     try {
       await client.query(fql`abort("oops")`);
     } catch (e) {
-      if (e instanceof QueryAbortError) {
+      if (e instanceof AbortError) {
         expect(e.httpStatus).toBe(400);
         expect(e.code).toBe("abort");
         expect(e.queryInfo?.summary).toBeDefined();

--- a/src/client.ts
+++ b/src/client.ts
@@ -227,34 +227,35 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
     switch (httpStatus) {
       case 400:
         if (queryCheckFailureCodes.includes(failure.error.code)) {
-          return new QueryCheckError(failure);
+          return new QueryCheckError(failure, httpStatus);
         }
         if (failure.error.code === "invalid_request") {
-          return new InvalidRequestError(failure);
+          return new InvalidRequestError(failure, httpStatus);
         }
         if (
           failure.error.code === "abort" &&
           failure.error.abort !== undefined
         ) {
           return new AbortError(
-            failure as QueryFailure & { error: { abort: QueryValue } }
+            failure as QueryFailure & { error: { abort: QueryValue } },
+            httpStatus
           );
         }
-        return new QueryRuntimeError(failure);
+        return new QueryRuntimeError(failure, httpStatus);
       case 401:
-        return new AuthenticationError(failure);
+        return new AuthenticationError(failure, httpStatus);
       case 403:
-        return new AuthorizationError(failure);
+        return new AuthorizationError(failure, httpStatus);
       case 409:
-        return new ContendedTransactionError(failure);
+        return new ContendedTransactionError(failure, httpStatus);
       case 429:
-        return new ThrottlingError(failure);
+        return new ThrottlingError(failure, httpStatus);
       case 440:
-        return new QueryTimeoutError(failure);
+        return new QueryTimeoutError(failure, httpStatus);
       case 500:
-        return new ServiceInternalError(failure);
+        return new ServiceInternalError(failure, httpStatus);
       case 503:
-        return new ServiceTimeoutError(failure);
+        return new ServiceTimeoutError(failure, httpStatus);
       default:
         return new ServiceError(failure, httpStatus);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -6,7 +6,7 @@ import {
   ClientError,
   NetworkError,
   ProtocolError,
-  QueryAbortError,
+  AbortError,
   QueryCheckError,
   QueryRuntimeError,
   QueryTimeoutError,
@@ -231,7 +231,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
           failure.error.code === "abort" &&
           failure.error.abort !== undefined
         ) {
-          return new QueryAbortError(
+          return new AbortError(
             failure as QueryFailure & { error: { abort: QueryValue } }
           );
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,6 +14,8 @@ import {
   ServiceInternalError,
   ServiceTimeoutError,
   ThrottlingError,
+  ContendedTransactionError,
+  InvalidRequestError,
 } from "./errors";
 import type { Query } from "./query-builder";
 import {
@@ -227,6 +229,9 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
         if (queryCheckFailureCodes.includes(failure.error.code)) {
           return new QueryCheckError(failure);
         }
+        if (failure.error.code === "invalid_request") {
+          return new InvalidRequestError(failure);
+        }
         if (
           failure.error.code === "abort" &&
           failure.error.abort !== undefined
@@ -240,6 +245,8 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
         return new AuthenticationError(failure);
       case 403:
         return new AuthorizationError(failure);
+      case 409:
+        return new ContendedTransactionError(failure);
       case 429:
         return new ThrottlingError(failure);
       case 440:

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -71,8 +71,8 @@ export class ServiceError extends FaunaError {
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryRuntimeError extends ServiceError {
-  constructor(failure: QueryFailure) {
-    super(failure, 400);
+  constructor(failure: QueryFailure, httpStatus: 400) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryRuntimeError);
     }
@@ -89,8 +89,8 @@ export class QueryRuntimeError extends ServiceError {
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryCheckError extends ServiceError {
-  constructor(failure: QueryFailure) {
-    super(failure, 400);
+  constructor(failure: QueryFailure, httpStatus: 400) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryCheckError);
     }
@@ -105,8 +105,8 @@ export class QueryCheckError extends ServiceError {
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class InvalidRequestError extends ServiceError {
-  constructor(failure: QueryFailure) {
-    super(failure, 400);
+  constructor(failure: QueryFailure, httpStatus: 400) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InvalidRequestError);
     }
@@ -127,8 +127,11 @@ export class AbortError extends ServiceError {
    */
   readonly abort: QueryValue;
 
-  constructor(failure: QueryFailure & { error: { abort: QueryValue } }) {
-    super(failure, 400);
+  constructor(
+    failure: QueryFailure & { error: { abort: QueryValue } },
+    httpStatus: 400
+  ) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryCheckError);
     }
@@ -142,8 +145,8 @@ export class AbortError extends ServiceError {
  * used.
  */
 export class AuthenticationError extends ServiceError {
-  constructor(failure: QueryFailure) {
-    super(failure, 401);
+  constructor(failure: QueryFailure, httpStatus: 401) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AuthenticationError);
     }
@@ -156,8 +159,8 @@ export class AuthenticationError extends ServiceError {
  * permission to perform the requested action.
  */
 export class AuthorizationError extends ServiceError {
-  constructor(failure: QueryFailure) {
-    super(failure, 403);
+  constructor(failure: QueryFailure, httpStatus: 403) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AuthorizationError);
     }
@@ -169,8 +172,8 @@ export class AuthorizationError extends ServiceError {
  * An error due to a contended transaction.
  */
 export class ContendedTransactionError extends ServiceError {
-  constructor(failure: QueryFailure) {
-    super(failure, 409);
+  constructor(failure: QueryFailure, httpStatus: 409) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InvalidRequestError);
     }
@@ -183,8 +186,8 @@ export class ContendedTransactionError extends ServiceError {
  * and thus the request could not be served.
  */
 export class ThrottlingError extends ServiceError {
-  constructor(failure: QueryFailure) {
-    super(failure, 429);
+  constructor(failure: QueryFailure, httpStatus: 429) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ThrottlingError);
     }
@@ -205,8 +208,8 @@ export class QueryTimeoutError extends ServiceError {
    */
   readonly stats?: { [key: string]: number };
 
-  constructor(failure: QueryFailure) {
-    super(failure, 440);
+  constructor(failure: QueryFailure, httpStatus: 440) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryTimeoutError);
     }
@@ -219,8 +222,8 @@ export class QueryTimeoutError extends ServiceError {
  * ServiceInternalError indicates Fauna failed unexpectedly.
  */
 export class ServiceInternalError extends ServiceError {
-  constructor(failure: QueryFailure) {
-    super(failure, 500);
+  constructor(failure: QueryFailure, httpStatus: 500) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ServiceInternalError);
     }
@@ -233,8 +236,8 @@ export class ServiceInternalError extends ServiceError {
  * the request before the timeout was reached.
  */
 export class ServiceTimeoutError extends ServiceError {
-  constructor(failure: QueryFailure) {
-    super(failure, 503);
+  constructor(failure: QueryFailure, httpStatus: 503) {
+    super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ServiceTimeoutError);
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -111,7 +111,7 @@ export class QueryAbortError extends ServiceError {
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryCheckError);
     }
-    this.name = "QueryCheckError";
+    this.name = "QueryAbortError";
     this.abort = failure.error.abort;
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -29,12 +29,6 @@ export class ServiceError extends FaunaError {
    */
   readonly code: string;
   /**
-   * The user provided value passed to the originating `abort()` call.
-   * Present only when the query encountered an `abort()` call, which is denoted
-   * by the error code `"abort"`
-   */
-  readonly abort?: QueryValue;
-  /**
    * Details about the query sent along with the response
    */
   readonly queryInfo?: QueryInfo;
@@ -54,7 +48,6 @@ export class ServiceError extends FaunaError {
 
     this.name = "ServiceError";
     this.code = failure.error.code;
-    this.abort = failure.error.abort;
     this.httpStatus = httpStatus;
 
     const info: QueryInfo = {
@@ -76,8 +69,8 @@ export class ServiceError extends FaunaError {
  * The 'code' field will vary based on the specific error cause.
  */
 export class QueryRuntimeError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 400) {
-    super(failure, httpStatus);
+  constructor(failure: QueryFailure) {
+    super(failure, 400);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryRuntimeError);
     }
@@ -92,12 +85,34 @@ export class QueryRuntimeError extends ServiceError {
  * failing.
  */
 export class QueryCheckError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 400) {
-    super(failure, httpStatus);
+  constructor(failure: QueryFailure) {
+    super(failure, 400);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryCheckError);
     }
     this.name = "QueryCheckError";
+  }
+}
+
+/**
+ * An error due to a "compile-time" check of the query
+ * failing.
+ */
+export class QueryAbortError extends ServiceError {
+  /**
+   * The user provided value passed to the originating `abort()` call.
+   * Present only when the query encountered an `abort()` call, which is denoted
+   * by the error code `"abort"`
+   */
+  readonly abort: QueryValue;
+
+  constructor(failure: QueryFailure & { error: { abort: QueryValue } }) {
+    super(failure, 400);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, QueryCheckError);
+    }
+    this.name = "QueryCheckError";
+    this.abort = failure.error.abort;
   }
 }
 
@@ -114,8 +129,8 @@ export class QueryTimeoutError extends ServiceError {
    */
   readonly stats?: { [key: string]: number };
 
-  constructor(failure: QueryFailure, httpStatus: 440) {
-    super(failure, httpStatus);
+  constructor(failure: QueryFailure) {
+    super(failure, 440);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryTimeoutError);
     }
@@ -129,8 +144,8 @@ export class QueryTimeoutError extends ServiceError {
  * used.
  */
 export class AuthenticationError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 401) {
-    super(failure, httpStatus);
+  constructor(failure: QueryFailure) {
+    super(failure, 401);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AuthenticationError);
     }
@@ -143,8 +158,8 @@ export class AuthenticationError extends ServiceError {
  * permission to perform the requested action.
  */
 export class AuthorizationError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 403) {
-    super(failure, httpStatus);
+  constructor(failure: QueryFailure) {
+    super(failure, 403);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AuthorizationError);
     }
@@ -157,8 +172,8 @@ export class AuthorizationError extends ServiceError {
  * and thus the request could not be served.
  */
 export class ThrottlingError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 429) {
-    super(failure, httpStatus);
+  constructor(failure: QueryFailure) {
+    super(failure, 429);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ThrottlingError);
     }
@@ -170,8 +185,8 @@ export class ThrottlingError extends ServiceError {
  * ServiceInternalError indicates Fauna failed unexpectedly.
  */
 export class ServiceInternalError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 500) {
-    super(failure, httpStatus);
+  constructor(failure: QueryFailure) {
+    super(failure, 500);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ServiceInternalError);
     }
@@ -184,8 +199,8 @@ export class ServiceInternalError extends ServiceError {
  * the request before the timeout was reached.
  */
 export class ServiceTimeoutError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 503) {
-    super(failure, httpStatus);
+  constructor(failure: QueryFailure) {
+    super(failure, 503);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ServiceTimeoutError);
     }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -99,6 +99,22 @@ export class QueryCheckError extends ServiceError {
 }
 
 /**
+ * An error due to an invalid request to Fauna. Either the request body was not
+ * valid JSON or did not conform to the API specification
+ *
+ * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
+ */
+export class InvalidRequestError extends ServiceError {
+  constructor(failure: QueryFailure) {
+    super(failure, 400);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InvalidRequestError);
+    }
+    this.name = "InvalidRequestError";
+  }
+}
+
+/**
  * An error due to calling the FQL `abort` function.
  *
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
@@ -118,29 +134,6 @@ export class AbortError extends ServiceError {
     }
     this.name = "AbortError";
     this.abort = failure.error.abort;
-  }
-}
-
-/**
- * A failure due to the timeout being exceeded, but the timeout
- * was set lower than the query's expected processing time.
- * This response is distinguished from a ServiceTimeoutException
- * in that a QueryTimeoutError shows Fauna behaving in an expected
- * manner.
- */
-export class QueryTimeoutError extends ServiceError {
-  /**
-   * Statistics regarding the query.
-   */
-  readonly stats?: { [key: string]: number };
-
-  constructor(failure: QueryFailure) {
-    super(failure, 440);
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, QueryTimeoutError);
-    }
-    this.name = "QueryTimeoutError";
-    this.stats = failure.stats;
   }
 }
 
@@ -173,6 +166,19 @@ export class AuthorizationError extends ServiceError {
 }
 
 /**
+ * An error due to a contended transaction.
+ */
+export class ContendedTransactionError extends ServiceError {
+  constructor(failure: QueryFailure) {
+    super(failure, 409);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, InvalidRequestError);
+    }
+    this.name = "ContendedTransactionError";
+  }
+}
+
+/**
  * ThrottlingError indicates some capacity limit was exceeded
  * and thus the request could not be served.
  */
@@ -183,6 +189,29 @@ export class ThrottlingError extends ServiceError {
       Error.captureStackTrace(this, ThrottlingError);
     }
     this.name = "ThrottlingError";
+  }
+}
+
+/**
+ * A failure due to the timeout being exceeded, but the timeout
+ * was set lower than the query's expected processing time.
+ * This response is distinguished from a ServiceTimeoutException
+ * in that a QueryTimeoutError shows Fauna behaving in an expected
+ * manner.
+ */
+export class QueryTimeoutError extends ServiceError {
+  /**
+   * Statistics regarding the query.
+   */
+  readonly stats?: { [key: string]: number };
+
+  constructor(failure: QueryFailure) {
+    super(failure, 440);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, QueryTimeoutError);
+    }
+    this.name = "QueryTimeoutError";
+    this.stats = failure.stats;
   }
 }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -67,6 +67,8 @@ export class ServiceError extends FaunaError {
  * QueryRuntimeError's occur when a bug in your query causes an invalid execution
  * to be requested.
  * The 'code' field will vary based on the specific error cause.
+ *
+ * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryRuntimeError extends ServiceError {
   constructor(failure: QueryFailure) {
@@ -83,6 +85,8 @@ export class QueryRuntimeError extends ServiceError {
 /**
  * An error due to a "compile-time" check of the query
  * failing.
+ *
+ * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryCheckError extends ServiceError {
   constructor(failure: QueryFailure) {
@@ -95,10 +99,11 @@ export class QueryCheckError extends ServiceError {
 }
 
 /**
- * An error due to a "compile-time" check of the query
- * failing.
+ * An error due to calling the FQL `abort` function.
+ *
+ * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
-export class QueryAbortError extends ServiceError {
+export class AbortError extends ServiceError {
   /**
    * The user provided value passed to the originating `abort()` call.
    * Present only when the query encountered an `abort()` call, which is denoted
@@ -111,7 +116,7 @@ export class QueryAbortError extends ServiceError {
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryCheckError);
     }
-    this.name = "QueryAbortError";
+    this.name = "AbortError";
     this.abort = failure.error.abort;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,12 @@ export {
   endpoints,
 } from "./client-configuration";
 export {
+  AbortError,
   AuthenticationError,
   AuthorizationError,
   ClientError,
+  ContendedTransactionError,
+  InvalidRequestError,
   NetworkError,
   ProtocolError,
   QueryCheckError,


### PR DESCRIPTION
Ticket(s): 
- [FE-3388](https://faunadb.atlassian.net/browse/FE-3388)
- [FE-3402](https://faunadb.atlassian.net/browse/FE-3402)

## Problem
We should distinguish between 400 errors from invalid reuqests, calling `abort`, and those from other issues, so users can more easily handle them.

We've not added an error for 409 errors yet.

## Solution
Create a AbortError class and throw it if a 400 error has the code "abort".
Create an InvalidRequestError class and throw it if a 400 error has the code "invalid_request".
Create a ContendedTransactionError class and throw it on a 409 response.

Also included a nit about using `expect.toBe` instead of `expect.toEqual` which is more for asserting the values of objects.

## Out of scope
n/a

## Testing
Core updated the wire protocol, so we can now also test that the code coming back is "abort" and not "aborted".

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3388]: https://faunadb.atlassian.net/browse/FE-3388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FE-3402]: https://faunadb.atlassian.net/browse/FE-3402?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ