### PR TITLE
Ping the watchers on release

### DIFF
--- a/concourse/scripts/publish.sh
+++ b/concourse/scripts/publish.sh
@@ -18,7 +18,7 @@ then
   npm publish
   rm .npmrc
 
-  echo "fauna-js@$PACKAGE_VERSION published to npm @driver-release-watchers" > ../slack-message/publish
+  echo "fauna-js@$PACKAGE_VERSION published to npm <!subteam^S03CV3GLMCZ>" > ../slack-message/publish
 else
   echo "fauna-js@${NPM_LATEST_VERSION} package has been already published" > ../slack-message/publish
   echo "fauna-js@${NPM_LATEST_VERSION} package has been already published" 1>&2


### PR DESCRIPTION
## Problem
- stakeholders want to know when driver published.
- the `@` tags don't work over the stripe API. You have to use the group id instead: https://github.com/cloudfoundry-community/slack-notification-resource
## Solution
- use the group id
## Result
- stakeholders get pinged

## Testing
- need to do a release to test it
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
