### PR TITLE
FE-3305 Handle Node HTTP2 race condition on GOAWAY

### DIFF
--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -48,6 +48,7 @@ describe("last_txn_ts tracking in client", () => {
     `);
     expect(resultThree.txn_ts).not.toBeUndefined();
     expect(resultThree.txn_ts).not.toEqual(resultTwo.txn_ts);
+    myClient.close();
   });
 
   it("Accepts an override of the last_txn_ts datetime and sends in the headers", async () => {

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -428,6 +428,7 @@ describe("query can encode / decode QueryValue correctly", () => {
     };
     const docCreated = await client.query<any>(fql`
         ${new Module(collectionName)}.create(${toughInput})`);
+    client.close();
     expect(docCreated.data.should_exist).toBeUndefined();
     expect(docCreated.data.nested_object.i_dont_exist).toBeUndefined();
     expect(docCreated.data.foo).toBe("bar");

--- a/__tests__/unit/node-http2-client.test.ts
+++ b/__tests__/unit/node-http2-client.test.ts
@@ -1,6 +1,5 @@
 import { getDefaultHTTPClient, NodeHTTP2Client } from "../../src";
 import { getDefaultHTTPClientOptions } from "../client";
-import http2 from "node:http2";
 
 const client = getDefaultHTTPClient(getDefaultHTTPClientOptions());
 

--- a/__tests__/unit/node-http2-client.test.ts
+++ b/__tests__/unit/node-http2-client.test.ts
@@ -1,5 +1,6 @@
 import { getDefaultHTTPClient, NodeHTTP2Client } from "../../src";
 import { getDefaultHTTPClientOptions } from "../client";
+import http2 from "node:http2";
 
 const client = getDefaultHTTPClient(getDefaultHTTPClientOptions());
 

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -39,7 +39,7 @@ export interface ClientConfiguration {
 
   /**
    * Time in milliseconds the client will keep an HTTP2 session open after all
-   * requests are completed. The default is 500 ms.
+   * requests are completed. The default is 5000 ms.
    */
   http2_session_idle_ms: number;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,7 +39,7 @@ export const DEFAULT_CLIENT_CONFIG: Omit<ClientConfiguration, "secret"> = {
   client_timeout_buffer_ms: 5000,
   endpoint: endpoints.default,
   format: "tagged",
-  http2_session_idle_ms: 500,
+  http2_session_idle_ms: 5000,
   max_conns: 10,
   query_timeout_ms: 5000,
 };

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -26,15 +26,11 @@ export class FetchClient implements HTTPClient {
     method,
     client_timeout_ms,
   }: HTTPRequest): Promise<HTTPResponse> {
-    const controller = new AbortController();
-    const signal = controller.signal;
-    setTimeout(() => controller.abort(), client_timeout_ms);
-
     const response = await fetch(this.#url, {
       method,
       headers: { ...requestHeaders, "Content-Type": "application/json" },
       body: JSON.stringify(data),
-      signal,
+      signal: AbortSignal.timeout(client_timeout_ms),
     }).catch((error) => {
       throw new NetworkError("The network connection encountered a problem.", {
         cause: error,

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -76,7 +76,7 @@ export class NodeHTTP2Client implements HTTPClient {
         //
         // TLDR; In Node, there is a race condition between handling
         // GOAWAY and submitting requests - that can cause
-        // clients that safely checked handle go away to submit
+        // clients that safely handle go away to submit
         // requests fter a GOAWAWY was recieved anyway.
         //
         // technical explanation: node HTTP2 request gets put

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -77,7 +77,7 @@ export class NodeHTTP2Client implements HTTPClient {
         // TLDR; In Node, there is a race condition between handling
         // GOAWAY and submitting requests - that can cause
         // clients that safely handle go away to submit
-        // requests fter a GOAWAWY was recieved anyway.
+        // requests after a GOAWAY was received anyway.
         //
         // technical explanation: node HTTP2 request gets put
         // on event queue before it is actually executed. In the iterim,

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -64,78 +64,41 @@ export class NodeHTTP2Client implements HTTPClient {
   }
 
   /** {@inheritDoc HTTPClient.request} */
-  async request({
-    client_timeout_ms,
-    data: requestData,
-    headers: requestHeaders,
-    method,
-  }: HTTPRequest): Promise<HTTPResponse> {
-    let req: ClientHttp2Stream;
-
-    const requestPromise = new Promise<HTTPResponse>(
-      (resolvePromise, rejectPromise) => {
-        const onResponse = (
-          http2ResponseHeaders: IncomingHttpHeaders & IncomingHttpStatusHeader
-        ) => {
-          const status = Number(
-            http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS]
+  async request(req: HTTPRequest): Promise<HTTPResponse> {
+    let retryCount = 0;
+    let memoizedError: any;
+    do {
+      try {
+        return await this.#doRequest(req);
+      } catch (error: any) {
+        // see https://github.com/nodejs/node/pull/42190/files
+        // and https://github.com/nodejs/help/issues/2105
+        //
+        // TLDR; In Node, there is a race condition between handling
+        // GOAWAY and submitting requests - that can cause
+        // clients that safely checked handle go away to submit
+        // requests fter a GOAWAWY was recieved anyway.
+        //
+        // technical explanation: node HTTP2 request gets put
+        // on event queue before it is actually executed. In the iterim,
+        // a GOAWAY can come and cause the request to fail
+        // with a GOAWAY.
+        if (error?.code !== "ERR_HTTP2_GOAWAY_SESSION") {
+          // TODO: be more discernable about error types
+          throw new NetworkError(
+            "The network connection encountered a problem.",
+            {
+              cause: error,
+            }
           );
-          let responseData = "";
-
-          // append response data to the data string every time we receive new
-          // data chunks in the response
-          req.on("data", (chunk: any) => {
-            responseData += chunk;
-          });
-
-          // Once the response is finished, resolve the promise
-          req.on("end", () => {
-            resolvePromise({
-              status,
-              body: responseData,
-              headers: http2ResponseHeaders,
-            });
-          });
-        };
-
-        try {
-          const httpRequestHeaders: OutgoingHttpHeaders = {
-            ...requestHeaders,
-            [http2.constants.HTTP2_HEADER_PATH]: "/query/1",
-            [http2.constants.HTTP2_HEADER_METHOD]: method,
-          };
-
-          const session = this.#connect();
-          req = session
-            .request(httpRequestHeaders)
-            .setEncoding("utf8")
-            .on("error", (error: any) => {
-              rejectPromise(error);
-            })
-            .on("response", onResponse);
-
-          req.write(JSON.stringify(requestData), "utf8");
-
-          // req.setTimeout must be called before req.end()
-          req.setTimeout(client_timeout_ms, () => {
-            req.destroy(new Error(`Client timeout`));
-          });
-
-          req.end();
-        } catch (error) {
-          rejectPromise(error);
         }
+        memoizedError = error;
+        retryCount++;
       }
-    );
-
-    try {
-      return await requestPromise;
-    } catch (error) {
-      // TODO: be more discernable about error types
-      throw new NetworkError("The network connection encountered a problem.", {
-        cause: error,
-      });
-    }
+    } while (retryCount < 3);
+    throw new NetworkError("The network connection encountered a problem.", {
+      cause: memoizedError,
+    });
   }
 
   /** {@inheritDoc HTTPClient.close} */
@@ -179,5 +142,67 @@ export class NodeHTTP2Client implements HTTPClient {
       this.#session = new_session;
     }
     return this.#session;
+  }
+
+  #doRequest({
+    client_timeout_ms,
+    data: requestData,
+    headers: requestHeaders,
+    method,
+  }: HTTPRequest): Promise<HTTPResponse> {
+    return new Promise<HTTPResponse>((resolvePromise, rejectPromise) => {
+      let req: ClientHttp2Stream;
+      const onResponse = (
+        http2ResponseHeaders: IncomingHttpHeaders & IncomingHttpStatusHeader
+      ) => {
+        const status = Number(
+          http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS]
+        );
+        let responseData = "";
+
+        // append response data to the data string every time we receive new
+        // data chunks in the response
+        req.on("data", (chunk: any) => {
+          responseData += chunk;
+        });
+
+        // Once the response is finished, resolve the promise
+        req.on("end", () => {
+          resolvePromise({
+            status,
+            body: responseData,
+            headers: http2ResponseHeaders,
+          });
+        });
+      };
+
+      try {
+        const httpRequestHeaders: OutgoingHttpHeaders = {
+          ...requestHeaders,
+          [http2.constants.HTTP2_HEADER_PATH]: "/query/1",
+          [http2.constants.HTTP2_HEADER_METHOD]: method,
+        };
+
+        const session = this.#connect();
+        req = session
+          .request(httpRequestHeaders)
+          .setEncoding("utf8")
+          .on("error", (error: any) => {
+            rejectPromise(error);
+          })
+          .on("response", onResponse);
+
+        req.write(JSON.stringify(requestData), "utf8");
+
+        // req.setTimeout must be called before req.end()
+        req.setTimeout(client_timeout_ms, () => {
+          req.destroy(new Error(`Client timeout`));
+        });
+
+        req.end();
+      } catch (error) {
+        rejectPromise(error);
+      }
+    });
   }
 }


### PR DESCRIPTION
Ticket(s): FE-3305

## Problem
- TLDR; In Node, there is a race condition between handling GOAWAY and submitting requests - that can cause clients that safely checked handle go away to submit requests fter a GOAWAWY was recieved anyway.
- A short idle timeout can trigger this race condition.
- We had several tests not closing clients, leaving open handles (items still waiting for events on test exit) - which could mask bugs on close.
- technical explanation: node HTTP2 request gets put on event queue before it is actually executed. In the interim, a GOAWAY can come and cause the request to fail with a GOAWAY.
## Solution
- retry on GOAWAY up to three times. I did not put a sleep in here as it should be pretty snappy. We just need to get in line properly in the event queue.
- Increase the default idle timeout.
- close all clients in tests
## Result
- less go away errors
## Testing
Used the driver sandbox over a VPN from Buenos Aires.

When I run this code in it:

```javascript
import { Client, fql, } from "fauna";

const client = new Client({ format: "decorated" });

try {
  console.log(await client.query(fql`"Hello"`));
  client.close();
} catch (e) {
  console.log(e);
  console.log(e.summary);
  console.log("abort data " + e.abort);
}
```


with this commit I get this output:

```
~/workplace/drivers-docker-sandbox/javascript (main*) » node index.js                                                                                                                                       cleve@Cleves-MBP
{
  data: '"Hello"',
  summary: '',
  txn_ts: 1683846299689199,
  stats: {
    compute_ops: 1,
    read_ops: 0,
    write_ops: 0,
    query_time_ms: 2,
    contention_retries: 0,
    storage_bytes_read: 0,
    storage_bytes_write: 0
  }
}
```


With 0.7.0 I get this output:

```
~/workplace/drivers-docker-sandbox/javascript (main*) » node index.js                                                                                                                                       cleve@Cleves-MBP
NetworkError: The network connection encountered a problem.
    at _NodeHTTP2Client.request (/Users/cleve/workplace/drivers-docker-sandbox/javascript/node_modules/fauna/dist/node/index.js:868:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async #query (/Users/cleve/workplace/drivers-docker-sandbox/javascript/node_modules/fauna/dist/node/index.js:1099:29)
    at async file:///Users/cleve/workplace/drivers-docker-sandbox/javascript/index.js:6:15 {
  [cause]: Error [ERR_HTTP2_GOAWAY_SESSION]: New streams cannot be created after receiving a GOAWAY
      at new NodeError (node:internal/errors:399:5)
      at ClientHttp2Stream.requestOnConnect (node:internal/http2/core:705:17)
      at node:internal/http2/core:1830:68
      at Array.forEach (<anonymous>)
      at ClientHttp2Session.<anonymous> (node:internal/http2/core:1830:11)
      at Object.onceWrapper (node:events:628:26)
      at ClientHttp2Session.emit (node:events:525:35)
      at emit (node:internal/http2/core:330:3)
      at process.processTicksAndRejections (node:internal/process/task_queues:84:21) {
    code: 'ERR_HTTP2_GOAWAY_SESSION'
  }
}


```

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
