### PR TITLE
Pagination iterator type (2) - @set decodes to Page, which can be used to build an iterable

### DIFF
--- a/__tests__/integration/page.test.ts
+++ b/__tests__/integration/page.test.ts
@@ -1,4 +1,4 @@
-import { fql, Page } from "../../src";
+import { DocumentT, fql, Page, SetIterator } from "../../src";
 import { getClient } from "../client";
 
 const client = getClient({
@@ -19,5 +19,135 @@ describe("querying for set", () => {
     // expect(result.data).toBeInstanceOf(Page);
     // expect(result.data.data).toStrictEqual([1, 2, 3]);
     // expect(result.data.after).toBe("1234");
+  });
+});
+
+describe("SetIterator", () => {
+  beforeAll(async () => {
+    await client.query(fql`
+      if (Collection.byName("IterTestSmall") != null) {
+        IterTestSmall.definition.delete()
+      }
+      if (Collection.byName("IterTestBig") != null) {
+        IterTestBig.definition.delete()
+      }
+    `);
+    await client.query(fql`
+      Collection.create({ name: "IterTestSmall" })
+      Collection.create({ name: "IterTestBig" })
+    `);
+    await client.query(fql`
+      [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+      ].map(i => IterTestSmall.create({ value: i }))
+
+      [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ].map(i => IterTestBig.create({ value: i }))
+    `);
+  });
+
+  type MyDoc = DocumentT<{
+    value: number;
+  }>;
+
+  it("can get single page using for..of when the set is small", async () => {
+    expect.assertions(1);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestSmall.all()`
+    );
+    const setIterator = response.data;
+
+    for await (const page of setIterator) {
+      expect(page.data.length).toBe(10);
+    }
+  });
+
+  it("can get multiple pages using for..of when the set is large", async () => {
+    expect.assertions(2);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    for await (const page of setIterator) {
+      expect(page.data.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("can get pages using next()", async () => {
+    expect.assertions(3);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    const result1 = await setIterator.next();
+    if (!result1.done) {
+      expect(result1.value.data.length).toBe(16);
+    }
+
+    const result2 = await setIterator.next();
+    if (!result2.done) {
+      expect(result2.value.data.length).toBe(4);
+    }
+
+    const result3 = await setIterator.next();
+    expect(result3.done).toBe(true);
+  });
+
+  it("can get pages using a loop with next()", async () => {
+    expect.assertions(2);
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    let done = false;
+    while (!done) {
+      const next = await setIterator.next();
+      done = next.done ?? false;
+
+      if (!next.done) {
+        const page = next.value;
+        expect(page.data.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("can can stop the iterator with the return method", async () => {
+    expect.assertions(1);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    for await (const page of setIterator) {
+      expect(page.data.length).toBe(16);
+      await setIterator.return();
+    }
+  });
+
+  it("can can stop the iterator with the throw method", async () => {
+    expect.assertions(2);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    try {
+      for await (const page of setIterator) {
+        expect(page.data.length).toBe(16);
+        await setIterator.throw("oops");
+      }
+    } catch (e) {
+      expect(e).toBe("oops");
+    }
   });
 });

--- a/__tests__/integration/page.test.ts
+++ b/__tests__/integration/page.test.ts
@@ -55,10 +55,9 @@ describe("SetIterator", () => {
   it("can get single page using for..of when the set is small", async () => {
     expect.assertions(1);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestSmall.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestSmall.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     for await (const page of setIterator) {
       expect(page.data.length).toBe(10);
@@ -68,10 +67,9 @@ describe("SetIterator", () => {
   it("can get multiple pages using for..of when the set is large", async () => {
     expect.assertions(2);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     for await (const page of setIterator) {
       expect(page.data.length).toBeGreaterThan(0);
@@ -81,10 +79,9 @@ describe("SetIterator", () => {
   it("can get pages using next()", async () => {
     expect.assertions(3);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     const result1 = await setIterator.next();
     if (!result1.done) {
@@ -102,10 +99,9 @@ describe("SetIterator", () => {
 
   it("can get pages using a loop with next()", async () => {
     expect.assertions(2);
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     let done = false;
     while (!done) {
@@ -122,10 +118,9 @@ describe("SetIterator", () => {
   it("can can stop the iterator with the return method", async () => {
     expect.assertions(1);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     for await (const page of setIterator) {
       expect(page.data.length).toBe(16);
@@ -136,10 +131,9 @@ describe("SetIterator", () => {
   it("can can stop the iterator with the throw method", async () => {
     expect.assertions(2);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     try {
       for await (const page of setIterator) {

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -1,4 +1,7 @@
-import { EmbeddedSet, Page } from "../../src";
+import { EmbeddedSet, Page, SetIterator } from "../../src";
+import { getClient } from "../client";
+
+const client = getClient();
 
 describe("Page", () => {
   it("can be constructed directly", () => {
@@ -18,5 +21,40 @@ describe("Embedded Set", () => {
   it("can be constructed directly", () => {
     const set = new EmbeddedSet("1234");
     expect(set.after).toBe("1234");
+  });
+});
+
+describe("SetIterator", () => {
+  it("can be constructed from a Page", () => {
+    const page = new Page({
+      data: [1, 2, 3],
+      after: "1234",
+    });
+    const set = new SetIterator<number>(client, page);
+    expect(set.data).toStrictEqual([1, 2, 3]);
+    expect(set.after).toBe("1234");
+  });
+
+  it("can be constructed from an EmbeddedSet", () => {
+    const embeddedSet = new EmbeddedSet("1234");
+    const set = new SetIterator<number>(client, embeddedSet);
+    expect(set.after).toBe("1234");
+  });
+
+  it("after is optional", () => {
+    const set = new SetIterator<number>(client, { data: [1, 2, 3] });
+    expect(set.data).toStrictEqual([1, 2, 3]);
+    expect(set.after).toBeUndefined();
+  });
+
+  it("data is optional if after is provided", () => {
+    const set = new SetIterator<number>(client, { after: "1234" });
+    expect(set.data).toBeUndefined;
+    expect(set.after).toBe("1234");
+  });
+
+  it("throws if data and after are both undefined", () => {
+    // @ts-ignore-next-line
+    expect(() => new SetIterator<number>(client, {})).toThrow();
   });
 });

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -1,4 +1,4 @@
-import { Page } from "../../src";
+import { EmbeddedSet, Page } from "../../src";
 
 describe("Page", () => {
   it("can be constructed directly", () => {
@@ -13,14 +13,15 @@ describe("Page", () => {
     expect(set.after).toBeUndefined();
   });
 
-  it("data is optional if after is provided", () => {
-    const set = new Page<number>({ after: "1234" });
-    expect(set.data).toBeUndefined;
-    expect(set.after).toBe("1234");
+  it("throws if data is undefined", () => {
+    // @ts-expect-error
+    expect(() => new Page<number>({ after: "1234" })).toThrow();
   });
+});
 
-  it("throws if data and after are both undefined", () => {
-    // @ts-ignore-next-line
-    expect(() => new Page<number>({})).toThrow();
+describe("Embedded Set", () => {
+  it("can be constructed directly", () => {
+    const set = new EmbeddedSet("1234");
+    expect(set.after).toBe("1234");
   });
 });

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -12,11 +12,6 @@ describe("Page", () => {
     expect(set.data).toStrictEqual([1, 2, 3]);
     expect(set.after).toBeUndefined();
   });
-
-  it("throws if data is undefined", () => {
-    // @ts-expect-error
-    expect(() => new Page<number>({ after: "1234" })).toThrow();
-  });
 });
 
 describe("Embedded Set", () => {

--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -11,6 +11,7 @@ import {
   Page,
   TaggedTypeFormat,
   TimeStub,
+  EmbeddedSet,
 } from "../../src";
 
 describe("tagged format", () => {
@@ -73,7 +74,7 @@ describe("tagged format", () => {
         }
       },
       "page": { "@set": { "data": ["a", "b"] } },
-      "page_string": { "@set": "abc123" }
+      "embeddedSet": { "@set": "abc123" }
     }`;
 
     const bugs_mod = new Module("Bugs");
@@ -100,7 +101,7 @@ describe("tagged format", () => {
     const nullDoc = new NullDocument(docReference, "not found");
 
     const page = new Page({ data: ["a", "b"] });
-    const page_string = new Page({ after: "abc123" });
+    const embeddedSet = new EmbeddedSet("abc123");
 
     const result = TaggedTypeFormat.decode(allTypes);
     expect(result.name).toEqual("fir");
@@ -126,7 +127,7 @@ describe("tagged format", () => {
     expect(result.namedDoc).toStrictEqual(namedDoc);
     expect(result.nullDoc).toStrictEqual(nullDoc);
     expect(result.page).toStrictEqual(page);
-    expect(result.page_string).toStrictEqual(page_string);
+    expect(result.embeddedSet).toStrictEqual(embeddedSet);
   });
 
   it("can be encoded", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,11 +42,13 @@ export {
   Document,
   DocumentReference,
   type DocumentT,
+  EmbeddedSet,
   Module,
   NamedDocument,
   NamedDocumentReference,
   NullDocument,
   Page,
+  SetIterator,
   TimeStub,
 } from "./values";
 export {

--- a/src/values/page.ts
+++ b/src/values/page.ts
@@ -51,17 +51,14 @@ export class SetIterator<T extends QueryValue>
   #currentAfter?: string;
 
   constructor(client: Client, initial: Page<T> | EmbeddedSet) {
+    if (!("data" in initial) && initial.after === undefined) {
+      throw new TypeError(
+        "Failed to construct a Page. 'data' and 'after' are both undefined"
+      );
+    }
     this.#generator = generatePages(client, initial);
+    if ("data" in initial) this.#currentData = initial.data;
     this.#currentAfter = initial.after;
-  }
-
-  static fromPage<T extends QueryValue>(
-    client: Client,
-    initial: Page<T>
-  ): SetIterator<T> {
-    const iter = new SetIterator<T>(client, initial);
-    iter.#currentData = initial.data;
-    return iter;
   }
 
   /** A materialized page of data */

--- a/src/values/page.ts
+++ b/src/values/page.ts
@@ -110,9 +110,7 @@ async function* generatePages<T extends QueryValue>(
   while (currentPage.after) {
     // cursor means there is more data to fetch
     const response = await client.query<Page<T>>(
-      // project for data and after cursors so we don't have issues with
-      // recursive Page instances
-      fql`Set.paginate(${currentPage.after}) { data, after }`
+      fql`Set.paginate(${currentPage.after})`
     );
     const nextPage = response.data;
 

--- a/src/values/page.ts
+++ b/src/values/page.ts
@@ -1,12 +1,14 @@
+import { Client } from "../client";
+import { fql } from "../query-builder";
 import { QueryValue } from "../wire-protocol";
 
 /**
- * A Fauna Set.
+ * A materialize view of a Set.
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
  */
 export class Page<T extends QueryValue> {
   /** A materialized page of data */
-  readonly data?: T[];
+  readonly data: T[];
   /**
    * A pagination cursor, used to obtain additional information in the Set.
    * If `after` is not provided, then `data` must be present and represents the
@@ -14,17 +16,112 @@ export class Page<T extends QueryValue> {
    */
   readonly after?: string;
 
-  constructor({
-    data,
-    after,
-  }: { data: T[]; after?: string } | { data?: undefined; after: string }) {
-    if (data === undefined && after === undefined) {
-      throw new TypeError(
-        "Failed to construct a Page. 'data' and 'after' are both undefined"
-      );
-    }
-
+  constructor({ data, after }: { data: T[]; after?: string }) {
     this.data = data;
     this.after = after;
   }
+}
+
+/**
+ * A un-materialize Set. Typically received when a materialized Set contains
+ * another set, the EmbeddedSet does not contain any data to avoid potential
+ * issues such as self-reference and infinite recursion
+ * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
+ */
+export class EmbeddedSet {
+  /**
+   * A pagination cursor, used to obtain additional information in the Set.
+   */
+  readonly after: string;
+
+  constructor(after: string) {
+    this.after = after;
+  }
+}
+
+/**
+ * A class to provide an iterable API for fetching multiple pages of data, given
+ * a Fauna Set
+ */
+export class SetIterator<T extends QueryValue>
+  implements AsyncGenerator<Page<T>, void, unknown>
+{
+  readonly #generator: AsyncGenerator<Page<T>, void, unknown>;
+  #currentData?: T[];
+  #currentAfter?: string;
+
+  constructor(client: Client, initial: Page<T> | EmbeddedSet) {
+    this.#generator = generatePages(client, initial);
+    this.#currentAfter = initial.after;
+  }
+
+  static fromPage<T extends QueryValue>(
+    client: Client,
+    initial: Page<T>
+  ): SetIterator<T> {
+    const iter = new SetIterator<T>(client, initial);
+    iter.#currentData = initial.data;
+    return iter;
+  }
+
+  /** A materialized page of data */
+  get data() {
+    return this.#currentData;
+  }
+
+  /**
+   * A pagination cursor, used to obtain additional information in the Set.
+   * If `after` is not provided, then `data` must be present and represents the
+   * last Page in the Set.
+   */
+  get after() {
+    return this.#currentAfter;
+  }
+
+  async next(): Promise<IteratorResult<Page<T>, void>> {
+    const next = await this.#generator.next();
+    if (next.value) {
+      this.#currentData = next.value.data;
+      this.#currentAfter = next.value.after;
+    }
+    return next;
+  }
+
+  async return(): Promise<IteratorResult<Page<T>, void>> {
+    return this.#generator.return();
+  }
+
+  async throw(e: any): Promise<IteratorResult<Page<T>, void>> {
+    return this.#generator.throw(e);
+  }
+
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+}
+
+async function* generatePages<T extends QueryValue>(
+  client: Client,
+  initial: Page<T> | EmbeddedSet
+): AsyncGenerator<Page<T>, void, unknown> {
+  let currentPage = initial;
+
+  if ("data" in initial) {
+    yield new Page(initial);
+  }
+
+  while (currentPage.after) {
+    // cursor means there is more data to fetch
+    const response = await client.query<Page<T>>(
+      // project for data and after cursors so we don't have issues with
+      // recursive Page instances
+      fql`Set.paginate(${currentPage.after}) { data, after }`
+    );
+    const nextPage = response.data;
+
+    currentPage = nextPage;
+    yield new Page(nextPage);
+  }
+
+  return;
 }


### PR DESCRIPTION
Ticket(s): [FE-3110](https://faunadb.atlassian.net/browse/FE-3110)

## Problem
We want to provide native async-iterator API for fetching multiple pages of data.

We want to limit friction for users getting paginated data.

Users need to have control over remote fetches, and need access to the after-cursors if they want them.

## Solution
Add the `EmbeddedSet` class to differentiate between a materialized Set (Page) and an unmaterialized one. This lets us enforce that a `Page` instance always contains data.

Add a `SetIterator` class (same as `SetIterator` in #141). Can be constructed and used like this

```typescript
const response = await client.query(fql`MyCollection.all()`);
const page = response.data;
const setIterator = new SetIterator(client, page);

for await (const page of setIterator) {
  // do stuff with page
}
```

NOTE: Regarding helper factory methods, these are not implemented here (yet), but it would be pretty trivial to add helpers to either Client or Page or both:

```typescript
class Page<T> {
  // ...

  toIter(client: Client): SetIterator<T> {
    return new SetIterator(client, this)
  }
}
```
```typescript
class Client {
  // ...

  setIterator<T>(page: Page<T>): SetIterator<T> {
    return new SetIterator(this, page)
  }
}
```

## Out of scope
n/a

## Testing
Added new tests.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3110]: https://faunadb.atlassian.net/browse/FE-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ