### PR TITLE
Add client arg to decode function

### DIFF
--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -12,6 +12,9 @@ import {
   TaggedTypeFormat,
   TimeStub,
 } from "../../src";
+import { getClient } from "../client";
+
+const client = getClient();
 
 describe("tagged format", () => {
   it("can be decoded", () => {
@@ -102,7 +105,7 @@ describe("tagged format", () => {
     const page = new Page({ data: ["a", "b"] });
     const page_string = new Page({ after: "abc123" });
 
-    const result = TaggedTypeFormat.decode(allTypes);
+    const result = TaggedTypeFormat.decode(client, allTypes);
     expect(result.name).toEqual("fir");
     expect(result.age).toEqual(200);
     expect(result.birthdate).toBeInstanceOf(DateStub);
@@ -298,7 +301,7 @@ describe("tagged format", () => {
       const encoded = TaggedTypeFormat.encode(input);
       const encodedKey = Object.keys(encoded)[0];
       expect(encodedKey).toEqual(tag);
-      const decoded = TaggedTypeFormat.decode(JSON.stringify(encoded));
+      const decoded = TaggedTypeFormat.decode(client, JSON.stringify(encoded));
       expect(typeof decoded).toBe(expectedType);
       expect(decoded).toEqual(expected);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -295,7 +295,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
         parsedResponse = {
           ...fetchResponse,
           body: isTaggedFormat
-            ? TaggedTypeFormat.decode(fetchResponse.body)
+            ? TaggedTypeFormat.decode(this, fetchResponse.body)
             : JSON.parse(fetchResponse.body),
         };
         if (parsedResponse.body.query_tags) {

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -1,3 +1,4 @@
+import { Client } from "./client";
 import { ClientError } from "./errors";
 import {
   DateStub,
@@ -32,7 +33,7 @@ export class TaggedTypeFormat {
    * @param input - JSON string result from Fauna
    * @returns object of result of FQL query
    */
-  static decode(input: string): any {
+  static decode(client: Client, input: string): any {
     return JSON.parse(input, (_, value: any) => {
       if (value == null) return null;
       if (value["@mod"]) {


### PR DESCRIPTION
Ticket(s): [FE-3110](https://faunadb.atlassian.net/browse/FE-3110)

IMPORTANT: this is ONLY necessary if we go with #141 option for pagination iterator

## Problem
Decoding context has no client in it. If we want to decode results into classes that contain a client, then the decoder needs to have a client.

## Solution
add a client argument to the decode function 

## Result
`Client.query` is the only place that calls `TaggedTypeFormat.decode`; the client now passes in `this` to `decode`. The decode function is now ready to use the client where we need it.

## Out of scope
Implementing pagination helpers. This is a small step to building a Page class that can make additional calls to the database.

## Testing
Updated decoding tests where necessary.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3110]: https://faunadb.atlassian.net/browse/FE-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ