### PR TITLE
FE-3527 Optimize NodeHTTP2Client to create one NodeHTTP2Client per HTTPClientOptions

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -367,9 +367,15 @@ describe("query", () => {
   });
 
   it("session is closed regardless of number of clients", async () => {
-    const httpClient1 = new NodeHTTP2Client(getDefaultHTTPClientOptions());
-    const httpClient2 = new NodeHTTP2Client(getDefaultHTTPClientOptions());
-    const httpClient3 = new NodeHTTP2Client(getDefaultHTTPClientOptions());
+    const httpClient1 = NodeHTTP2Client.getClient(
+      getDefaultHTTPClientOptions()
+    );
+    const httpClient2 = NodeHTTP2Client.getClient(
+      getDefaultHTTPClientOptions()
+    );
+    const httpClient3 = NodeHTTP2Client.getClient(
+      getDefaultHTTPClientOptions()
+    );
     const client1 = getClient({}, httpClient1);
     const client2 = getClient({}, httpClient2);
     const client3 = getClient({}, httpClient3);

--- a/__tests__/unit/client.test.ts
+++ b/__tests__/unit/client.test.ts
@@ -40,7 +40,7 @@ describe("Client", () => {
     // Sessions are only connected upon making requests. An HTTPClient that has
     // not yet made a request appears effectively as closed.
 
-    const nodeClient = new NodeHTTP2Client(getDefaultHTTPClientOptions());
+    const nodeClient = NodeHTTP2Client.getClient(getDefaultHTTPClientOptions());
     const clientOne = new Client(getDefaultSecretAndEndpoint(), nodeClient);
     await clientOne.query(fql`"Hello World"`); // nodeClient.request(): refs = [nodeClient]
     expect(nodeClient.isClosed()).toBe(false);
@@ -50,7 +50,7 @@ describe("Client", () => {
 
     const clientTwo = new Client(
       getDefaultSecretAndEndpoint(),
-      new NodeHTTP2Client(getDefaultHTTPClientOptions())
+      NodeHTTP2Client.getClient(getDefaultHTTPClientOptions())
     );
     expect((await clientTwo.query(fql`"Hello World"`)).data).toEqual(
       "Hello World"
@@ -59,7 +59,7 @@ describe("Client", () => {
 
     const clientThree = new Client(
       getDefaultSecretAndEndpoint(),
-      new NodeHTTP2Client(getDefaultHTTPClientOptions())
+      NodeHTTP2Client.getClient(getDefaultHTTPClientOptions())
     );
     expect((await clientThree.query(fql`"Hello World"`)).data).toEqual(
       "Hello World"

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -8,7 +8,7 @@ import {
 } from "./http-client";
 
 export const getDefaultHTTPClient = (options: HTTPClientOptions): HTTPClient =>
-  isNode() ? new NodeHTTP2Client(options) : new FetchClient(options);
+  isNode() ? NodeHTTP2Client.getClient(options) : new FetchClient(options);
 
 export const isHTTPResponse = (res: any): res is HTTPResponse =>
   res instanceof Object && "body" in res && "headers" in res && "status" in res;

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -176,6 +176,7 @@ const encodeMap = {
   namedDocument: (value: NamedDocument): TaggedRef => ({
     "@ref": { name: value.name, coll: { "@mod": value.coll.name } },
   }),
+  // es-lint-disable-next-line @typescript-eslint/no-unused-vars
   set: (value: Page<QueryValue> | EmbeddedSet) => {
     throw new ClientError(
       "Page could not be encoded. Fauna does not accept encoded Set values, yet. Use Page.data and Page.after as arguments, instead."


### PR DESCRIPTION
Ticket(s): FE-3527

## Problem
- we are creating 1 NodeHTTP2Client per Fauna Client
- we are storing references to NodeHTTP2Client to do ref counting in a set
- can save a few resources with some refactoring
## Solution
- create 1 NodeHTTP2Client per unique HTTPOptions used to build a NodeHTTP2Client
- do ref counting via a numeric counter
## Result
- same behavior for customer
- space saved

## Testing
- Full test suite. See GitHub actions
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
