### PR TITLE
Enable QueryOptions for Client.paginate

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -204,12 +204,13 @@ export class Client {
    * ```
    */
   paginate<T extends QueryValue>(
-    iterable: Page<T> | EmbeddedSet | Query
+    iterable: Page<T> | EmbeddedSet | Query,
+    options?: QueryOptions
   ): SetIterator<T> {
     if (iterable instanceof Query) {
-      return SetIterator.fromQuery(this, iterable);
+      return SetIterator.fromQuery(this, iterable, options);
     }
-    return SetIterator.fromPageable(this, iterable) as SetIterator<T>;
+    return SetIterator.fromPageable(this, iterable, options) as SetIterator<T>;
   }
 
   /**


### PR DESCRIPTION
Ticket(s): FE-3564

## Problem
`QueryOptions` cannot be provided to `Client.paginate`

## Solution
Add optional argument for `Client.paginate` to pass in `QueryOptions` and handle in `SetIterator`

## Result
Can provide `QueryOptions` to `Client.paginate` for both input cases: an existing Page or a Query

## Out of scope
n/a

## Testing
Added new tests confirming `QueryOptions` get applied when `SetIterator` makes additional queries.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
