### PR TITLE
Separate QueryOptions from QueryRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,11 @@ console.assert(user_doc.email === "alice@site.example");
 Options are available to configure queries on each request.
 
 ```typescript
-import { fql, Client, type QueryRequestHeaders } from "fauna";
+import { fql, Client, type QueryOptions } from "fauna";
 
 const client = new Client();
 
-const options: QueryRequestHeaders = {
+const options: QueryOptions = {
   format: "tagged",
   linearized: false,
   query_timeout_ms: 60_000,

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -466,7 +466,7 @@ describe("query can encode / decode QueryValue correctly", () => {
   });
 
   it("treats undefined as unprovided passed directly as value", async () => {
-    expect.assertions(3);
+    expect.assertions(2);
     const client = getClient();
     const collectionName = "UndefinedTest";
     await client.query(fql`
@@ -487,12 +487,11 @@ describe("query can encode / decode QueryValue correctly", () => {
           }
         })`);
     } catch (e) {
-      if (e instanceof ClientError) {
-        expect(e.name).toBe("ClientError");
+      if (e instanceof TypeError) {
+        expect(e.name).toBe("TypeError");
         expect(e.message).toBe(
-          "A client level error occurred. Fauna was not called."
+          "Passing undefined as a QueryValue is not supported"
         );
-        expect(e.cause).toBeDefined();
       }
     }
   });

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -1,4 +1,4 @@
-import type { QueryValueObject, ValueFormat } from "./wire-protocol";
+import type { ValueFormat } from "./wire-protocol";
 
 /**
  * Configuration for a client. The options provided are be used as
@@ -108,65 +108,6 @@ export interface ClientConfiguration {
    * Enable or disable typechecking of the query before evaluation. If no value
    * is provided, the value of `typechecked` in the database configuration will
    * be used.
-   */
-  typecheck?: boolean;
-}
-
-/**
- * Options for queries. Each query can be made with different options. Settings here
- * take precedence over those in {@link ClientConfiguration}.
- */
-export interface QueryOptions {
-  /** Optional arguments. Variables in the query will be initialized to the
-   * value associated with an argument key.
-   */
-  arguments?: QueryValueObject;
-
-  /**
-   * Determines the encoded format expected for the query `arguments` field, and
-   * the `data` field of a successful response.
-   * Overrides the optional setting on the {@link ClientConfiguration}.
-   */
-  format?: ValueFormat;
-
-  /**
-   * If true, unconditionally run the query as strictly serialized.
-   * This affects read-only transactions. Transactions which write
-   * will always be strictly serialized.
-   * Overrides the optional setting on the {@link ClientConfiguration}.
-   */
-  linearized?: boolean;
-
-  /**
-   * The max number of times to retry the query if contention is encountered.
-   *Overrides the optional setting on the {@link ClientConfiguration}.
-   */
-  max_contention_retries?: number;
-
-  /**
-   * Tags provided back via logging and telemetry.
-   * Overrides the optional setting on the {@link ClientConfiguration}.
-   */
-  query_tags?: Record<string, string>;
-
-  /**
-   * The timeout to use in this query in milliseconds.
-   * Overrides the optional setting on the {@link ClientConfiguration}.
-   */
-  query_timeout_ms?: number;
-
-  /**
-   * A traceparent provided back via logging and telemetry.
-   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
-   * Overrides the optional setting on the {@link ClientConfiguration}.
-   */
-  traceparent?: string;
-
-  /**
-   * Enable or disable typechecking of the query before evaluation. If no value
-   * is provided, the value of `typechecked` in the database configuration will
-   * be used.
-   * Overrides the optional setting on the {@link ClientConfiguration}.
    */
   typecheck?: boolean;
 }

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -1,7 +1,8 @@
-import type { ValueFormat } from "./wire-protocol";
+import type { QueryValueObject, ValueFormat } from "./wire-protocol";
 
 /**
- * Configuration for a client.
+ * Configuration for a client. The query options provided are be used as
+ * default options for each query.
  */
 export interface ClientConfiguration {
   /**
@@ -107,6 +108,64 @@ export interface ClientConfiguration {
    * Enable or disable typechecking of the query before evaluation. If no value
    * is provided, the value of `typechecked` in the database configuration will
    * be used.
+   */
+  typecheck?: boolean;
+}
+
+/**
+ * Options for queries. Each query can be made with different options.
+ */
+export interface QueryOptions {
+  /** Optional arguments. Variables in the query will be initialized to the
+   * value associated with an argument key.
+   */
+  arguments?: QueryValueObject;
+
+  /**
+   * Determines the encoded format expected for the query `arguments` field, and
+   * the `data` field of a successful response.
+   * Overrides the optional setting for the client.
+   */
+  format?: ValueFormat;
+
+  /**
+   * If true, unconditionally run the query as strictly serialized.
+   * This affects read-only transactions. Transactions which write
+   * will always be strictly serialized.
+   * Overrides the optional setting for the client.
+   */
+  linearized?: boolean;
+
+  /**
+   * The max number of times to retry the query if contention is encountered.
+   * Overrides the optional setting for the client.
+   */
+  max_contention_retries?: number;
+
+  /**
+   * Tags provided back via logging and telemetry.
+   * Overrides the optional setting on the client.
+   */
+  query_tags?: Record<string, string>;
+
+  /**
+   * The timeout to use in this query in milliseconds.
+   * Overrides the timeout for the client.
+   */
+  query_timeout_ms?: number;
+
+  /**
+   * A traceparent provided back via logging and telemetry.
+   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
+   * Overrides the optional setting for the client.
+   */
+  traceparent?: string;
+
+  /**
+   * Enable or disable typechecking of the query before evaluation. If no value
+   * is provided, the value of `typechecked` in the database configuration will
+   * be used.
+   * Overrides the optional setting for the client.
    */
   typecheck?: boolean;
 }

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -1,7 +1,7 @@
 import type { ValueFormat } from "./wire-protocol";
 
 /**
- * Configuration for a client. The options provided are be used as
+ * Configuration for a client. The options provided are used as the
  * default options for each query.
  */
 export interface ClientConfiguration {

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -1,7 +1,7 @@
 import type { QueryValueObject, ValueFormat } from "./wire-protocol";
 
 /**
- * Configuration for a client. The query options provided are be used as
+ * Configuration for a client. The options provided are be used as
  * default options for each query.
  */
 export interface ClientConfiguration {
@@ -113,7 +113,8 @@ export interface ClientConfiguration {
 }
 
 /**
- * Options for queries. Each query can be made with different options.
+ * Options for queries. Each query can be made with different options. Settings here
+ * take precedence over those in {@link ClientConfiguration}.
  */
 export interface QueryOptions {
   /** Optional arguments. Variables in the query will be initialized to the
@@ -124,7 +125,7 @@ export interface QueryOptions {
   /**
    * Determines the encoded format expected for the query `arguments` field, and
    * the `data` field of a successful response.
-   * Overrides the optional setting for the client.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
    */
   format?: ValueFormat;
 
@@ -132,32 +133,32 @@ export interface QueryOptions {
    * If true, unconditionally run the query as strictly serialized.
    * This affects read-only transactions. Transactions which write
    * will always be strictly serialized.
-   * Overrides the optional setting for the client.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
    */
   linearized?: boolean;
 
   /**
    * The max number of times to retry the query if contention is encountered.
-   * Overrides the optional setting for the client.
+   *Overrides the optional setting on the {@link ClientConfiguration}.
    */
   max_contention_retries?: number;
 
   /**
    * Tags provided back via logging and telemetry.
-   * Overrides the optional setting on the client.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
    */
   query_tags?: Record<string, string>;
 
   /**
    * The timeout to use in this query in milliseconds.
-   * Overrides the timeout for the client.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
    */
   query_timeout_ms?: number;
 
   /**
    * A traceparent provided back via logging and telemetry.
    * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
-   * Overrides the optional setting for the client.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
    */
   traceparent?: string;
 
@@ -165,7 +166,7 @@ export interface QueryOptions {
    * Enable or disable typechecking of the query before evaluation. If no value
    * is provided, the value of `typechecked` in the database configuration will
    * be used.
-   * Overrides the optional setting for the client.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
    */
   typecheck?: boolean;
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,8 +1,4 @@
-import {
-  ClientConfiguration,
-  endpoints,
-  type QueryOptions,
-} from "./client-configuration";
+import { ClientConfiguration, endpoints } from "./client-configuration";
 import {
   AuthenticationError,
   AuthorizationError,
@@ -35,7 +31,7 @@ import {
   isQuerySuccess,
   QueryInterpolation,
   type QueryFailure,
-  type QueryRequest,
+  type QueryOptions,
   type QuerySuccess,
   type QueryValue,
 } from "./wire-protocol";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ export { Client } from "./client";
 export {
   endpoints,
   type ClientConfiguration,
-  type QueryOptions,
   type Endpoints,
 } from "./client-configuration";
 export {
@@ -31,6 +30,7 @@ export {
   type QueryFailure,
   type QueryInfo,
   type QueryInterpolation,
+  type QueryOptions,
   type QueryRequest,
   type QueryStats,
   type QuerySuccess,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 export { Client } from "./client";
 export {
-  type ClientConfiguration,
-  type Endpoints,
   endpoints,
+  type ClientConfiguration,
+  type QueryOptions,
+  type Endpoints,
 } from "./client-configuration";
 export {
   AbortError,
@@ -31,7 +32,6 @@ export {
   type QueryInfo,
   type QueryInterpolation,
   type QueryRequest,
-  type QueryRequestHeaders,
   type QueryStats,
   type QuerySuccess,
   type Span,

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -1,10 +1,10 @@
-import { QueryOptions } from "./client-configuration";
 import { TaggedTypeFormat } from "./tagged-type";
 import type {
   QueryValueObject,
   QueryValue,
   QueryInterpolation,
   QueryRequest,
+  QueryOptions,
 } from "./wire-protocol";
 
 /**

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -1,10 +1,10 @@
+import { QueryOptions } from "./client-configuration";
 import { TaggedTypeFormat } from "./tagged-type";
 import type {
   QueryValueObject,
   QueryValue,
   QueryInterpolation,
   QueryRequest,
-  QueryRequestHeaders,
 } from "./wire-protocol";
 
 /**
@@ -56,7 +56,7 @@ export class Query {
   /**
    * Converts this Query to a {@link QueryRequest} you can send
    * to Fauna.
-   * @param requestHeaders - optional {@link QueryRequestHeaders} to include
+   * @param requestHeaders - optional {@link QueryOptions} to include
    *   in the request (and thus override the defaults in your {@link ClientConfiguration}.
    *   If not passed in, no headers will be set as overrides.
    * @returns a {@link QueryRequest}.
@@ -69,11 +69,11 @@ export class Query {
    *  { query: { fql: ["'foo'.length == ", { value: { "@int": "8" } }, ""] }}
    * ```
    */
-  toQuery(requestHeaders: QueryRequestHeaders = {}): QueryRequest {
+  toQuery(requestHeaders: QueryOptions = {}): QueryRequest {
     return { ...this.#render(requestHeaders), ...requestHeaders };
   }
 
-  #render(requestHeaders: QueryRequestHeaders): QueryRequest {
+  #render(requestHeaders: QueryOptions): QueryRequest {
     if (this.#queryFragments.length === 1) {
       return { query: { fql: [this.#queryFragments[0]] }, arguments: {} };
     }

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -27,6 +27,65 @@ export interface QueryRequest {
 }
 
 /**
+ * Options for queries. Each query can be made with different options. Settings here
+ * take precedence over those in {@link ClientConfiguration}.
+ */
+export interface QueryOptions {
+  /** Optional arguments. Variables in the query will be initialized to the
+   * value associated with an argument key.
+   */
+  arguments?: QueryValueObject;
+
+  /**
+   * Determines the encoded format expected for the query `arguments` field, and
+   * the `data` field of a successful response.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
+   */
+  format?: ValueFormat;
+
+  /**
+   * If true, unconditionally run the query as strictly serialized.
+   * This affects read-only transactions. Transactions which write
+   * will always be strictly serialized.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
+   */
+  linearized?: boolean;
+
+  /**
+   * The max number of times to retry the query if contention is encountered.
+   *Overrides the optional setting on the {@link ClientConfiguration}.
+   */
+  max_contention_retries?: number;
+
+  /**
+   * Tags provided back via logging and telemetry.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
+   */
+  query_tags?: Record<string, string>;
+
+  /**
+   * The timeout to use in this query in milliseconds.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
+   */
+  query_timeout_ms?: number;
+
+  /**
+   * A traceparent provided back via logging and telemetry.
+   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
+   * Overrides the optional setting on the {@link ClientConfiguration}.
+   */
+  traceparent?: string;
+
+  /**
+   * Enable or disable typechecking of the query before evaluation. If no value
+   * is provided, the value of `typechecked` in the database configuration will
+   * be used.
+   * Overrides the optional setting on the {@link ClientConfiguration}.
+   */
+  typecheck?: boolean;
+}
+
+/**
  * tagged declares that type information is transmitted and received by the driver.
  * "simple" indicates it is not - pure JSON is used.
  * "decorated" will cause the service output to be shown in FQL syntax that could

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -16,7 +16,7 @@ import {
 /**
  * A request to make to Fauna.
  */
-export interface QueryRequest extends QueryRequestHeaders {
+export interface QueryRequest {
   /** The query */
   query: string | QueryInterpolation;
 
@@ -24,49 +24,6 @@ export interface QueryRequest extends QueryRequestHeaders {
    * value associated with an argument key.
    */
   arguments?: QueryValueObject;
-}
-
-export interface QueryRequestHeaders {
-  /**
-   * Determines the encoded format expected for the query `arguments` field, and
-   * the `data` field of a successful response.
-   */
-  format?: ValueFormat;
-  /**
-   * If true, unconditionally run the query as strictly serialized.
-   * This affects read-only transactions. Transactions which write
-   * will always be strictly serialized.
-   * Overrides the optional setting for the client.
-   */
-  linearized?: boolean;
-  /**
-   * The timeout to use in this query in milliseconds.
-   * Overrides the timeout for the client.
-   */
-  query_timeout_ms?: number;
-  /**
-   * The max number of times to retry the query if contention is encountered.
-   * Overrides the optional setting for the client.
-   */
-  max_contention_retries?: number;
-
-  /**
-   * Tags provided back via logging and telemetry.
-   * Overrides the optional setting on the client.
-   */
-  query_tags?: Record<string, string>;
-  /**
-   * A traceparent provided back via logging and telemetry.
-   * Must match format: https://www.w3.org/TR/trace-context/#traceparent-header
-   * Overrides the optional setting for the client.
-   */
-  traceparent?: string;
-  /**
-   * Enable or disable typechecking of the query before evaluation. If no value
-   * is provided, the value of `typechecked` in the database configuration will
-   * be used.
-   */
-  typecheck?: boolean;
 }
 
 /**


### PR DESCRIPTION
Ticket(s): [FE-3564](https://faunadb.atlassian.net/browse/FE-3564)

## Problem
We do not send query options in the request body, so QueryHeaders is not part of the wire protocol. We've already updated Client.query to only accept the `Query` type, so there is no way for users to provide query options through the current `QueryRequest` type.

## Solution
- `QueryRequest` should not extend `QueryHeaders`
- Rename `QueryHeaders` to `QueryOptions`
- `QueryOptions` should be an optional second argument to query.
- When `QueryOptions` and `ClientConfiguration` make the same setting, `QueryOptions` takes precedence.
- Add an `arguments` field to `QueryOptions` to make up for the fact that we are not passing a `QueryRequest` directly to `Client.query`.

## Result
The wire-protocol module sticks to describing the data can is sent and received.

Types are more accurate and easier to use inside the Client code. It is more clear how the client configuration and per-query options get combined.

## Out of scope
`QueryOptions` should also be passed into `Client.paginate` but that is not done, yet.

## Testing
Updated tests and added a test demonstrating using `arguments`

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3564]: https://faunadb.atlassian.net/browse/FE-3564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ