### PR TITLE
Refactor QueryBuilder to remove dependency on encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ client.query(fql`
   } else {
     Collection.create({ name: ${collectionName} })
     "Collection exists now!"
-  }`)
+  }`);
 ```
 
 This has several advantages:
@@ -210,11 +210,11 @@ console.assert(user_doc.email === "alice@site.example");
 Options are available to configure queries on each request.
 
 ```typescript
-import { fql, Client, type QueryRequestHeaders } from "fauna";
+import { fql, Client, type QueryRequestOptions } from "fauna";
 
 const client = new Client();
 
-const options: QueryRequestHeaders = {
+const options: QueryRequestOptions = {
   format: "tagged",
   linearized: false,
   query_timeout_ms: 60_000,

--- a/__tests__/unit/query-builder.test.ts
+++ b/__tests__/unit/query-builder.test.ts
@@ -1,94 +1,93 @@
-import { fql } from "../../src";
+import { TaggedTypeFormat, fql } from "../../src";
+import { FQLFragment } from "../../src/wire-protocol";
 
-describe("fql method producing Querys", () => {
+describe("fql method producing Queries", () => {
   it("parses with no variables", () => {
     const queryBuilder = fql`'foo'.length`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({ fql: ["'foo'.length"] });
-    expect(queryRequest.arguments).toStrictEqual({});
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe(`'foo'.length`);
+    expect(encoded).toEqual({ fql: ["'foo'.length"] });
   });
 
   it("parses with a string variable", () => {
     const str = "foo";
     const queryBuilder = fql`${str}.length`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe(`"foo".length`);
+    expect(encoded).toEqual({
       fql: [{ value: "foo" }, ".length"],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 
   it("parses with a number variable", () => {
     const num = 8;
     const queryBuilder = fql`'foo'.length == ${num}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe(`'foo'.length == 8`);
+    expect(encoded).toEqual({
       fql: ["'foo'.length == ", { value: { "@int": "8" } }],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 
   it("parses with a boolean variable", () => {
     const bool = true;
     const queryBuilder = fql`val.enabled == ${bool}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe(`val.enabled == true`);
+    expect(encoded).toEqual({
       fql: ["val.enabled == ", { value: true }],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 
   it("parses with a null variable", () => {
     const queryBuilder = fql`value: ${null}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe(`value: null`);
+    expect(encoded).toEqual({
       fql: ["value: ", { value: null }],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 
   it("parses with an object variable", () => {
     const obj = { foo: "bar", bar: "baz" };
     const queryBuilder = fql`value: ${obj}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe('value: {"foo":"bar","bar":"baz"}');
+    expect(encoded).toEqual({
       fql: ["value: ", { value: { bar: "baz", foo: "bar" } }],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
-  });
-
-  it("parses with an object variable having a toQuery property", () => {
-    const obj = { foo: "bar", bar: "baz", toQuery: "hehe" };
-    const queryBuilder = fql`value: ${obj}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
-      fql: ["value: ", { value: { bar: "baz", foo: "bar", toQuery: "hehe" } }],
-    });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 
   it("parses with an array variable", () => {
     const arr = [1, 2, 3];
     const queryBuilder = fql`value: ${arr}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe("value: [1,2,3]");
+    expect(encoded).toEqual({
       fql: [
         "value: ",
         { value: [{ "@int": "1" }, { "@int": "2" }, { "@int": "3" }] },
       ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 
   it("parses with multiple variables", () => {
     const str = "bar";
     const num = 17;
     const queryBuilder = fql`${str}.length == ${num + 3}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe('"bar".length == 20');
+    expect(encoded).toEqual({
       fql: [{ value: "bar" }, ".length == ", { value: { "@int": "20" } }],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 
   it("parses nested expressions", () => {
@@ -96,15 +95,16 @@ describe("fql method producing Querys", () => {
     const num = 17;
     const innerQuery = fql`Math.add(${num}, 3)`;
     const queryBuilder = fql`${str}.length == ${innerQuery}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe('"baz".length == Math.add(17, 3)');
+    expect(encoded).toEqual({
       fql: [
         { value: "baz" },
         ".length == ",
         { fql: ["Math.add(", { value: { "@int": "17" } }, ", 3)"] },
       ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 
   it("parses deep nested expressions", () => {
@@ -116,8 +116,12 @@ describe("fql method producing Querys", () => {
     const deeperBuilder = fql`Math.add(${num}, 3)`;
     const innerQuery = fql`Math.add(${deeperBuilder}, ${otherNum})`;
     const queryBuilder = fql`${deepFirst}.length == ${innerQuery}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe(
+      '("baz" + "bar").length == Math.add(Math.add(17, 3), 3)'
+    );
+    expect(encoded).toEqual({
       fql: [
         { fql: ["(", { value: "baz" }, " + ", { value: "bar" }, ")"] },
         ".length == ",
@@ -132,38 +136,6 @@ describe("fql method producing Querys", () => {
         },
       ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
-  });
-
-  it("adds headers if passed in", () => {
-    const str = "baz";
-    const num = 17;
-    const innerQuery = fql`Math.add(${num}, 3)`;
-    const queryBuilder = fql`${str}.length == ${innerQuery}`;
-    const queryRequest = queryBuilder.toQuery({
-      linearized: true,
-      query_timeout_ms: 600,
-      max_contention_retries: 4,
-      query_tags: { a: "tag" },
-      traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00",
-      typecheck: false,
-    });
-    expect(queryRequest).toMatchObject({
-      linearized: true,
-      query_timeout_ms: 600,
-      max_contention_retries: 4,
-      query_tags: { a: "tag" },
-      traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00",
-      typecheck: false,
-    });
-    expect(queryRequest.query).toEqual({
-      fql: [
-        { value: "baz" },
-        ".length == ",
-        { fql: ["Math.add(", { value: { "@int": "17" } }, ", 3)"] },
-      ],
-    });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 
   it("parses with FQL string interpolation", async () => {
@@ -172,14 +144,18 @@ describe("fql method producing Querys", () => {
       let name = ${codeName}
       "Hello, #{name}"
     `;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const encoded: FQLFragment = TaggedTypeFormat.encode(queryBuilder);
+
+    expect(queryBuilder.toString()).toBe(`
+      let name = "Alice"
+      "Hello, #{name}"
+    `);
+    expect(encoded).toEqual({
       fql: [
         "\n      let name = ",
         { value: "Alice" },
         '\n      "Hello, #{name}"\n    ',
       ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export {
   type QueryInfo,
   type QueryInterpolation,
   type QueryRequest,
-  type QueryRequestHeaders,
+  type QueryRequestOptions,
   type QueryStats,
   type QuerySuccess,
   type Span,

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -4,14 +4,14 @@ import type {
   QueryValue,
   QueryInterpolation,
   QueryRequest,
-  QueryRequestHeaders,
+  QueryRequestOptions,
 } from "./wire-protocol";
 
 /**
  * Creates a new Query. Accepts template literal inputs.
  * @param queryFragments - a {@link TemplateStringsArray} that constitute
  *   the strings that are the basis of the query.
- * @param queryArgs - an Array\<QueryValue | Query\> that
+ * @param queryArgs - an Array\<QueryValue\> that
  *   constitute the arguments to inject between the queryFragments.
  * @throws Error - if you call this method directly (not using template
  *   literals) and pass invalid construction parameters
@@ -25,23 +25,24 @@ import type {
  */
 export function fql(
   queryFragments: ReadonlyArray<string>,
-  ...queryArgs: (QueryValue | Query)[]
+  ...queryArgs: QueryValue[]
 ): Query {
   return new Query(queryFragments, ...queryArgs);
 }
 
 /**
- * Internal class.
  * A builder for composing queries using the {@link fql} tagged template
  * function
+ *
+ * @internal This class is not intended to be used directly
  */
 export class Query {
-  readonly #queryFragments: ReadonlyArray<string>;
-  readonly #queryArgs: (QueryValue | Query)[];
+  readonly queryFragments: ReadonlyArray<string>;
+  readonly queryArgs: QueryValue[];
 
   constructor(
     queryFragments: ReadonlyArray<string>,
-    ...queryArgs: (QueryValue | Query)[]
+    ...queryArgs: QueryValue[]
   ) {
     if (
       queryFragments.length === 0 ||
@@ -49,62 +50,28 @@ export class Query {
     ) {
       throw new Error("invalid query constructed");
     }
-    this.#queryFragments = queryFragments;
-    this.#queryArgs = queryArgs;
+    this.queryFragments = queryFragments;
+    this.queryArgs = queryArgs;
   }
 
-  /**
-   * Converts this Query to a {@link QueryRequest} you can send
-   * to Fauna.
-   * @param requestHeaders - optional {@link QueryRequestHeaders} to include
-   *   in the request (and thus override the defaults in your {@link ClientConfiguration}.
-   *   If not passed in, no headers will be set as overrides.
-   * @returns a {@link QueryRequest}.
-   * @example
-   * ```typescript
-   *  const num = 8;
-   *  const queryBuilder = fql`'foo'.length == ${num}`;
-   *  const queryRequest = queryBuilder.toQuery();
-   *  // produces:
-   *  { query: { fql: ["'foo'.length == ", { value: { "@int": "8" } }, ""] }}
-   * ```
-   */
-  toQuery(requestHeaders: QueryRequestHeaders = {}): QueryRequest {
-    return { ...this.#render(requestHeaders), ...requestHeaders };
-  }
-
-  #render(requestHeaders: QueryRequestHeaders): QueryRequest {
-    if (this.#queryFragments.length === 1) {
-      return { query: { fql: [this.#queryFragments[0]] }, arguments: {} };
-    }
-
-    let resultArgs: QueryValueObject = {};
-    const renderedFragments: (string | QueryInterpolation)[] =
-      this.#queryFragments.flatMap((fragment, i) => {
+  toString(): string {
+    return this.queryFragments
+      .map((fragment, i) => {
         // There will always be one more fragment than there are arguments
-        if (i === this.#queryFragments.length - 1) {
+        if (i === this.queryFragments.length - 1) {
           return fragment === "" ? [] : [fragment];
         }
 
-        const arg = this.#queryArgs[i];
-        let subQuery: string | QueryInterpolation;
+        const arg = this.queryArgs[i];
+        let subQuery: string;
         if (arg instanceof Query) {
-          const request = arg.toQuery(requestHeaders);
-          subQuery = request.query;
-          resultArgs = { ...resultArgs, ...request.arguments };
+          subQuery = arg.toString();
         } else {
-          // arguments in the template format must always be encoded, regardless
-          // of the "x-format" request header
-          // TODO: catch and rethrow Errors, indicating bad user input
-          subQuery = { value: TaggedTypeFormat.encode(arg) };
+          subQuery = JSON.stringify(arg);
         }
 
-        return [fragment, subQuery].filter((x) => x !== "");
-      });
-
-    return {
-      query: { fql: renderedFragments },
-      arguments: resultArgs,
-    };
+        return fragment + subQuery;
+      })
+      .join("");
   }
 }

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -1,11 +1,4 @@
-import { TaggedTypeFormat } from "./tagged-type";
-import type {
-  QueryValueObject,
-  QueryValue,
-  QueryInterpolation,
-  QueryRequest,
-  QueryRequestOptions,
-} from "./wire-protocol";
+import type { QueryValue } from "./wire-protocol";
 
 /**
  * Creates a new Query. Accepts template literal inputs.

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { fql } from "./query-builder";
+import { Query, fql } from "./query-builder";
 import {
   DateStub,
   Document,
@@ -16,7 +16,7 @@ import {
 /**
  * A request to make to Fauna.
  */
-export interface QueryRequest extends QueryRequestHeaders {
+export interface QueryRequest {
   /** The query */
   query: string | QueryInterpolation;
 
@@ -26,7 +26,11 @@ export interface QueryRequest extends QueryRequestHeaders {
   arguments?: QueryValueObject;
 }
 
-export interface QueryRequestHeaders {
+export interface QueryRequestOptions {
+  /** Optional arguments. Variables in the query will be initialized to the
+   * value associated with an argument key.
+   */
+  arguments?: QueryValueObject;
   /**
    * Determines the encoded format expected for the query `arguments` field, and
    * the `data` field of a successful response.
@@ -281,4 +285,5 @@ export type QueryValue =
   | NamedDocumentReference
   | NullDocument
   | Page<QueryValue>
-  | EmbeddedSet;
+  | EmbeddedSet
+  | Query;


### PR DESCRIPTION
Ticket(s): [FE-3179](https://faunadb.atlassian.net/browse/FE-3179)

## Problem
The Query class calls encoding, and the encoder cannot work with nested Query objects.

## Solution
Separate concerns of building queries from encoding them

## Result
The Query class is a container for query string fragments and arguments. The encoder does all of the work to encode arguments, including nested Query objects.

It no longer makes sense for the Query object to handle information about query options/headers, so cleaned up some functionality around query options and direct arguments.

## Out of scope
Handling Query objects within objects and arrays.

## Testing
Added a bunch of more tests. We were previously testing the query-builder with only the tagged format, so I added tests and expectations for the simple format as well.

Added a test for providing direct arguments, which was always possible if not prominently exposed.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3179]: https://faunadb.atlassian.net/browse/FE-3179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ