### PR TITLE
Make constraint failure test more robust

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -173,7 +173,10 @@ describe("query", () => {
     expect.assertions(6);
     try {
       await client.query(
-        fql`Function.create({"name": "double", "body": "x => x * 2"})`
+        fql`Function.create({"name": "my_double", "body": "x => x * 2"})`
+      );
+      await client.query(
+        fql`Function.create({"name": "my_double", "body": "x => x * 2"})`
       );
     } catch (e) {
       if (e instanceof ServiceError) {


### PR DESCRIPTION
Ticket(s): [FE-3537](https://faunadb.atlassian.net/browse/FE-3537)

## Problem
The integration test for constraint failures relied on creating a function whose name collided with a built-in function. But Core changed the name of that function so the test now fails.

## Solution
Try to create the same function twice.

## Result
Doesn't matter what the name of the function is now.

## Testing
passing

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3537]: https://faunadb.atlassian.net/browse/FE-3537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ