### PR TITLE
Pagination iterator type (1) - @set decodes to iterable with built-in client

### DIFF
--- a/__tests__/integration/page.test.ts
+++ b/__tests__/integration/page.test.ts
@@ -119,4 +119,36 @@ describe("PaginationHelper", () => {
       }
     }
   });
+
+  it("can can stop the iterator with the return method", async () => {
+    expect.assertions(1);
+
+    const response = await client.query<PaginationHelper<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const paginationHelper = response.data;
+
+    for await (const page of paginationHelper) {
+      expect(page.data.length).toBe(16);
+      await paginationHelper.return();
+    }
+  });
+
+  it("can can stop the iterator with the throw method", async () => {
+    expect.assertions(2);
+
+    const response = await client.query<PaginationHelper<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const paginationHelper = response.data;
+
+    try {
+      for await (const page of paginationHelper) {
+        expect(page.data.length).toBe(16);
+        await paginationHelper.throw("oops");
+      }
+    } catch (e) {
+      expect(e).toBe("oops");
+    }
+  });
 });

--- a/__tests__/integration/page.test.ts
+++ b/__tests__/integration/page.test.ts
@@ -1,4 +1,5 @@
-import { fql, Page } from "../../src";
+import { DocumentT, fql } from "../../src";
+import { PaginationHelper } from "../../src/values";
 import { getClient } from "../client";
 
 const client = getClient({
@@ -19,5 +20,103 @@ describe("querying for set", () => {
     // expect(result.data).toBeInstanceOf(Page);
     // expect(result.data.data).toStrictEqual([1, 2, 3]);
     // expect(result.data.after).toBe("1234");
+  });
+});
+
+describe("PaginationHelper", () => {
+  beforeAll(async () => {
+    await client.query(fql`
+      if (Collection.byName("IterTestSmall") != null) {
+        IterTestSmall.definition.delete()
+      }
+      if (Collection.byName("IterTestBig") != null) {
+        IterTestBig.definition.delete()
+      }
+    `);
+    await client.query(fql`
+      Collection.create({ name: "IterTestSmall" })
+      Collection.create({ name: "IterTestBig" })
+    `);
+    await client.query(fql`
+      [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+      ].map(i => IterTestSmall.create({ value: i }))
+
+      [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ].map(i => IterTestBig.create({ value: i }))
+    `);
+  });
+
+  type MyDoc = DocumentT<{
+    value: number;
+  }>;
+
+  it("can get single page using for..of when the set is small", async () => {
+    expect.assertions(1);
+
+    const response = await client.query<PaginationHelper<MyDoc>>(
+      fql`IterTestSmall.all()`
+    );
+    const paginationHelper = response.data;
+
+    for await (const page of paginationHelper) {
+      expect(page.data.length).toBe(10);
+    }
+  });
+
+  it("can get multiple pages using for..of when the set is large", async () => {
+    expect.assertions(2);
+
+    const response = await client.query<PaginationHelper<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const paginationHelper = response.data;
+
+    for await (const page of paginationHelper) {
+      expect(page.data.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("can get pages using next()", async () => {
+    expect.assertions(3);
+
+    const response = await client.query<PaginationHelper<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const paginationHelper = response.data;
+
+    const result1 = await paginationHelper.next();
+    if (!result1.done) {
+      expect(result1.value.data.length).toBe(16);
+    }
+
+    const result2 = await paginationHelper.next();
+    if (!result2.done) {
+      expect(result2.value.data.length).toBe(4);
+    }
+
+    const result3 = await paginationHelper.next();
+    expect(result3.done).toBe(true);
+  });
+
+  it("can get pages using a loop with next()", async () => {
+    expect.assertions(2);
+    const response = await client.query<PaginationHelper<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const paginationHelper = response.data;
+
+    let done = false;
+    while (!done) {
+      const next = await paginationHelper.next();
+      done = next.done ?? false;
+
+      if (!next.done) {
+        const page = next.value;
+        expect(page.data.length).toBeGreaterThan(0);
+      }
+    }
   });
 });

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -1,4 +1,4 @@
-import { Page, PaginationHelper } from "../../src";
+import { EmbeddedSet, Page, SetIterator } from "../../src";
 import { getClient } from "../client";
 
 const client = getClient();
@@ -17,9 +17,16 @@ describe("Page", () => {
   });
 });
 
-describe("PaginationHelper", () => {
+describe("EmbeddedSet", () => {
   it("can be constructed directly", () => {
-    const set = new PaginationHelper<number>(client, {
+    const set = new EmbeddedSet("1234");
+    expect(set.after).toBe("1234");
+  });
+});
+
+describe("SetIterator", () => {
+  it("can be constructed directly", () => {
+    const set = new SetIterator<number>(client, {
       data: [1, 2, 3],
       after: "1234",
     });
@@ -27,20 +34,36 @@ describe("PaginationHelper", () => {
     expect(set.after).toBe("1234");
   });
 
+  it("can be constructed from a Page", () => {
+    const page = new Page({
+      data: [1, 2, 3],
+      after: "1234",
+    });
+    const set = new SetIterator<number>(client, page);
+    expect(set.data).toStrictEqual([1, 2, 3]);
+    expect(set.after).toBe("1234");
+  });
+
+  it("can be constructed from an EmbeddedSet", () => {
+    const embeddedSet = new EmbeddedSet("1234");
+    const set = new SetIterator<number>(client, embeddedSet);
+    expect(set.after).toBe("1234");
+  });
+
   it("after is optional", () => {
-    const set = new PaginationHelper<number>(client, { data: [1, 2, 3] });
+    const set = new SetIterator<number>(client, { data: [1, 2, 3] });
     expect(set.data).toStrictEqual([1, 2, 3]);
     expect(set.after).toBeUndefined();
   });
 
   it("data is optional if after is provided", () => {
-    const set = new PaginationHelper<number>(client, { after: "1234" });
+    const set = new SetIterator<number>(client, { after: "1234" });
     expect(set.data).toBeUndefined;
     expect(set.after).toBe("1234");
   });
 
   it("throws if data and after are both undefined", () => {
     // @ts-ignore-next-line
-    expect(() => new PaginationHelper<number>(client, {})).toThrow();
+    expect(() => new SetIterator<number>(client, {})).toThrow();
   });
 });

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -1,4 +1,7 @@
-import { Page } from "../../src";
+import { Page, PaginationHelper } from "../../src";
+import { getClient } from "../client";
+
+const client = getClient();
 
 describe("Page", () => {
   it("can be constructed directly", () => {
@@ -12,15 +15,32 @@ describe("Page", () => {
     expect(set.data).toStrictEqual([1, 2, 3]);
     expect(set.after).toBeUndefined();
   });
+});
+
+describe("PaginationHelper", () => {
+  it("can be constructed directly", () => {
+    const set = new PaginationHelper<number>(client, {
+      data: [1, 2, 3],
+      after: "1234",
+    });
+    expect(set.data).toStrictEqual([1, 2, 3]);
+    expect(set.after).toBe("1234");
+  });
+
+  it("after is optional", () => {
+    const set = new PaginationHelper<number>(client, { data: [1, 2, 3] });
+    expect(set.data).toStrictEqual([1, 2, 3]);
+    expect(set.after).toBeUndefined();
+  });
 
   it("data is optional if after is provided", () => {
-    const set = new Page<number>({ after: "1234" });
+    const set = new PaginationHelper<number>(client, { after: "1234" });
     expect(set.data).toBeUndefined;
     expect(set.after).toBe("1234");
   });
 
   it("throws if data and after are both undefined", () => {
     // @ts-ignore-next-line
-    expect(() => new Page<number>({})).toThrow();
+    expect(() => new PaginationHelper<number>(client, {})).toThrow();
   });
 });

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -1,4 +1,4 @@
-import { EmbeddedSet, Page, SetIterator } from "../../src";
+import { Page, SetIterator } from "../../src";
 import { getClient } from "../client";
 
 const client = getClient();
@@ -14,13 +14,6 @@ describe("Page", () => {
     const set = new Page<number>({ data: [1, 2, 3] });
     expect(set.data).toStrictEqual([1, 2, 3]);
     expect(set.after).toBeUndefined();
-  });
-});
-
-describe("EmbeddedSet", () => {
-  it("can be constructed directly", () => {
-    const set = new EmbeddedSet("1234");
-    expect(set.after).toBe("1234");
   });
 });
 
@@ -41,12 +34,6 @@ describe("SetIterator", () => {
     });
     const set = new SetIterator<number>(client, page);
     expect(set.data).toStrictEqual([1, 2, 3]);
-    expect(set.after).toBe("1234");
-  });
-
-  it("can be constructed from an EmbeddedSet", () => {
-    const embeddedSet = new EmbeddedSet("1234");
-    const set = new SetIterator<number>(client, embeddedSet);
     expect(set.after).toBe("1234");
   });
 

--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -10,7 +10,7 @@ import {
   NullDocument,
   TaggedTypeFormat,
   TimeStub,
-  PaginationHelper,
+  SetIterator,
 } from "../../src";
 import { getClient } from "../client";
 
@@ -102,8 +102,8 @@ describe("tagged format", () => {
     });
     const nullDoc = new NullDocument(docReference, "not found");
 
-    const page = new PaginationHelper(client, { data: ["a", "b"] });
-    const page_string = new PaginationHelper(client, { after: "abc123" });
+    const page = new SetIterator(client, { data: ["a", "b"] });
+    const page_string = new SetIterator(client, { after: "abc123" });
 
     const result = TaggedTypeFormat.decode(client, allTypes);
     expect(result.name).toEqual("fir");

--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -8,9 +8,9 @@ import {
   NamedDocument,
   NamedDocumentReference,
   NullDocument,
-  Page,
   TaggedTypeFormat,
   TimeStub,
+  PaginationHelper,
 } from "../../src";
 import { getClient } from "../client";
 
@@ -102,8 +102,8 @@ describe("tagged format", () => {
     });
     const nullDoc = new NullDocument(docReference, "not found");
 
-    const page = new Page({ data: ["a", "b"] });
-    const page_string = new Page({ after: "abc123" });
+    const page = new PaginationHelper(client, { data: ["a", "b"] });
+    const page_string = new PaginationHelper(client, { after: "abc123" });
 
     const result = TaggedTypeFormat.decode(client, allTypes);
     expect(result.name).toEqual("fir");

--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -12,6 +12,9 @@ import {
   TaggedTypeFormat,
   TimeStub,
 } from "../../src";
+import { getClient } from "../client";
+
+const client = getClient();
 
 describe("tagged format", () => {
   it("can be decoded", () => {
@@ -102,7 +105,7 @@ describe("tagged format", () => {
     const page = new Page({ data: ["a", "b"] });
     const page_string = new Page({ after: "abc123" });
 
-    const result = TaggedTypeFormat.decode(allTypes);
+    const result = TaggedTypeFormat.decode(client, allTypes);
     expect(result.name).toEqual("fir");
     expect(result.age).toEqual(200);
     expect(result.birthdate).toBeInstanceOf(DateStub);
@@ -298,7 +301,7 @@ describe("tagged format", () => {
       const encoded = TaggedTypeFormat.encode(input);
       const encodedKey = Object.keys(encoded)[0];
       expect(encodedKey).toEqual(tag);
-      const decoded = TaggedTypeFormat.decode(JSON.stringify(encoded));
+      const decoded = TaggedTypeFormat.decode(client, JSON.stringify(encoded));
       expect(typeof decoded).toBe(expectedType);
       expect(decoded).toEqual(expected);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -295,7 +295,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
         parsedResponse = {
           ...fetchResponse,
           body: isTaggedFormat
-            ? TaggedTypeFormat.decode(fetchResponse.body)
+            ? TaggedTypeFormat.decode(this, fetchResponse.body)
             : JSON.parse(fetchResponse.body),
         };
         if (parsedResponse.body.query_tags) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,12 +42,13 @@ export {
   Document,
   DocumentReference,
   type DocumentT,
+  EmbeddedSet,
   Module,
   NamedDocument,
   NamedDocumentReference,
   NullDocument,
   Page,
-  PaginationHelper,
+  SetIterator,
   TimeStub,
 } from "./values";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export {
   NamedDocumentReference,
   NullDocument,
   Page,
+  PaginationHelper,
   TimeStub,
 } from "./values";
 export {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,6 @@ export {
   Document,
   DocumentReference,
   type DocumentT,
-  EmbeddedSet,
   Module,
   NamedDocument,
   NamedDocumentReference,

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -10,7 +10,7 @@ import {
   TimeStub,
   Page,
   NullDocument,
-  PaginationHelper,
+  SetIterator,
 } from "./values";
 import { QueryValueObject, QueryValue } from "./wire-protocol";
 
@@ -66,9 +66,9 @@ export class TaggedTypeFormat {
         return ref;
       } else if (value["@set"]) {
         if (typeof value["@set"] === "string") {
-          return new PaginationHelper(client, { after: value["@set"] });
+          return new SetIterator(client, { after: value["@set"] });
         }
-        return new PaginationHelper(client, value["@set"]);
+        return new SetIterator(client, value["@set"]);
       } else if (value["@int"]) {
         return Number(value["@int"]);
       } else if (value["@long"]) {
@@ -177,7 +177,7 @@ const encodeMap = {
   namedDocument: (value: NamedDocument): TaggedRef => ({
     "@ref": { name: value.name, coll: { "@mod": value.coll.name } },
   }),
-  set: (value: Page<any> | PaginationHelper<any>) => {
+  set: (value: Page<any> | SetIterator<any>) => {
     throw new ClientError(
       "Page could not be encoded. Fauna does not accept encoded Set values, yet. Use Page.data and Page.after as arguments, instead."
     );
@@ -232,7 +232,7 @@ const encode = (input: QueryValue): QueryValue => {
         return encode(input.ref);
       } else if (input instanceof Page) {
         return encodeMap["set"](input);
-      } else if (input instanceof PaginationHelper) {
+      } else if (input instanceof SetIterator) {
         return encodeMap["set"](input);
       } else {
         return encodeMap["object"](input);

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -1,3 +1,4 @@
+import { Client } from "./client";
 import { ClientError } from "./errors";
 import {
   DateStub,
@@ -32,7 +33,7 @@ export class TaggedTypeFormat {
    * @param input - JSON string result from Fauna
    * @returns object of result of FQL query
    */
-  static decode(input: string): any {
+  static decode(client: Client, input: string): any {
     return JSON.parse(input, (_, value: any) => {
       if (value == null) return null;
       if (value["@mod"]) {

--- a/src/values/page.ts
+++ b/src/values/page.ts
@@ -1,30 +1,104 @@
+import { Client } from "../client";
+import { fql } from "../query-builder";
 import { QueryValue } from "../wire-protocol";
 
 /**
- * A Fauna Set.
+ * A materialized Fauna Set.
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
  */
 export class Page<T extends QueryValue> {
+  readonly data: T[];
+  readonly after?: string;
+
+  constructor({ data, after }: PageObject<T>) {
+    this.data = data;
+    this.after = after;
+  }
+}
+
+/**
+ * A class to provide an iterable API for fetching multiple pages of data, given
+ * a Fauna Set
+ */
+export class PaginationHelper<T extends QueryValue>
+  implements AsyncGenerator<Page<T>, void, unknown>
+{
+  readonly #generator: AsyncGenerator<Page<T>, void, unknown>;
+  #currentData?: T[];
+  #currentAfter?: string;
+
+  constructor(client: Client, initial: PageObject<T> | EmbeddedSet) {
+    if (!("data" in initial) && initial.after === undefined) {
+      throw new TypeError(
+        "Failed to construct a Page. 'data' and 'after' are both undefined"
+      );
+    }
+    this.#generator = generatePages(client, initial);
+    if ("data" in initial) this.#currentData = initial.data;
+    this.#currentAfter = initial.after;
+  }
+
   /** A materialized page of data */
-  readonly data?: T[];
+  get data() {
+    return this.#currentData;
+  }
+
   /**
    * A pagination cursor, used to obtain additional information in the Set.
    * If `after` is not provided, then `data` must be present and represents the
    * last Page in the Set.
    */
-  readonly after?: string;
-
-  constructor({
-    data,
-    after,
-  }: { data: T[]; after?: string } | { data?: undefined; after: string }) {
-    if (data === undefined && after === undefined) {
-      throw new TypeError(
-        "Failed to construct a Page. 'data' and 'after' are both undefined"
-      );
-    }
-
-    this.data = data;
-    this.after = after;
+  get after() {
+    return this.#currentAfter;
   }
+
+  async next(): Promise<IteratorResult<Page<T>, void>> {
+    const next = await this.#generator.next();
+    if (next.value) {
+      this.#currentData = next.value.data;
+      this.#currentAfter = next.value.after;
+    }
+    return next;
+  }
+
+  async return(): Promise<IteratorResult<Page<T>, void>> {
+    return this.#generator.return();
+  }
+
+  async throw(e: any): Promise<IteratorResult<Page<T>, void>> {
+    return this.#generator.throw(e);
+  }
+
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+}
+
+type PageObject<T> = { data: T[]; after?: string };
+type EmbeddedSet = { after: string };
+
+async function* generatePages<T extends QueryValue>(
+  client: Client,
+  initial: PageObject<T> | EmbeddedSet
+): AsyncGenerator<Page<T>, void, unknown> {
+  let currentPage = initial;
+
+  if ("data" in initial) {
+    yield new Page(initial);
+  }
+
+  while (currentPage.after) {
+    // cursor means there is more data to fetch
+    const response = await client.query<PageObject<T>>(
+      // project for data and after cursors so we don't have issues with
+      // recursive Page instances
+      fql`Set.paginate(${currentPage.after}) { data, after }`
+    );
+    const nextPage = response.data;
+
+    currentPage = nextPage;
+    yield new Page(nextPage);
+  }
+
+  return;
 }

--- a/src/values/page.ts
+++ b/src/values/page.ts
@@ -23,23 +23,6 @@ export class Page<T extends QueryValue> implements PageObject<T> {
 }
 
 /**
- * A un-materialize Set. Typically received when a materialized Set contains
- * another set, the EmbeddedSet does not contain any data to avoid potential
- * issues such as self-reference and infinite recursion
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
- */
-export class EmbeddedSet implements EmbeddedSetObject {
-  /**
-   * A pagination cursor, used to obtain additional information in the Set.
-   */
-  readonly after: string;
-
-  constructor(after: string) {
-    this.after = after;
-  }
-}
-
-/**
  * A class to provide an iterable API for fetching multiple pages of data, given
  * a Fauna Set
  */
@@ -102,7 +85,7 @@ type EmbeddedSetObject = { after: string };
 
 async function* generatePages<T extends QueryValue>(
   client: Client,
-  initial: PageObject<T> | EmbeddedSet
+  initial: PageObject<T> | EmbeddedSetObject
 ): AsyncGenerator<Page<T>, void, unknown> {
   let currentPage = initial;
 

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -8,7 +8,7 @@ import {
   NamedDocument,
   NamedDocumentReference,
   Page,
-  PaginationHelper,
+  SetIterator,
   TimeStub,
 } from "./values";
 
@@ -279,4 +279,4 @@ export type QueryValue =
   | NamedDocument
   | NamedDocumentReference
   | Page<QueryValue>
-  | PaginationHelper<QueryValue>;
+  | SetIterator<QueryValue>;

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -8,6 +8,7 @@ import {
   NamedDocument,
   NamedDocumentReference,
   Page,
+  PaginationHelper,
   TimeStub,
 } from "./values";
 
@@ -277,4 +278,5 @@ export type QueryValue =
   | DocumentReference
   | NamedDocument
   | NamedDocumentReference
-  | Page<QueryValue>;
+  | Page<QueryValue>
+  | PaginationHelper<QueryValue>;


### PR DESCRIPTION
Ticket(s): [FE-3110](https://faunadb.atlassian.net/browse/FE-3110)
depends on #140 

## Problem
We want to provide native async-iterator API for fetching multiple pages of data.

We want to limit friction for users getting paginated data.

Users need to have control over remote fetches, and need access to the after-cursors if they want them.

## Solution
Create a `SetIterator` class that implements `AsyncGenerator`. `SetIterator` most closely represents a Fauna Set, which can be a materialized Set or an embedded Set. `Page` stays very simple. The `SetIterator` iterator returns instances of `Page`.

When the client receives an `@set` tagged value, it is decoded into the `SetIterator` class. It can be used like this

```typescript
const response = await client.query(fql`MyCollection.all()`);
const setIterator = response.data

for await (const page of setIterator) {
  // do stuff with page
}
```


The helper is constructed with a reference to the client so it can make additional calls to the database without any intermediate steps.

## Result
Pages can be fetched using `for await (page of pagination_helper) { ... }` syntax to asynchronously fetch all pages.

The AsyncGenerator methods `next()`, `return()`, and `throw()` can also be used to provide more control.

## Out of scope
n/a

## Testing
Added new tests.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3110]: https://faunadb.atlassian.net/browse/FE-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ