### PR TITLE
Pagination iterator type (3) - Can iterate directly over a query

### DIFF
--- a/__tests__/integration/page.test.ts
+++ b/__tests__/integration/page.test.ts
@@ -1,4 +1,4 @@
-import { fql, Page } from "../../src";
+import { DocumentT, fql, Page, SetIterator } from "../../src";
 import { getClient } from "../client";
 
 const client = getClient({
@@ -19,5 +19,135 @@ describe("querying for set", () => {
     // expect(result.data).toBeInstanceOf(Page);
     // expect(result.data.data).toStrictEqual([1, 2, 3]);
     // expect(result.data.after).toBe("1234");
+  });
+});
+
+describe("SetIterator", () => {
+  beforeAll(async () => {
+    await client.query(fql`
+      if (Collection.byName("IterTestSmall") != null) {
+        IterTestSmall.definition.delete()
+      }
+      if (Collection.byName("IterTestBig") != null) {
+        IterTestBig.definition.delete()
+      }
+    `);
+    await client.query(fql`
+      Collection.create({ name: "IterTestSmall" })
+      Collection.create({ name: "IterTestBig" })
+    `);
+    await client.query(fql`
+      [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+      ].map(i => IterTestSmall.create({ value: i }))
+
+      [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ].map(i => IterTestBig.create({ value: i }))
+    `);
+  });
+
+  type MyDoc = DocumentT<{
+    value: number;
+  }>;
+
+  it("can get single page using for..of when the set is small", async () => {
+    expect.assertions(1);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestSmall.all()`
+    );
+    const setIterator = response.data;
+
+    for await (const page of setIterator) {
+      expect(page.data.length).toBe(10);
+    }
+  });
+
+  it("can get multiple pages using for..of when the set is large", async () => {
+    expect.assertions(2);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    for await (const page of setIterator) {
+      expect(page.data.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("can get pages using next()", async () => {
+    expect.assertions(3);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    const result1 = await setIterator.next();
+    if (!result1.done) {
+      expect(result1.value.data.length).toBe(16);
+    }
+
+    const result2 = await setIterator.next();
+    if (!result2.done) {
+      expect(result2.value.data.length).toBe(4);
+    }
+
+    const result3 = await setIterator.next();
+    expect(result3.done).toBe(true);
+  });
+
+  it("can get pages using a loop with next()", async () => {
+    expect.assertions(2);
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    let done = false;
+    while (!done) {
+      const next = await setIterator.next();
+      done = next.done ?? false;
+
+      if (!next.done) {
+        const page = next.value;
+        expect(page.data.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("can can stop the iterator with the return method", async () => {
+    expect.assertions(1);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    for await (const page of setIterator) {
+      expect(page.data.length).toBe(16);
+      await setIterator.return();
+    }
+  });
+
+  it("can can stop the iterator with the throw method", async () => {
+    expect.assertions(2);
+
+    const response = await client.query<SetIterator<MyDoc>>(
+      fql`IterTestBig.all()`
+    );
+    const setIterator = response.data;
+
+    try {
+      for await (const page of setIterator) {
+        expect(page.data.length).toBe(16);
+        await setIterator.throw("oops");
+      }
+    } catch (e) {
+      expect(e).toBe("oops");
+    }
   });
 });

--- a/__tests__/integration/page.test.ts
+++ b/__tests__/integration/page.test.ts
@@ -55,10 +55,9 @@ describe("SetIterator", () => {
   it("can get single page using for..of when the set is small", async () => {
     expect.assertions(1);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestSmall.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestSmall.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     for await (const page of setIterator) {
       expect(page.data.length).toBe(10);
@@ -68,10 +67,9 @@ describe("SetIterator", () => {
   it("can get multiple pages using for..of when the set is large", async () => {
     expect.assertions(2);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     for await (const page of setIterator) {
       expect(page.data.length).toBeGreaterThan(0);
@@ -81,10 +79,9 @@ describe("SetIterator", () => {
   it("can get pages using next()", async () => {
     expect.assertions(3);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     const result1 = await setIterator.next();
     if (!result1.done) {
@@ -102,10 +99,9 @@ describe("SetIterator", () => {
 
   it("can get pages using a loop with next()", async () => {
     expect.assertions(2);
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     let done = false;
     while (!done) {
@@ -122,10 +118,9 @@ describe("SetIterator", () => {
   it("can can stop the iterator with the return method", async () => {
     expect.assertions(1);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     for await (const page of setIterator) {
       expect(page.data.length).toBe(16);
@@ -136,10 +131,9 @@ describe("SetIterator", () => {
   it("can can stop the iterator with the throw method", async () => {
     expect.assertions(2);
 
-    const response = await client.query<SetIterator<MyDoc>>(
-      fql`IterTestBig.all()`
-    );
-    const setIterator = response.data;
+    const response = await client.query<Page<MyDoc>>(fql`IterTestBig.all()`);
+    const page = response.data;
+    const setIterator = new SetIterator(client, page);
 
     try {
       for await (const page of setIterator) {

--- a/__tests__/integration/set.test.ts
+++ b/__tests__/integration/set.test.ts
@@ -184,12 +184,15 @@ describe("SetIterator", () => {
   });
 
   it("can be flattened", async () => {
-    expect.assertions(20);
+    expect.assertions(21);
 
     const setIterator = client.paginate<MyDoc>(fql`IterTestBig.all()`);
 
+    const foundItems: number[] = [];
     for await (const item of setIterator.flatten()) {
       expect(item.id).toBeDefined();
+      foundItems.push(item.value);
     }
+    expect(foundItems).toEqual(bigItems);
   });
 });

--- a/__tests__/integration/set.test.ts
+++ b/__tests__/integration/set.test.ts
@@ -6,10 +6,10 @@ const client = getClient({
   query_timeout_ms: 60_000,
 });
 
-const smallItems = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-const bigItems = [
+const smallItems = new Set([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+const bigItems = new Set([
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
-];
+]);
 
 afterAll(() => {
   client.close();
@@ -42,8 +42,8 @@ describe("SetIterator", () => {
       Collection.create({ name: "IterTestBig" })
     `);
     await client.query(fql`
-      ${smallItems}.map(i => IterTestSmall.create({ value: i }))
-      ${bigItems}.map(i => IterTestBig.create({ value: i }))
+      ${[...smallItems]}.map(i => IterTestSmall.create({ value: i }))
+      ${[...bigItems]}.map(i => IterTestBig.create({ value: i }))
     `);
   });
 
@@ -58,11 +58,11 @@ describe("SetIterator", () => {
     const page = response.data;
     const setIterator = client.paginate(page);
 
-    const foundItems: number[] = [];
+    const foundItems = new Set<number>();
     for await (const page of setIterator) {
       expect(page.length).toBe(10);
       for (const item of page) {
-        foundItems.push(item.value);
+        foundItems.add(item.value);
       }
     }
     expect(foundItems).toEqual(smallItems);
@@ -75,11 +75,11 @@ describe("SetIterator", () => {
     const page = response.data;
     const setIterator = client.paginate(page);
 
-    const foundItems: number[] = [];
+    const foundItems = new Set<number>();
     for await (const page of setIterator) {
       expect(page.length).toBeGreaterThan(0);
       for (let item of page) {
-        foundItems.push(item.value);
+        foundItems.add(item.value);
       }
     }
     expect(foundItems).toEqual(bigItems);
@@ -92,13 +92,13 @@ describe("SetIterator", () => {
     const page = response.data;
     const setIterator = client.paginate(page);
 
-    const foundItems: number[] = [];
+    const foundItems = new Set<number>();
 
     const result1 = await setIterator.next();
     if (!result1.done) {
       expect(result1.value.length).toBe(16);
       for (const i of result1.value) {
-        foundItems.push(i.value);
+        foundItems.add(i.value);
       }
     }
 
@@ -106,7 +106,7 @@ describe("SetIterator", () => {
     if (!result2.done) {
       expect(result2.value.length).toBe(4);
       for (const i of result2.value) {
-        foundItems.push(i.value);
+        foundItems.add(i.value);
       }
     }
 
@@ -188,10 +188,10 @@ describe("SetIterator", () => {
 
     const setIterator = client.paginate<MyDoc>(fql`IterTestBig.all()`);
 
-    const foundItems: number[] = [];
+    const foundItems = new Set<number>();
     for await (const item of setIterator.flatten()) {
       expect(item.id).toBeDefined();
-      foundItems.push(item.value);
+      foundItems.add(item.value);
     }
     expect(foundItems).toEqual(bigItems);
   });

--- a/__tests__/integration/set.test.ts
+++ b/__tests__/integration/set.test.ts
@@ -1,4 +1,4 @@
-import { DocumentT, fql, Page, SetIterator } from "../../src";
+import { DocumentT, fql, Page } from "../../src";
 import { getClient } from "../client";
 
 const client = getClient({
@@ -179,7 +179,17 @@ describe("SetIterator", () => {
     const setIterator = client.paginate<number>(fql`42`);
 
     for await (const page of setIterator) {
-      expect(page).toBe(42);
+      expect(page).toStrictEqual([42]);
+    }
+  });
+
+  it("can be flattened", async () => {
+    expect.assertions(20);
+
+    const setIterator = client.paginate<MyDoc>(fql`IterTestBig.all()`);
+
+    for await (const item of setIterator.flatten()) {
+      expect(item.id).toBeDefined();
     }
   });
 });

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -1,4 +1,7 @@
-import { EmbeddedSet, Page } from "../../src";
+import { EmbeddedSet, Page, SetIterator } from "../../src";
+import { getClient } from "../client";
+
+const client = getClient();
 
 describe("Page", () => {
   it("can be constructed directly", () => {
@@ -18,5 +21,40 @@ describe("Embedded Set", () => {
   it("can be constructed directly", () => {
     const set = new EmbeddedSet("1234");
     expect(set.after).toBe("1234");
+  });
+});
+
+describe("SetIterator", () => {
+  it("can be constructed from a Page", () => {
+    const page = new Page({
+      data: [1, 2, 3],
+      after: "1234",
+    });
+    const set = new SetIterator<number>(client, page);
+    expect(set.data).toStrictEqual([1, 2, 3]);
+    expect(set.after).toBe("1234");
+  });
+
+  it("can be constructed from an EmbeddedSet", () => {
+    const embeddedSet = new EmbeddedSet("1234");
+    const set = new SetIterator<number>(client, embeddedSet);
+    expect(set.after).toBe("1234");
+  });
+
+  it("after is optional", () => {
+    const set = new SetIterator<number>(client, { data: [1, 2, 3] });
+    expect(set.data).toStrictEqual([1, 2, 3]);
+    expect(set.after).toBeUndefined();
+  });
+
+  it("data is optional if after is provided", () => {
+    const set = new SetIterator<number>(client, { after: "1234" });
+    expect(set.data).toBeUndefined;
+    expect(set.after).toBe("1234");
+  });
+
+  it("throws if data and after are both undefined", () => {
+    // @ts-ignore-next-line
+    expect(() => new SetIterator<number>(client, {})).toThrow();
   });
 });

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -1,4 +1,4 @@
-import { Page } from "../../src";
+import { EmbeddedSet, Page } from "../../src";
 
 describe("Page", () => {
   it("can be constructed directly", () => {
@@ -13,14 +13,15 @@ describe("Page", () => {
     expect(set.after).toBeUndefined();
   });
 
-  it("data is optional if after is provided", () => {
-    const set = new Page<number>({ after: "1234" });
-    expect(set.data).toBeUndefined;
-    expect(set.after).toBe("1234");
+  it("throws if data is undefined", () => {
+    // @ts-expect-error
+    expect(() => new Page<number>({ after: "1234" })).toThrow();
   });
+});
 
-  it("throws if data and after are both undefined", () => {
-    // @ts-ignore-next-line
-    expect(() => new Page<number>({})).toThrow();
+describe("Embedded Set", () => {
+  it("can be constructed directly", () => {
+    const set = new EmbeddedSet("1234");
+    expect(set.after).toBe("1234");
   });
 });

--- a/__tests__/unit/page.test.ts
+++ b/__tests__/unit/page.test.ts
@@ -12,11 +12,6 @@ describe("Page", () => {
     expect(set.data).toStrictEqual([1, 2, 3]);
     expect(set.after).toBeUndefined();
   });
-
-  it("throws if data is undefined", () => {
-    // @ts-expect-error
-    expect(() => new Page<number>({ after: "1234" })).toThrow();
-  });
 });
 
 describe("Embedded Set", () => {

--- a/__tests__/unit/set.test.ts
+++ b/__tests__/unit/set.test.ts
@@ -46,16 +46,20 @@ describe("SetIterator", () => {
     }));
 
     for await (const page of setIterator) {
-      expect(page).toBe(42);
+      expect(page).toStrictEqual([42]);
     }
   });
 
-  it("after is optional", () => {
-    const set = new SetIterator<number>(client, { data: [1, 2, 3] });
-  });
+  it("can be flattened", async () => {
+    expect.assertions(1);
 
-  it("data is optional if after is provided", () => {
-    const set = new SetIterator<number>(client, { after: "1234" });
+    const setIterator = new SetIterator<number>(client, async () => ({
+      data: 42,
+    }));
+
+    for await (const item of setIterator.flatten()) {
+      expect(item).toStrictEqual(42);
+    }
   });
 
   it("throws if data and after are both undefined", () => {

--- a/__tests__/unit/set.test.ts
+++ b/__tests__/unit/set.test.ts
@@ -41,9 +41,7 @@ describe("SetIterator", () => {
   it("can be constructed with an initial thunk", async () => {
     expect.assertions(1);
 
-    const setIterator = new SetIterator<number>(client, async () => ({
-      data: 42,
-    }));
+    const setIterator = new SetIterator<number>(client, async () => 42);
 
     for await (const page of setIterator) {
       expect(page).toStrictEqual([42]);
@@ -53,9 +51,7 @@ describe("SetIterator", () => {
   it("can be flattened", async () => {
     expect.assertions(1);
 
-    const setIterator = new SetIterator<number>(client, async () => ({
-      data: 42,
-    }));
+    const setIterator = new SetIterator<number>(client, async () => 42);
 
     for await (const item of setIterator.flatten()) {
       expect(item).toStrictEqual(42);

--- a/__tests__/unit/set.test.ts
+++ b/__tests__/unit/set.test.ts
@@ -31,26 +31,31 @@ describe("SetIterator", () => {
       after: "1234",
     });
     const set = new SetIterator<number>(client, page);
-    expect(set.data).toStrictEqual([1, 2, 3]);
-    expect(set.after).toBe("1234");
   });
 
   it("can be constructed from an EmbeddedSet", () => {
     const embeddedSet = new EmbeddedSet("1234");
     const set = new SetIterator<number>(client, embeddedSet);
-    expect(set.after).toBe("1234");
+  });
+
+  it("can be constructed with an initial thunk", async () => {
+    expect.assertions(1);
+
+    const setIterator = new SetIterator<number>(client, async () => ({
+      data: 42,
+    }));
+
+    for await (const page of setIterator) {
+      expect(page).toBe(42);
+    }
   });
 
   it("after is optional", () => {
     const set = new SetIterator<number>(client, { data: [1, 2, 3] });
-    expect(set.data).toStrictEqual([1, 2, 3]);
-    expect(set.after).toBeUndefined();
   });
 
   it("data is optional if after is provided", () => {
     const set = new SetIterator<number>(client, { after: "1234" });
-    expect(set.data).toBeUndefined;
-    expect(set.after).toBe("1234");
   });
 
   it("throws if data and after are both undefined", () => {

--- a/__tests__/unit/set.test.ts
+++ b/__tests__/unit/set.test.ts
@@ -38,7 +38,7 @@ describe("SetIterator", () => {
     new SetIterator<number>(client, embeddedSet);
   });
 
-  it("can be constructed with an initial thunk", async () => {
+  it("can be constructed with an initial thunk for a T", async () => {
     expect.assertions(1);
 
     const setIterator = new SetIterator<number>(client, async () => 42);
@@ -46,6 +46,23 @@ describe("SetIterator", () => {
     for await (const page of setIterator) {
       expect(page).toStrictEqual([42]);
     }
+  });
+
+  it("can be constructed with an initial thunk for a Page<T>", async () => {
+    expect.assertions(1);
+
+    const setIterator = new SetIterator<number>(
+      client,
+      async () => new Page({ data: [42] })
+    );
+
+    for await (const page of setIterator) {
+      expect(page).toStrictEqual([42]);
+    }
+  });
+
+  it("can be constructed with an initial thunk for an EmbeddedSet", async () => {
+    new SetIterator<number>(client, async () => new EmbeddedSet("1234"));
   });
 
   it("can be flattened", async () => {

--- a/__tests__/unit/set.test.ts
+++ b/__tests__/unit/set.test.ts
@@ -30,12 +30,12 @@ describe("SetIterator", () => {
       data: [1, 2, 3],
       after: "1234",
     });
-    const set = new SetIterator<number>(client, page);
+    new SetIterator<number>(client, page);
   });
 
   it("can be constructed from an EmbeddedSet", () => {
     const embeddedSet = new EmbeddedSet("1234");
-    const set = new SetIterator<number>(client, embeddedSet);
+    new SetIterator<number>(client, embeddedSet);
   });
 
   it("can be constructed with an initial thunk", async () => {

--- a/__tests__/unit/set.test.ts
+++ b/__tests__/unit/set.test.ts
@@ -75,6 +75,19 @@ describe("SetIterator", () => {
     }
   });
 
+  it("can flatten a Page", async () => {
+    expect.assertions(2);
+
+    const setIterator = new SetIterator<number>(
+      client,
+      async () => new Page({ data: [42, 42] })
+    );
+
+    for await (const item of setIterator.flatten()) {
+      expect(item).toStrictEqual(42);
+    }
+  });
+
   it("throws if data and after are both undefined", () => {
     // @ts-ignore-next-line
     expect(() => new SetIterator<number>(client, {})).toThrow();

--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -11,6 +11,7 @@ import {
   Page,
   TaggedTypeFormat,
   TimeStub,
+  EmbeddedSet,
 } from "../../src";
 
 describe("tagged format", () => {
@@ -73,7 +74,7 @@ describe("tagged format", () => {
         }
       },
       "page": { "@set": { "data": ["a", "b"] } },
-      "page_string": { "@set": "abc123" }
+      "embeddedSet": { "@set": "abc123" }
     }`;
 
     const bugs_mod = new Module("Bugs");
@@ -100,7 +101,7 @@ describe("tagged format", () => {
     const nullDoc = new NullDocument(docReference, "not found");
 
     const page = new Page({ data: ["a", "b"] });
-    const page_string = new Page({ after: "abc123" });
+    const embeddedSet = new EmbeddedSet("abc123");
 
     const result = TaggedTypeFormat.decode(allTypes);
     expect(result.name).toEqual("fir");
@@ -126,7 +127,7 @@ describe("tagged format", () => {
     expect(result.namedDoc).toStrictEqual(namedDoc);
     expect(result.nullDoc).toStrictEqual(nullDoc);
     expect(result.page).toStrictEqual(page);
-    expect(result.page_string).toStrictEqual(page_string);
+    expect(result.embeddedSet).toStrictEqual(embeddedSet);
   });
 
   it("can be encoded", () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -137,6 +137,45 @@ export class Client {
     this.#isClosed = true;
   }
 
+  /**
+   * Creates an iterator to yield pages of data. If additional pages exist, the
+   * iterator will lazily fetch addition pages on each iteration.
+   *
+   * @typeParam T - The expected type of the items returned from Fauna on each
+   * iteration
+   * @param iterable - a {@link Query} or an existing fauna Set ({@link Page} or
+   * {@link EmbeddedSet})
+   * @returns A {@link SetIterator} that lazily fetches new pages of data on
+   * each iteration
+   *
+   * @example
+   * ```javascript
+   *  const userIterator = await client.paginate(fql`
+   *    Users.all()
+   *  `);
+   *
+   *  for await (const users of userIterator) {
+   *    for (const user of users) {
+   *      // do something with each user
+   *    }
+   *  }
+   * ```
+   *
+   * @example
+   * The {@link SetIterator.flatten} method can be used so the iterator yields
+   * items directly. Each item is fetched asynchronously and hides when
+   * additional pages are fetched.
+   *
+   * ```javascript
+   *  const userIterator = await client.paginate(fql`
+   *    Users.all()
+   *  `);
+   *
+   *  for await (const user of userIterator.flatten()) {
+   *    // do something with each user
+   *  }
+   * ```
+   */
   paginate<T extends QueryValue>(
     iterable: Page<T> | EmbeddedSet | Query
   ): SetIterator<T> {
@@ -148,12 +187,15 @@ export class Client {
 
   /**
    * Queries Fauna.
+   *
+   * @typeParam T - The expected type of the response from Fauna
    * @param request - a {@link Query} to execute in Fauna.
    *  Note, you can embed header fields in this object; if you do that there's no need to
    *  pass the headers parameter.
    * @param headers - optional {@link QueryRequestHeaders} to apply on top of the request input.
    *   Values in this headers parameter take precedence over the same values in the {@link ClientConfiguration}.
    * @returns Promise&lt;{@link QuerySuccess}&gt;.
+   *
    * @throws {@link ServiceError} Fauna emitted an error. The ServiceError will be
    *   one of ServiceError's child classes if the error can be further categorized,
    *   or a concrete ServiceError if it cannot. ServiceError child types are

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,7 +17,7 @@ import {
   ContendedTransactionError,
   InvalidRequestError,
 } from "./errors";
-import type { Query } from "./query-builder";
+import { Query } from "./query-builder";
 import {
   isQueryFailure,
   isQuerySuccess,
@@ -33,7 +33,7 @@ import {
   type HTTPClient,
 } from "./http-client";
 import { TaggedTypeFormat } from "./tagged-type";
-import { Page, SetIterator } from "./values";
+import { EmbeddedSet, Page, SetIterator } from "./values";
 
 const defaultClientConfiguration: Pick<
   ClientConfiguration,
@@ -137,14 +137,13 @@ export class Client {
     this.#isClosed = true;
   }
 
-  paginate<T extends QueryValue = QueryValue>(
-    iterable: Page<T> | Query
+  paginate<T extends QueryValue>(
+    iterable: Page<T> | EmbeddedSet | Query
   ): SetIterator<T> {
-    if (iterable instanceof Page) {
-      return new SetIterator<T>(this, iterable);
+    if (iterable instanceof Query) {
+      return SetIterator.fromQuery(this, iterable);
     }
-
-    return new SetIterator<T>(this, () => this.query(iterable));
+    return SetIterator.fromPageable(this, iterable) as SetIterator<T>;
   }
 
   /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -33,6 +33,7 @@ import {
   type HTTPClient,
 } from "./http-client";
 import { TaggedTypeFormat } from "./tagged-type";
+import { Page, SetIterator } from "./values";
 
 const defaultClientConfiguration: Pick<
   ClientConfiguration,
@@ -134,6 +135,16 @@ export class Client {
     }
     this.#httpClient.close();
     this.#isClosed = true;
+  }
+
+  paginate<T extends QueryValue = QueryValue>(
+    iterable: Page<T> | Query
+  ): SetIterator<T> {
+    if (iterable instanceof Page) {
+      return new SetIterator<T>(this, iterable);
+    }
+
+    return new SetIterator<T>(this, () => this.query(iterable));
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,11 +42,13 @@ export {
   Document,
   DocumentReference,
   type DocumentT,
+  EmbeddedSet,
   Module,
   NamedDocument,
   NamedDocumentReference,
   NullDocument,
   Page,
+  SetIterator,
   TimeStub,
 } from "./values";
 export {

--- a/src/values/index.ts
+++ b/src/values/index.ts
@@ -1,3 +1,3 @@
 export * from "./date-time";
 export * from "./doc";
-export * from "./page";
+export * from "./set";

--- a/src/values/page.ts
+++ b/src/values/page.ts
@@ -51,17 +51,14 @@ export class SetIterator<T extends QueryValue>
   #currentAfter?: string;
 
   constructor(client: Client, initial: Page<T> | EmbeddedSet) {
+    if (!("data" in initial) && initial.after === undefined) {
+      throw new TypeError(
+        "Failed to construct a Page. 'data' and 'after' are both undefined"
+      );
+    }
     this.#generator = generatePages(client, initial);
+    if ("data" in initial) this.#currentData = initial.data;
     this.#currentAfter = initial.after;
-  }
-
-  static fromPage<T extends QueryValue>(
-    client: Client,
-    initial: Page<T>
-  ): SetIterator<T> {
-    const iter = new SetIterator<T>(client, initial);
-    iter.#currentData = initial.data;
-    return iter;
   }
 
   /** A materialized page of data */

--- a/src/values/page.ts
+++ b/src/values/page.ts
@@ -110,9 +110,7 @@ async function* generatePages<T extends QueryValue>(
   while (currentPage.after) {
     // cursor means there is more data to fetch
     const response = await client.query<Page<T>>(
-      // project for data and after cursors so we don't have issues with
-      // recursive Page instances
-      fql`Set.paginate(${currentPage.after}) { data, after }`
+      fql`Set.paginate(${currentPage.after})`
     );
     const nextPage = response.data;
 

--- a/src/values/page.ts
+++ b/src/values/page.ts
@@ -1,12 +1,14 @@
+import { Client } from "../client";
+import { fql } from "../query-builder";
 import { QueryValue } from "../wire-protocol";
 
 /**
- * A Fauna Set.
+ * A materialize view of a Set.
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
  */
 export class Page<T extends QueryValue> {
   /** A materialized page of data */
-  readonly data?: T[];
+  readonly data: T[];
   /**
    * A pagination cursor, used to obtain additional information in the Set.
    * If `after` is not provided, then `data` must be present and represents the
@@ -14,17 +16,112 @@ export class Page<T extends QueryValue> {
    */
   readonly after?: string;
 
-  constructor({
-    data,
-    after,
-  }: { data: T[]; after?: string } | { data?: undefined; after: string }) {
-    if (data === undefined && after === undefined) {
-      throw new TypeError(
-        "Failed to construct a Page. 'data' and 'after' are both undefined"
-      );
-    }
-
+  constructor({ data, after }: { data: T[]; after?: string }) {
     this.data = data;
     this.after = after;
   }
+}
+
+/**
+ * A un-materialize Set. Typically received when a materialized Set contains
+ * another set, the EmbeddedSet does not contain any data to avoid potential
+ * issues such as self-reference and infinite recursion
+ * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
+ */
+export class EmbeddedSet {
+  /**
+   * A pagination cursor, used to obtain additional information in the Set.
+   */
+  readonly after: string;
+
+  constructor(after: string) {
+    this.after = after;
+  }
+}
+
+/**
+ * A class to provide an iterable API for fetching multiple pages of data, given
+ * a Fauna Set
+ */
+export class SetIterator<T extends QueryValue>
+  implements AsyncGenerator<Page<T>, void, unknown>
+{
+  readonly #generator: AsyncGenerator<Page<T>, void, unknown>;
+  #currentData?: T[];
+  #currentAfter?: string;
+
+  constructor(client: Client, initial: Page<T> | EmbeddedSet) {
+    this.#generator = generatePages(client, initial);
+    this.#currentAfter = initial.after;
+  }
+
+  static fromPage<T extends QueryValue>(
+    client: Client,
+    initial: Page<T>
+  ): SetIterator<T> {
+    const iter = new SetIterator<T>(client, initial);
+    iter.#currentData = initial.data;
+    return iter;
+  }
+
+  /** A materialized page of data */
+  get data() {
+    return this.#currentData;
+  }
+
+  /**
+   * A pagination cursor, used to obtain additional information in the Set.
+   * If `after` is not provided, then `data` must be present and represents the
+   * last Page in the Set.
+   */
+  get after() {
+    return this.#currentAfter;
+  }
+
+  async next(): Promise<IteratorResult<Page<T>, void>> {
+    const next = await this.#generator.next();
+    if (next.value) {
+      this.#currentData = next.value.data;
+      this.#currentAfter = next.value.after;
+    }
+    return next;
+  }
+
+  async return(): Promise<IteratorResult<Page<T>, void>> {
+    return this.#generator.return();
+  }
+
+  async throw(e: any): Promise<IteratorResult<Page<T>, void>> {
+    return this.#generator.throw(e);
+  }
+
+  [Symbol.asyncIterator]() {
+    return this;
+  }
+}
+
+async function* generatePages<T extends QueryValue>(
+  client: Client,
+  initial: Page<T> | EmbeddedSet
+): AsyncGenerator<Page<T>, void, unknown> {
+  let currentPage = initial;
+
+  if ("data" in initial) {
+    yield new Page(initial);
+  }
+
+  while (currentPage.after) {
+    // cursor means there is more data to fetch
+    const response = await client.query<Page<T>>(
+      // project for data and after cursors so we don't have issues with
+      // recursive Page instances
+      fql`Set.paginate(${currentPage.after}) { data, after }`
+    );
+    const nextPage = response.data;
+
+    currentPage = nextPage;
+    yield new Page(nextPage);
+  }
+
+  return;
 }

--- a/src/values/set.ts
+++ b/src/values/set.ts
@@ -1,6 +1,6 @@
 import { Client } from "../client";
 import { Query, fql } from "../query-builder";
-import { QuerySuccess, QueryValue } from "../wire-protocol";
+import { QueryValue } from "../wire-protocol";
 
 /**
  * A materialize view of a Set.
@@ -23,7 +23,7 @@ export class Page<T extends QueryValue> {
 }
 
 /**
- * A un-materialize Set. Typically received when a materialized Set contains
+ * A un-materialized Set. Typically received when a materialized Set contains
  * another set, the EmbeddedSet does not contain any data to avoid potential
  * issues such as self-reference and infinite recursion
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
@@ -48,6 +48,22 @@ export class SetIterator<T extends QueryValue>
 {
   readonly #generator: AsyncGenerator<T[], void, unknown>;
 
+  /**
+   * Constructs a new {@link SetIterator}.
+   *
+   * @remarks Though you can use {@link SetIterator} class directly, it is
+   * most common to create an instance through the {@link Client.paginate} `paginate`
+   * method.
+   *
+   * @typeParam T - The expected type of the items returned from Fauna on each
+   * iteration
+   * @param client - The {@link Client} that will be used to fetch new data on
+   * each iteration
+   * @param initial - An existing fauna Set ({@link Page} or
+   * {@link EmbeddedSet}) or function which returns a promise. If the Promise
+   * resolves to a {@link Page} or {@link EmbeddedSet} then the iterator will
+   * use the client to fetch additional pages of data
+   */
   constructor(
     client: Client,
     initial: Page<T> | EmbeddedSet | (() => Promise<T>)
@@ -58,16 +74,19 @@ export class SetIterator<T extends QueryValue>
       this.#generator = generatePages(client, initial);
     } else {
       throw new TypeError(
-        "Expected 'Pageable<QueryValue> | (() => Promise<T>)', but received " +
-          // @ts-expect-error "Property 'constructor' does not exist on type 'never'."
-          // This is okay, we still want to catch weird inputs from JS
-          initial.constructor.name +
-          " " +
-          JSON.stringify(initial)
+        `Expected 'Page<T> | EmbeddedSet | (() => Promise<T>)', but received ${JSON.stringify(
+          initial
+        )}`
       );
     }
   }
 
+  /**
+   * Constructs a new {@link SetIterator} from an {@link Query}
+   *
+   * @internal Though you can use {@link SetIterator.fromQuery} directly, it is
+   * intended as a convenience for use in the {@link Client.paginate} method
+   */
   static fromQuery<T extends QueryValue>(
     client: Client,
     query: Query
@@ -78,6 +97,13 @@ export class SetIterator<T extends QueryValue>
     });
   }
 
+  /**
+   * Constructs a new {@link SetIterator} from an {@link Page} or
+   * {@link EmbeddedSet}
+   *
+   * @internal Though you can use {@link SetIterator.fromPageable} directly, it
+   * is intended as a convenience for use in the {@link Client.paginate} method
+   */
   static fromPageable<T extends QueryValue>(
     client: Client,
     pageable: Page<T> | EmbeddedSet
@@ -85,63 +111,86 @@ export class SetIterator<T extends QueryValue>
     return new SetIterator<T>(client, pageable);
   }
 
+  /**
+   * Constructs a new {@link FlattenedSetIterator} from the current instance
+   *
+   * @returns A new {@link FlattenedSetIterator} from the current instance
+   */
   flatten(): FlattenedSetIterator<T> {
     return new FlattenedSetIterator(this);
   }
 
+  /** Implement {@link AsyncGenerator.next} */
   async next(): Promise<IteratorResult<T[], void>> {
     return this.#generator.next();
   }
 
+  /** Implement {@link AsyncGenerator.return} */
   async return(): Promise<IteratorResult<T[], void>> {
     return this.#generator.return();
   }
 
+  /** Implement {@link AsyncGenerator.throw} */
   async throw(e: any): Promise<IteratorResult<T[], void>> {
     return this.#generator.throw(e);
   }
 
+  /** Implement {@link AsyncGenerator} */
   [Symbol.asyncIterator]() {
     return this;
   }
 }
 
+/**
+ * A class to provide an iterable API for fetching multiple pages of data, given
+ * a Fauna Set. This class takes a {@link SetIterator} and flattens the results
+ * to yield the items directly.
+ */
 export class FlattenedSetIterator<T extends QueryValue>
   implements AsyncGenerator<T, void, unknown>
 {
   readonly #generator: AsyncGenerator<T, void, unknown>;
 
+  /**
+   * Constructs a new {@link FlattenedSetIterator}.
+   *
+   * @remarks Though you can use {@link FlattenedSetIterator} class directly, it
+   * is most common to create an instance through the
+   * {@link SetIterator.flatten} method.
+   *
+   * @typeParam T - The expected type of the items returned from Fauna on each
+   * iteration
+   * @param setIterator - The {@link SetIterator}
+   */
   constructor(setIterator: SetIterator<T>) {
-    async function* generateItems<T extends QueryValue>(
-      setIterator: SetIterator<T>
-    ) {
-      for await (const page of setIterator) {
-        for (const item of page) {
-          yield item;
-        }
-      }
-    }
-
     this.#generator = generateItems(setIterator);
   }
 
+  /** Implement {@link AsyncGenerator.next} */
   async next(): Promise<IteratorResult<T, void>> {
     return this.#generator.next();
   }
 
+  /** Implement {@link AsyncGenerator.return} */
   async return(): Promise<IteratorResult<T, void>> {
     return this.#generator.return();
   }
 
+  /** Implement {@link AsyncGenerator.throw} */
   async throw(e: any): Promise<IteratorResult<T, void>> {
     return this.#generator.throw(e);
   }
 
+  /** Implement {@link AsyncGenerator} */
   [Symbol.asyncIterator]() {
     return this;
   }
 }
 
+/**
+ * Internal async generator function to use with {@link Page} and
+ * {@link EmbeddedSet} values
+ */
 async function* generatePages<T extends QueryValue>(
   client: Client,
   initial: Page<T> | EmbeddedSet
@@ -154,9 +203,8 @@ async function* generatePages<T extends QueryValue>(
 
   while (currentPage.after) {
     // cursor means there is more data to fetch
-    const response = await client.query<Page<T>>(
-      fql`Set.paginate(${currentPage.after})`
-    );
+    const query = fql`Set.paginate(${currentPage.after})`;
+    const response = await client.query<Page<T>>(query);
     const nextPage = response.data;
 
     currentPage = nextPage;
@@ -164,6 +212,11 @@ async function* generatePages<T extends QueryValue>(
   }
 }
 
+/**
+ * Internal async generator function to use with a function that returns a
+ * promise of data. If the promise resolves to a {@link Page} or
+ * {@link EmbeddedSet} then continue iterating.
+ */
 async function* generateFromThunk<T extends QueryValue>(
   client: Client,
   thunk: () => Promise<T>
@@ -178,4 +231,17 @@ async function* generateFromThunk<T extends QueryValue>(
   }
 
   yield [result];
+}
+
+/**
+ * Internal async generator function that flattens a {@link SetIterator}
+ */
+async function* generateItems<T extends QueryValue>(
+  setIterator: SetIterator<T>
+) {
+  for await (const page of setIterator) {
+    for (const item of page) {
+      yield item;
+    }
+  }
 }

--- a/src/values/set.ts
+++ b/src/values/set.ts
@@ -3,7 +3,7 @@ import { Query, fql } from "../query-builder";
 import { QueryValue } from "../wire-protocol";
 
 /**
- * A materialize view of a Set.
+ * A materialized view of a Set.
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
  */
 export class Page<T extends QueryValue> {

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -4,6 +4,7 @@ import {
   DateStub,
   Document,
   DocumentReference,
+  EmbeddedSet,
   Module,
   NamedDocument,
   NamedDocumentReference,
@@ -277,4 +278,5 @@ export type QueryValue =
   | DocumentReference
   | NamedDocument
   | NamedDocumentReference
-  | Page<QueryValue>;
+  | Page<QueryValue>
+  | EmbeddedSet;


### PR DESCRIPTION
Ticket(s): [FE-3110](https://faunadb.atlassian.net/browse/FE-3110)

## Problem
We want to provide native async-iterator API for fetching multiple pages of data.

We want to limit friction for users getting paginated data.

Users need to have control over remote fetches, and need access to the after-cursors if they want them.

## Solution
Add the `EmbeddedSet` class to differentiate between a materialized Set (Page) and an unmaterialized one. This lets us enforce that a `Page` instance always contains data.

Add a `SetIterator` class. This version of `SetIterator` is different in a couple of ways:

- Instances of `Page` are unwrapped, so results from iterating are always `T[]` instead of `Page<T>`.
- `SetIterator` can be constructed from a nullary function that returns `Promise<QuerySuccess<QueryValue>>`. The first iteration will execute the function asynchronously. If the result is a `Page` then it will return the unwrapped data and continue iterating. If the result is not a `Page` then that value will be returned and iteration will stop.

Can be constructed with a query through the client

```typescript
const setIterator = client.paginate(fql`MyCollection.all()`);

for await (const page of setIterator) { ... }
```

constructed with an existing page through the client,

```typescript
const response = await client.query(fql`MyCollection.all()`);
const setIterator = client.paginate(page)

for await (const page of setIterator) { ... }
```

or still constructed directly,

```typescript
const response = await client.query(fql`MyCollection.all()`);
const page = response.data;
const setIterator = new SetIterator(client, page);

for await (const page of setIterator) { ... }
```

## Out of scope
n/a

## Testing
Added new tests.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3110]: https://faunadb.atlassian.net/browse/FE-3110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ