### PR TITLE
Write test to prove customers can use their own types

### DIFF
--- a/__tests__/integration/query-typings.test.ts
+++ b/__tests__/integration/query-typings.test.ts
@@ -1,0 +1,30 @@
+import { fql, QueryCheckError } from "../../src";
+import { getClient } from "../client";
+
+const client = getClient();
+
+afterAll(() => {
+  client.close();
+});
+
+describe.each`
+  method
+  ${"query"}
+  ${"paginate"}
+`("$method typings", ({ method }: { method: string }) => {
+  it("allows customers to use their own types", async () => {
+    expect.assertions(1);
+    // added in a junk property that is not part of QueryValue
+    type MyType = { x: number; t: QueryCheckError };
+    if ("query" === method) {
+      const result = (await client.query<MyType>(fql`{ "x": 123}`)).data;
+      expect(result).toEqual({ x: 123 });
+    } else {
+      for await (const page of client.paginate<MyType>(fql`{ "x": 123}`)) {
+        for (const result of page) {
+          expect(result).toEqual({ x: 123 });
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION

## Problem
- Customer asking how to deserialize into their own types
## Solution
- write test case showing how to do this for both `query` and `paginate`
## Result
- functionality of using own types will be regression tested

## Testing
- ran tests
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
