### PR TITLE
Import top level index.js in tests

### DIFF
--- a/__tests__/client.ts
+++ b/__tests__/client.ts
@@ -1,6 +1,4 @@
-import { Client } from "../src/client";
-import { ClientConfiguration, endpoints } from "../src/client-configuration";
-import { HTTPClient } from "../src/http-client";
+import { Client, ClientConfiguration, endpoints, HTTPClient } from "../src";
 
 export const getClient = (
   config?: Partial<ClientConfiguration>,

--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -1,8 +1,11 @@
+import {
+  Client,
+  endpoints,
+  fql,
+  getDefaultHTTPClient,
+  HTTPClient,
+} from "../../src";
 import { getClient } from "../client";
-import { Client } from "../../src/client";
-import { endpoints } from "../../src/client-configuration";
-import { HTTPClient, getDefaultHTTPClient } from "../../src/http-client";
-import { fql } from "../../src/query-builder";
 
 // save a copy
 const PROCESS_ENV = { ...process.env };

--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -1,6 +1,5 @@
+import { fql, getDefaultHTTPClient, HTTPClient } from "../../src";
 import { getClient } from "../client";
-import { fql } from "../../src/query-builder";
-import { HTTPClient, getDefaultHTTPClient } from "../../src/http-client";
 
 describe("last_txn_ts tracking in client", () => {
   it("Tracks the last_txn_ts datetime and send in the headers", async () => {

--- a/__tests__/integration/doc.test.ts
+++ b/__tests__/integration/doc.test.ts
@@ -1,15 +1,15 @@
-import { getClient } from "../client";
-import { fql } from "../../src/query-builder";
 import {
   Document,
   DocumentT,
   DocumentReference,
+  fql,
   Module,
   NamedDocument,
   NamedDocumentReference,
-  TimeStub,
   NullDocument,
-} from "../../src/values";
+  TimeStub,
+} from "../../src";
+import { getClient } from "../client";
 
 const client = getClient({
   max_conns: 5,

--- a/__tests__/integration/existing-collection.test.ts
+++ b/__tests__/integration/existing-collection.test.ts
@@ -1,6 +1,5 @@
+import { fql, ServiceError } from "../../src";
 import { getClient } from "../client";
-import { ServiceError } from "../../src";
-import { fql } from "../../src";
 
 const client = getClient();
 

--- a/__tests__/integration/page.test.ts
+++ b/__tests__/integration/page.test.ts
@@ -1,6 +1,5 @@
+import { fql, Page } from "../../src";
 import { getClient } from "../client";
-import { fql } from "../../src/query-builder";
-import { Page } from "../../src/values";
 
 const client = getClient({
   max_conns: 5,

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -1,26 +1,25 @@
-import { getClient } from "../client";
-import { type ClientConfiguration } from "../../src/client-configuration";
 import {
-  AuthenticationError,
-  ClientError,
-  NetworkError,
-  ProtocolError,
   AbortError,
-  QueryCheckError,
-  QueryRuntimeError,
-  QueryTimeoutError,
-  ServiceError,
-  InvalidRequestError,
-} from "../../src/errors";
-import {
+  AuthenticationError,
+  ClientConfiguration,
+  ClientError,
+  fql,
+  getDefaultHTTPClient,
   HTTPClient,
   HTTPRequest,
   HTTPResponse,
-  getDefaultHTTPClient,
-} from "../../src/http-client";
-import { fql } from "../../src/query-builder";
-import { Module } from "../../src/values";
-import { QueryRequest, QueryValue } from "../../src/wire-protocol";
+  InvalidRequestError,
+  Module,
+  NetworkError,
+  ProtocolError,
+  QueryCheckError,
+  QueryRequest,
+  QueryRuntimeError,
+  QueryTimeoutError,
+  QueryValue,
+  ServiceError,
+} from "../../src";
+import { getClient } from "../client";
 
 const client = getClient({
   max_conns: 5,

--- a/__tests__/integration/template-format.test.ts
+++ b/__tests__/integration/template-format.test.ts
@@ -1,4 +1,4 @@
-import { fql } from "../../src/query-builder";
+import { fql } from "../../src";
 import { getClient } from "../client";
 
 const client = getClient({

--- a/__tests__/unit/client.test.ts
+++ b/__tests__/unit/client.test.ts
@@ -1,8 +1,5 @@
+import { Client, ClientClosedError, fql, NodeHTTP2Client } from "../../src";
 import { getClient, getDefaultSecretAndEndpoint } from "../client";
-import { fql } from "../../src/query-builder";
-import { ClientClosedError } from "../../src/errors";
-import { Client } from "../../src/client";
-import { NodeHTTP2Client } from "../../src/http-client";
 
 describe("Client", () => {
   it("Refuses further requests after close", async () => {

--- a/__tests__/unit/datetime.test.ts
+++ b/__tests__/unit/datetime.test.ts
@@ -1,4 +1,4 @@
-import { DateStub, TimeStub } from "../../src/values";
+import { DateStub, TimeStub } from "../../src";
 
 type TestCase<I, O> = {
   input: I;

--- a/__tests__/unit/doc.test.ts
+++ b/__tests__/unit/doc.test.ts
@@ -5,9 +5,9 @@ import {
   Module,
   NamedDocument,
   NamedDocumentReference,
-  TimeStub,
   NullDocument,
-} from "../../src/values";
+  TimeStub,
+} from "../../src";
 
 describe("Module", () => {
   it("can be constructed directly", () => {

--- a/__tests__/unit/fetch-client.test.ts
+++ b/__tests__/unit/fetch-client.test.ts
@@ -1,17 +1,15 @@
 import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
-import { Client } from "../../src/client";
-import { endpoints } from "../../src/client-configuration";
 enableFetchMocks();
 
-import { NetworkError } from "../../src/errors";
 import {
   FetchClient,
   HTTPRequest,
   HTTPResponse,
   isHTTPResponse,
-} from "../../src/http-client";
-import { fql } from "../../src/query-builder";
-import { QueryFailure, QuerySuccess } from "../../src/wire-protocol";
+  NetworkError,
+  QueryFailure,
+  QuerySuccess,
+} from "../../src";
 
 let fetchClient: FetchClient;
 

--- a/__tests__/unit/node-http2-client.test.ts
+++ b/__tests__/unit/node-http2-client.test.ts
@@ -1,5 +1,4 @@
-import { getDefaultHTTPClient } from "../../src/http-client";
-import { NodeHTTP2Client } from "../../src/http-client/node-http2-client";
+import { getDefaultHTTPClient, NodeHTTP2Client } from "../../src";
 
 const client = getDefaultHTTPClient();
 

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -1,4 +1,4 @@
-import { Page } from "../../src/values";
+import { Page } from "../../src";
 
 describe("Page", () => {
   it("can be constructed directly", () => {

--- a/__tests__/unit/query-builder.test.ts
+++ b/__tests__/unit/query-builder.test.ts
@@ -1,4 +1,4 @@
-import { fql } from "../../src/query-builder";
+import { fql } from "../../src";
 
 describe("fql method producing Querys", () => {
   it("parses with no variables", () => {

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -1,18 +1,17 @@
 import fetchMock, { enableFetchMocks } from "jest-fetch-mock";
 enableFetchMocks();
 
-import { getClient } from "../client";
 import {
   AuthorizationError,
-  NetworkError,
+  FetchClient,
+  fql,
   QueryTimeoutError,
   ServiceError,
   ServiceInternalError,
   ServiceTimeoutError,
   ThrottlingError,
-} from "../../src/errors";
-import { FetchClient } from "../../src/http-client";
-import { fql } from "../../src/query-builder";
+} from "../../src";
+import { getClient } from "../client";
 
 afterAll(() => {
   client.close();

--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -1,15 +1,17 @@
-import { TaggedTypeFormat, LONG_MIN, LONG_MAX } from "../../src/tagged-type";
 import {
   DateStub,
   Document,
   DocumentReference,
+  LONG_MIN,
+  LONG_MAX,
   Module,
   NamedDocument,
   NamedDocumentReference,
   NullDocument,
   Page,
+  TaggedTypeFormat,
   TimeStub,
-} from "../../src/values";
+} from "../../src";
 
 describe("tagged format", () => {
   it("can be decoded", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
   AuthenticationError,
   AuthorizationError,
   ClientError,
+  ClientClosedError,
   ContendedTransactionError,
   InvalidRequestError,
   NetworkError,
@@ -22,6 +23,7 @@ export {
   ThrottlingError,
 } from "./errors";
 export { type Query, fql } from "./query-builder";
+export { LONG_MAX, LONG_MIN, TaggedTypeFormat } from "./tagged-type";
 export {
   type QueryValueObject,
   type QueryValue,
@@ -47,4 +49,12 @@ export {
   Page,
   TimeStub,
 } from "./values";
-export { FetchClient, NodeHTTP2Client } from "./http-client";
+export {
+  FetchClient,
+  getDefaultHTTPClient,
+  isHTTPResponse,
+  NodeHTTP2Client,
+  type HTTPClient,
+  type HTTPRequest,
+  type HTTPResponse,
+} from "./http-client";


### PR DESCRIPTION
Ticket(s): [FE-3456](https://faunadb.atlassian.net/browse/FE-3456)

## Problem
We've forgotten to export the necessary items from `src/index.js` a few times now. We should make sure tests only import from `src/index.js` so we don't forget to add things.

## Solution
Update all of the test to only import from `src/index.js`.

## Result
Tests are updated, and I found a few things that were not exported, so I added those to the exports.

## Out of scope
changing tests to point to the build artifacts ([FE-3453](https://faunadb.atlassian.net/browse/FE-3453))

## Testing
No changes to the tests, just how things get imported.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
