### PR TITLE
Notify watchers when driver published

### DIFF
--- a/concourse/scripts/publish.sh
+++ b/concourse/scripts/publish.sh
@@ -8,7 +8,7 @@ PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
 NPM_LATEST_VERSION=$(npm view fauna version)
 echo "Current package version: $PACKAGE_VERSION"
 echo "Latest version in npm: $NPM_LATEST_VERSION"
-
+n
 if [ "$PACKAGE_VERSION" \> "$NPM_LATEST_VERSION" ]
 then
   npm install
@@ -19,7 +19,7 @@ then
   npm publish
   rm .npmrc
 
-  echo "fauna-js@$PACKAGE_VERSION published to npm" > ../slack-message/publish
+  echo "fauna-js@$PACKAGE_VERSION published to npm @driver-release-watchers" > ../slack-message/publish
 else
   echo "fauna-js@${NPM_LATEST_VERSION} package has been already published" > ../slack-message/publish
   echo "fauna-js@${NPM_LATEST_VERSION} package has been already published" 1>&2

--- a/concourse/scripts/publish.sh
+++ b/concourse/scripts/publish.sh
@@ -8,7 +8,6 @@ PACKAGE_VERSION=$(node -p -e "require('./package.json').version")
 NPM_LATEST_VERSION=$(npm view fauna version)
 echo "Current package version: $PACKAGE_VERSION"
 echo "Latest version in npm: $NPM_LATEST_VERSION"
-n
 if [ "$PACKAGE_VERSION" \> "$NPM_LATEST_VERSION" ]
 then
   npm install


### PR DESCRIPTION

## Problem
- stakeholders want to know when new driver versions are published
## Solution
- tag them in slack
## Result
- folks get notified

## Testing
- need to do a release and see if we ping OK
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
