### PR TITLE
Support nulldoc

### DIFF
--- a/__tests__/integration/doc.test.ts
+++ b/__tests__/integration/doc.test.ts
@@ -8,6 +8,7 @@ import {
   NamedDocument,
   NamedDocumentReference,
   TimeStub,
+  NullDocument,
 } from "../../src/values";
 
 const client = getClient({
@@ -49,16 +50,19 @@ describe("querying for doc types", () => {
   });
 
   it("can round-trip DocumentReference to a non-existent doc", async () => {
+    expect.assertions(4);
     const mod = new Module("DocTest");
     const ref = new DocumentReference({ id: "101", coll: mod });
 
     const queryBuilder = fql`${ref}`;
-    const result = await client.query<DocumentReference>(queryBuilder);
+    const result = await client.query<NullDocument>(queryBuilder);
 
-    expect(result.data).toBeInstanceOf(DocumentReference);
-    expect(result.data).not.toBeInstanceOf(Document);
-    expect(result.data.id).toBe("101");
-    expect(result.data.coll.name).toBe("DocTest");
+    expect(result.data).toBeInstanceOf(NullDocument);
+    expect(result.data.cause).toBe("not found");
+    if (result.data.ref instanceof DocumentReference) {
+      expect(result.data.ref.id).toBe("101");
+      expect(result.data.ref.coll.name).toBe("DocTest");
+    }
   });
 
   it("can round-trip DocumentReference to an existent doc", async () => {

--- a/__tests__/unit/doc.test.ts
+++ b/__tests__/unit/doc.test.ts
@@ -6,6 +6,7 @@ import {
   NamedDocument,
   NamedDocumentReference,
   TimeStub,
+  NullDocument,
 } from "../../src/values";
 
 describe("Module", () => {
@@ -92,5 +93,31 @@ describe("NamedDocument", () => {
     expect(doc.coll.name).toBe("Collection");
     expect(doc.ts.isoString).toBe("2023-10-16T00:00:00Z");
     expect(doc.data).toStrictEqual({ metadata: "metadata" });
+  });
+});
+
+describe("NullDocument", () => {
+  it("can be constructed directly with a DocumentReference", () => {
+    expect.assertions(3);
+    const mod = new Module("Thing");
+    const ref = new DocumentReference({ id: "101", coll: mod });
+    const nullDoc = new NullDocument(ref, "not found");
+    if (nullDoc.ref instanceof DocumentReference) {
+      expect(nullDoc.ref.id).toBe("101");
+      expect(nullDoc.ref.coll.name).toBe("Thing");
+    }
+    expect(nullDoc.cause).toBe("not found");
+  });
+
+  it("can be constructed directly with a NamedDocumentReference", () => {
+    expect.assertions(3);
+    const mod = new Module("Collection");
+    const ref = new NamedDocumentReference({ name: "Thing", coll: mod });
+    const nullDoc = new NullDocument(ref, "permission denied");
+    if (nullDoc.ref instanceof NamedDocumentReference) {
+      expect(nullDoc.ref.name).toBe("Thing");
+      expect(nullDoc.ref.coll.name).toBe("Collection");
+    }
+    expect(nullDoc.cause).toBe("permission denied");
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export {
   Module,
   NamedDocument,
   NamedDocumentReference,
+  NullDocument,
   Page,
   TimeStub,
 } from "./values";

--- a/src/values/doc.ts
+++ b/src/values/doc.ts
@@ -191,6 +191,42 @@ export class Module {
 }
 
 /**
+ * A reference to a Document or Named Document that could not be read. The
+ * Document may or may not exist in future queries. The cause field specifies
+ * the reason the document could not be read, typically because the Document
+ * does not exist or due to insufficient privileges.
+ *
+ * Some read operations, such as the `<Collection>.byId` method may return
+ * either a Document or a NullDocument. This example shows how to handle such a
+ * result with the driver
+ *
+ * @example
+ * ```typescript
+ *  const response = await client.query<Document | NullDocument>(fql`
+ *    Users.byId("101")
+ *  `);
+ *  const maybeUserDocument = response.data;
+ *
+ *  if (maybeUserDocument instanceof NullDocument) {
+ *    // handle NullDocument case
+ *    const cause = maybeUserDocument.cause
+ *  } else {
+ *    // handle Document case
+ *    const color = maybeUserDocument.color;
+ *  }
+ * ```
+ */
+export class NullDocument {
+  readonly ref: DocumentReference | NamedDocumentReference;
+  readonly cause: string;
+
+  constructor(ref: DocumentReference | NamedDocumentReference, cause: string) {
+    this.ref = ref;
+    this.cause = cause;
+  }
+}
+
+/**
  * A Document typed with a user-defined data type. Typescript users can cast
  * instances of {@link Document} to {@link DocumentT} to access user-defined fields with type safety.
  *

--- a/src/values/doc.ts
+++ b/src/values/doc.ts
@@ -11,9 +11,10 @@ import { TimeStub } from "./date-time";
  *
  * @example
  * ```javascript
- *  const userDocumentReference = await client.query(fql`
+ *  const response = await client.query(fql`
  *    Users.byId("101")
  *  `);
+ *  const userDocumentReference = response.data;
  *
  *  const id = userDocumentReference.id;
  *  id === "101"; // returns true
@@ -46,9 +47,10 @@ export class DocumentReference {
  *
  * @example
  * ```javascript
- *  const userDocument = await client.query(fql`
+ *  const response = await client.query(fql`
  *    Users.byId("101")
  *  `);
+ *  const userDocument = response.data;
  *
  *  const color = userDocument.color;
  * ```
@@ -86,9 +88,10 @@ export class Document extends DocumentReference {
  *
  * @example
  * ```javascript
- *  const namedDocumentReference = await client.query(fql`
+ *  const response = await client.query(fql`
  *    Users.definition
  *  `);
+ *  const namedDocumentReference = response.data;
  *
  *  const collectionName = namedDocumentReference.name;
  *  collectionName === "Users"; // returns true
@@ -118,9 +121,10 @@ export class NamedDocumentReference {
  *
  * @example
  * ```javascript
- *  const userCollectionNamedDocument = await client.query(fql`
+ *  const response = await client.query(fql`
  *    Users.definition
  *  `);
+ *  const userCollectionNamedDocument = response.data;
  *
  *  const indexes = userCollectionNamedDocument.indexes;
  * ```
@@ -133,9 +137,10 @@ export class NamedDocumentReference {
  *    metadata: string
  *  }
  *
- *  const userCollection = await client.query<NamedDocument<CollectionMetadata>>(fql`
+ *  const response = await client.query<NamedDocument<CollectionMetadata>>(fql`
  *    Users.definition
  *  `);
+ *  const userCollection = response.data;
  *
  *  const metadata = userCollection.data.metadata;
  * ```
@@ -176,10 +181,10 @@ export class NamedDocument<
  *
  * @example
  * ```javascript
- *  const allUserDocuments = await client.query(fql`
+ *  const response = await client.query(fql`
  *    ${new Module("Users")}.all()
  *  `);
- *
+ *  const allUserDocuments = response.data;
  * ```
  */
 export class Module {
@@ -239,9 +244,10 @@ export class NullDocument {
  *    color: string
  *  }
  *
- *  const user = await client.query<DocumentT<User>>(fql`
+ *  const response = await client.query<DocumentT<User>>(fql`
  *    Users.byId("101")
  *  `);
+ *  const user = response.data;
  *
  *  const color = user.color;
  * ```


### PR DESCRIPTION
Ticket(s): [FE-3211](https://faunadb.atlassian.net/browse/FE-3211)

## Problem
If a Document cannot be read, Fauna returns a Reference with `exists: false`. We need to handle that case.

## Solution
Add a `NullDocument` type to decode non-existing refs

## Result
Decodes non-existing refs to the new `NullDocument` type. `NullDocument`s are encoded as a reference when passed back to Fauna.

## Out of scope
n/a

## Testing
Added new tests for NullDocument. I also realized that we don't test the encoding/decoding for any of the document types, so added those as well.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3211]: https://faunadb.atlassian.net/browse/FE-3211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ