### PR TITLE
Implement http2SessionIdleTime and ClientTimeout

### DIFF
--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -23,7 +23,7 @@ const client = getClient(
     query_timeout_ms: 60,
   },
   // use the FetchClient implementation, so we can mock requests
-  new FetchClient()
+  new FetchClient({})
 );
 
 describe("query", () => {

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -1,0 +1,84 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { Client } from "../client";
+import { QueryRequest } from "../wire-protocol";
+
+/**
+ * An object representing an http request.
+ * The {@link Client} provides this to the {@link HTTPClient} implementation.
+ */
+export type HTTPRequest = {
+  data: QueryRequest;
+  headers: Record<string, string | undefined>;
+  method: "POST";
+  url: string;
+};
+
+/**
+ * An object representing an http request.
+ * It is returned to, and handled by, the {@link Client}.
+ */
+export type HTTPResponse = {
+  body: string;
+  headers: Record<string, string | string[] | undefined>;
+  status: number;
+};
+
+export type HTTPClientOptions = {
+  /**
+   * Time in milliseconds at which the client will abort a request if it has not
+   * received a response
+   */
+  client_timeout_ms?: number;
+
+  /**
+   * Time in milliseconds the client will keep an HTTP2 session open after all
+   * requests are completed. Only necessary for HTTP2 implementations.
+   */
+  http2_sessions_idle_ms?: number;
+};
+
+/**
+ * An interface to provide implementation-specific, asyncronous http calls.
+ * This driver provides default implementations for common environments. Users
+ * can configure the {@link Client} to use custom implementations if desired.
+ */
+export abstract class HTTPClient {
+  /**
+   * Time in milliseconds at which the client will abort a request if it has not
+   * received a response
+   */
+  client_timeout_ms?: number;
+
+  /**
+   * Time in milliseconds the client will keep an HTTP2 session open after all
+   * requests are completed. Only necessary for HTTP2 implementations.
+   */
+  http2_sessions_idle_ms?: number;
+
+  constructor({
+    client_timeout_ms,
+    http2_sessions_idle_ms,
+  }: HTTPClientOptions) {
+    this.client_timeout_ms = client_timeout_ms;
+    this.http2_sessions_idle_ms = http2_sessions_idle_ms;
+  }
+
+  /**
+   * Makes an HTTP request and returns the response
+   * @param req - an {@link HTTPRequest}
+   * @returns A Promise&lt;{@link HTTPResponse}&gt;
+   */
+  abstract request(req: HTTPRequest): Promise<HTTPResponse>;
+
+  /**
+   * Flags the calling {@link Client} as no longer
+   * referencing this HTTPClient. Once no {@link Client} instances reference this HTTPClient
+   * the underlying resources will be closed.
+   * It is expected that calls to this method are _only_ made by a {@link Client}
+   * instantiation. The behavior of direct calls is undefined.
+   * @remarks
+   * For some HTTPClients, such as the {@link FetchClient}, this method
+   * is a no-op as there is no shared resource to close.
+   */
+  abstract close(): void;
+}

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,68 +1,19 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { Client } from "../client";
-import { QueryRequest } from "../wire-protocol";
 import { FetchClient } from "./fetch-client";
 import { NodeHTTP2Client } from "./node-http2-client";
+import {
+  HTTPClient,
+  HTTPClientOptions,
+  HTTPRequest,
+  HTTPResponse,
+} from "./http-client";
 
-export { FetchClient } from "./fetch-client";
-export { NodeHTTP2Client } from "./node-http2-client";
-
-/**
- * An object representing an http request.
- * The {@link Client} provides this to the {@link HTTPClient} implementation.
- */
-export type HTTPRequest = {
-  data: QueryRequest;
-  headers: Record<string, string | undefined>;
-  method: "POST";
-  url: string;
-};
-
-/**
- * An object representing an http request.
- * It is returned to, and handled by, the {@link Client}.
- */
-export type HTTPResponse = {
-  body: string;
-  headers: Record<string, string | string[] | undefined>;
-  status: number;
-};
-
-/**
- * An interface to provide implementation-specific, asyncronous http calls.
- * This driver provides default implementations for common environments. Users
- * can configure the {@link Client} to use custom implementations if desired.
- */
-export interface HTTPClient {
-  /**
-   * Makes an HTTP request and returns the response
-   * @param req - an {@link HTTPRequest}
-   * @returns A Promise&lt;{@link HTTPResponse}&gt;
-   */
-  request(req: HTTPRequest): Promise<HTTPResponse>;
-
-  /**
-   * Flags the calling {@link Client} as no longer
-   * referencing this HTTPClient. Once no {@link Client} instances reference this HTTPClient
-   * the underlying resources will be closed.
-   * It is expected that calls to this method are _only_ made by a {@link Client}
-   * instantiation. The behavior of direct calls is undefined.
-   * @remarks
-   * For some HTTPClients, such as the {@link FetchClient}, this method
-   * is a no-op as there is no shared resource to close.
-   */
-  close(): void;
-}
-
-export const getDefaultHTTPClient = () =>
-  isNode() ? NodeHTTP2Client.getClient() : new FetchClient();
-
-// utility functions
+export const getDefaultHTTPClient = (): HTTPClient =>
+  isNode() ? NodeHTTP2Client.getClient() : new FetchClient({});
 
 export const isHTTPResponse = (res: any): res is HTTPResponse =>
   res instanceof Object && "body" in res && "headers" in res && "status" in res;
 
-export function isNode() {
+const isNode = () => {
   if (typeof process !== "undefined" && process.release?.name === "node") {
     try {
       require("node:http2");
@@ -72,4 +23,13 @@ export function isNode() {
     }
   }
   return false;
-}
+};
+
+export {
+  FetchClient,
+  NodeHTTP2Client,
+  HTTPClient,
+  HTTPClientOptions,
+  HTTPRequest,
+  HTTPResponse,
+};

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -4,14 +4,19 @@ try {
 } catch (_) {
   http2 = undefined;
 }
-import { HTTPClient, HTTPRequest, HTTPResponse } from "./index";
+import {
+  HTTPClient,
+  HTTPClientOptions,
+  HTTPRequest,
+  HTTPResponse,
+} from "./http-client";
 import { NetworkError } from "../errors";
 import { QueryRequest } from "../wire-protocol";
 
 /**
  * An implementation for {@link HTTPClient} that uses the node http package
  */
-export class NodeHTTP2Client implements HTTPClient {
+export class NodeHTTP2Client extends HTTPClient {
   static #client: NodeHTTP2Client | null = null;
 
   #sessionMap: Map<string, SessionWrapper> = new Map();
@@ -22,8 +27,9 @@ export class NodeHTTP2Client implements HTTPClient {
    * @remarks Private constructor means you must instantiate with
    * {@link NodeHTTP2Client.getClient}
    */
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  private constructor() {}
+  private constructor(options: HTTPClientOptions) {
+    super(options);
+  }
 
   static getClient() {
     if (http2 === undefined) {
@@ -31,7 +37,7 @@ export class NodeHTTP2Client implements HTTPClient {
     }
 
     if (this.#client === null) {
-      this.#client = new NodeHTTP2Client();
+      this.#client = new NodeHTTP2Client({});
     }
 
     this.#client.#numberOfUsers++;


### PR DESCRIPTION
Ticket(s): [FE-3508](https://faunadb.atlassian.net/browse/FE-3508)

## Problem
Users need to be able to configure http2SessionIdleTime and ClientTimeout

## Solution
Convert `HTTPClient` interface to an abstract class with configuration properties: `client_timeout_ms` and `http2_sessions_idle_ms`. `FetchClient` and `NodeHTTP2Client` implement this class and can accept configuration options.

## Result
WIP:

- [ x ] `client_timeout_ms` for fetch client
- [ ] `client_timeout_ms` for node http client
- [ ] `http2_sessions_idle_ms` for node http client
- [ ] wire the options up to the client configuration
- [ ] validate that if `client_timeout_ms` is provided, that `query_timeout_ms` is also provided and `client_timeout_ms > query_timeout_ms + n`. Also validate this relationship if `query_timeout_ms` is provided as a per-query option.

## Out of scope
keepalive for fetch client

## Testing
Adding tests

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
