### PR TITLE
Pagination iterator type

### DIFF
--- a/__tests__/integration/page.test.ts
+++ b/__tests__/integration/page.test.ts
@@ -1,4 +1,4 @@
-import { fql, Page } from "../../src";
+import { DocumentT, fql, Page } from "../../src";
 import { getClient } from "../client";
 
 const client = getClient({
@@ -19,5 +19,113 @@ describe("querying for set", () => {
     // expect(result.data).toBeInstanceOf(Page);
     // expect(result.data.data).toStrictEqual([1, 2, 3]);
     // expect(result.data.after).toBe("1234");
+  });
+});
+
+describe("pagination iterator", () => {
+  beforeAll(async () => {
+    await client.query(fql`
+      if (Collection.byName("IterTestSmall") != null) {
+        IterTestSmall.definition.delete()
+      }
+      if (Collection.byName("IterTestBig") != null) {
+        IterTestBig.definition.delete()
+      }
+    `);
+    await client.query(fql`
+      Collection.create({ name: "IterTestSmall" })
+      Collection.create({ name: "IterTestBig" })
+    `);
+    await client.query(fql`
+      [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+      ].map(i => IterTestSmall.create({ value: i }))
+
+      [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ].map(i => IterTestBig.create({ value: i }))
+    `);
+  });
+
+  type MyDoc = DocumentT<{
+    value: number;
+  }>;
+
+  it("can get single page using for..of when the set is small", async () => {
+    expect.assertions(1);
+
+    const response = await client.query<Page<MyDoc>>(fql`IterTestSmall.all()`);
+    const page = response.data;
+
+    const iterator = client.paginate(page);
+
+    for await (const newPage of iterator) {
+      expect(newPage.length).toBe(10);
+    }
+  });
+
+  it("can get multiple pages using for..of when the set is large", async () => {
+    expect.assertions(2);
+
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+
+    const iterator = client.paginate(page);
+
+    for await (const data of iterator) {
+      expect(data.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("can get pages using next()", async () => {
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+
+    const iterator = client.paginate(page);
+
+    const result1 = await iterator.next();
+    expect(result1.done).toBe(false);
+    expect(result1.value?.length).toBe(16);
+
+    const result2 = await iterator.next();
+    expect(result2.done).toBe(false);
+    expect(result2.value?.length).toBe(4);
+
+    const result3 = await iterator.next();
+    expect(result3.done).toBe(true);
+  });
+
+  it("can get pages using a loop with hasNext()", async () => {
+    expect.assertions(4);
+
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+
+    const iterator = client.paginate(page);
+
+    while (iterator.hasNext()) {
+      const { value, done } = await iterator.next();
+      expect(value?.length).toBeGreaterThan(0);
+      expect(done).toBe(false);
+    }
+  });
+
+  it("can get previous pages using previous()", async () => {
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+
+    const iterator = client.paginate(page);
+
+    while (iterator.hasNext()) {
+      await iterator.next();
+    }
+
+    const result2 = await iterator.previous();
+    expect(result2.done).toBe(false);
+    expect(result2.value?.length).toBe(16);
+
+    const result3 = await iterator.previous();
+    expect(result3.done).toBe(true);
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,6 +33,8 @@ import {
   type HTTPClient,
 } from "./http-client";
 import { TaggedTypeFormat } from "./tagged-type";
+import { Page } from "./values";
+import { PaginationHelper } from "./pagination-helper";
 
 const defaultClientConfiguration: Pick<
   ClientConfiguration,
@@ -134,6 +136,10 @@ export class Client {
     }
     this.#httpClient.close();
     this.#isClosed = true;
+  }
+
+  paginate<T extends QueryValue = any>(page: Page<T>): PaginationHelper<T> {
+    return new PaginationHelper(this, [page]);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export {
   ServiceTimeoutError,
   ThrottlingError,
 } from "./errors";
+export { PaginationHelper } from "./pagination-helper";
 export { type Query, fql } from "./query-builder";
 export { LONG_MAX, LONG_MIN, TaggedTypeFormat } from "./tagged-type";
 export {

--- a/src/pagination-helper.ts
+++ b/src/pagination-helper.ts
@@ -1,0 +1,102 @@
+import { Client } from "./client";
+import { fql } from "./query-builder";
+import { Page, PageObject } from "./values";
+import { QueryValue } from "./wire-protocol";
+
+export class PaginationHelper<T extends QueryValue>
+  implements AsyncGenerator<T[], undefined, unknown>
+{
+  readonly #client: Client;
+  #pages: Page<T>[];
+  #iter: number;
+
+  constructor(client: Client, pages: Page<T>[]) {
+    this.#client = client;
+    this.#pages = pages;
+    this.#iter = -1;
+  }
+
+  hasNext(): boolean {
+    return (
+      this.#pages.length > 0 &&
+      (this.#iter < this.#pages.length - 1 || !!this.#pages[this.#iter].after)
+    );
+  }
+
+  hasPrevious(): boolean {
+    return this.#iter > 0;
+  }
+
+  async next(): Promise<IteratorResult<T[], undefined>> {
+    if (!this.hasNext()) {
+      return { done: true, value: undefined };
+    }
+
+    this.#iter++;
+
+    if (this.#iter < this.#pages.length) {
+      if (this.#pages[this.#iter].data) {
+        // Most common: we will almost always have data here
+        const data = this.#pages[this.#iter].data as T[];
+        return { done: false, value: data };
+      } else {
+        // Uncommon: If there is no data then it's an embedded set and we need to materialize it.
+        // TODO: handle embedded sets
+      }
+    } else if (this.#iter === this.#pages.length) {
+      const cursor = this.#pages[this.#iter - 1].after;
+      if (!cursor) {
+        // no cursor means the previous page was the last page
+        return { done: true, value: undefined };
+      }
+      // cursor means there is more data to fetch
+      const response = await this.#client.query<Page<T> | PageObject<T>>(
+        fql`Set.paginate(${cursor})`
+      );
+      let nextPage = response.data;
+      // Core doesn't return `@set` tagged values for `Set.paginate()` calls,
+      // yet, so we have to check if the result is decoded into a Page. If not,
+      // then we have a PageObject and should construct a Page with it. This
+      // won't be necessary once core is updated.
+      if (!(nextPage instanceof Page)) {
+        nextPage = new Page(nextPage);
+      }
+      this.#pages.push(nextPage);
+      if (nextPage.data) {
+        return {
+          done: false,
+          value: nextPage.data,
+        };
+      } else {
+        // unreachable since we just queried `Set.paginate()`
+      }
+    }
+
+    return { done: true, value: undefined };
+  }
+
+  async previous(): Promise<IteratorResult<T[], undefined>> {
+    if (!this.hasPrevious()) {
+      return { done: true, value: undefined };
+    }
+
+    this.#iter--;
+
+    // Can assume there is data here, since we must have called `next` before,
+    // and that means that data has been materialized for that page.
+    const data = this.#pages[this.#iter].data as T[];
+    return { done: false, value: data };
+  }
+
+  async return(): Promise<IteratorResult<T[], undefined>> {
+    return { done: true, value: undefined };
+  }
+
+  async throw(e: Error): Promise<IteratorResult<T[], undefined>> {
+    throw e;
+  }
+
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+}

--- a/src/values/page.ts
+++ b/src/values/page.ts
@@ -14,10 +14,7 @@ export class Page<T extends QueryValue> {
    */
   readonly after?: string;
 
-  constructor({
-    data,
-    after,
-  }: { data: T[]; after?: string } | { data?: undefined; after: string }) {
+  constructor({ data, after }: PageObject<T>) {
     if (data === undefined && after === undefined) {
       throw new TypeError(
         "Failed to construct a Page. 'data' and 'after' are both undefined"
@@ -28,3 +25,14 @@ export class Page<T extends QueryValue> {
     this.after = after;
   }
 }
+
+/**
+ * A plain javascript object with Page-like structure containing data and after
+ * cursor. `@set` tagged values are PageObjects.
+ *
+ * @internal This type is intended only to help the driver handle Page-like
+ * data. This type should not be necessary for consumers of the driver.
+ */
+export type PageObject<T extends QueryValue> =
+  | { data: T[]; after?: string }
+  | { data?: undefined; after: string };


### PR DESCRIPTION
Ticket(s): [FE-3110](https://faunadb.atlassian.net/browse/FE-3110)

## Problem
We want to provide native async-iterator API for fetching multiple pages of data.

## Solution
Create a `PaginationHelper` class that implements `AsyncGenerator`.

Add a method to `Client` to create a `PaginationHelper` from a `Page`.

## Result
`PaginationHelper`s are created by calling `client_instance.paginate(page_instance)`.

Pages can be fetched using `for await (data of iterator) { ... }` syntax to asynchronously fetch all pages.

`iterable.next()` method can also be used to more control.

Added a `iterable.previous()` method as well to go back a page. Each call to `next` caches the value in an array, so `previous` will return the cached values.

## Out of scope
n/a

## Testing
Added new tests.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3110]: https://faunadb.atlassian.net/browse/FE-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ