### PR TITLE
Make type parameter to Client.query more specific

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -159,7 +159,7 @@ export class Client {
    * @throws {@link ClientClosedError} if a query is issued after the client is closed.
    * due to an internal error.
    */
-  async query<T = any>(
+  async query<T extends QueryValue = any>(
     request: Query,
     headers?: QueryRequestHeaders
   ): Promise<QuerySuccess<T>> {
@@ -261,7 +261,9 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
     }
   }
 
-  async #query<T = any>(queryRequest: QueryRequest): Promise<QuerySuccess<T>> {
+  async #query<T extends QueryValue = any>(
+    queryRequest: QueryRequest
+  ): Promise<QuerySuccess<T>> {
     try {
       const headers = {
         Authorization: `Bearer ${this.#clientConfiguration.secret}`,

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -7,6 +7,7 @@ import {
   Module,
   NamedDocument,
   NamedDocumentReference,
+  NullDocument,
   Page,
   TimeStub,
 } from "./values";
@@ -277,4 +278,5 @@ export type QueryValue =
   | DocumentReference
   | NamedDocument
   | NamedDocumentReference
+  | NullDocument
   | Page<QueryValue>;


### PR DESCRIPTION
## Problem
`Client.query` cannot actually return just `any`. The `QueryResponse` type will always contain a `QueryValue` after decoding is done.

## Solution
Add type bounds to `Client.query`

## Result
Typescript users cannot accidentally try to receive their own classes from `Client.query`.

## Out of scope
n/a

## Testing
n/a

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
