### PR TITLE
Bolt package version into a constants file so that users can use gitpkg and direct github access to depend on this package. This will fix our platform test pipeline as it uses gitpkg

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+VERSION=`cat "package.json" | grep "^  \"version\":" | cut -d: -f2 | cut -d\" -f2`
+echo "export const packageVersion = \"$VERSION\";" > ./src/util/package-version.ts
+git add ./src/util/package-version.ts
 if [[ `git status --porcelain -- '*.ts' 'package.json'` ]]; then
   yarn build
   yarn lint

--- a/__tests__/unit/package-verison.test.ts
+++ b/__tests__/unit/package-verison.test.ts
@@ -1,0 +1,8 @@
+import packageJson from "../../package.json";
+import { packageVersion } from "../../src/util/package-version";
+
+describe("package version", () => {
+  it("is correct", () => {
+    expect(packageJson.version).toEqual(packageVersion);
+  });
+});

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -1,4 +1,4 @@
-import packageJson from "../../package.json";
+import { packageVersion } from "./package-version";
 
 let os: any;
 try {
@@ -13,7 +13,7 @@ try {
  */
 export const getDriverEnv = (): string => {
   const driverEnv = {
-    driver: ["javascript", packageJson.version].join("-"),
+    driver: ["javascript", packageVersion].join("-"),
     env: "unknown",
     os: "unknown",
     runtime: "unknown",

--- a/src/util/package-version.ts
+++ b/src/util/package-version.ts
@@ -1,0 +1,1 @@
+export const packageVersion = "0.7.2";


### PR DESCRIPTION
## Problem
- we use gitpkg in the platform tests so we an always get latest version of code. Unfortunately gitpkg is setup to only bundle the src as this is what plays nice with platform tests; this makes package.json and tsconfig.json unavailable.
## Solution
- Bolt in the package version on every commit using husky hooks.
## Result
- pipeline unblocked.

## Testing
- added a test to confirm we're in sync.
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
