### PR TITLE
Update Node.js runtime versions

### DIFF
--- a/.github/workflows/pr_validate.yml
+++ b/.github/workflows/pr_validate.yml
@@ -21,7 +21,7 @@ jobs:
           - 7443:8443
     strategy:
       matrix:
-        node: ["18", "19"]
+        node: ["18", "20"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ This Driver supports and is tested on:
   - Safari
   - Edge
 - Node.js - [Current and Active LTS](https://nodejs.org/en/about/releases/)
-  - Current - v19
-  - Active LTS - v18
+  - Current - v20
+  - LTS - v18
 - Cloudflare Workers
 - AWS Lambda
 - Netlify

--- a/concourse/scripts/docker-compose-fauna.yml
+++ b/concourse/scripts/docker-compose-fauna.yml
@@ -8,7 +8,7 @@ services:
       - "8443:8443"
 
   node-lts:
-    image: node:18.15-alpine3.16
+    image: node:18.16-alpine3.16
     container_name: node-lts
     depends_on:
       - faunadb
@@ -27,7 +27,7 @@ services:
         yarn test:integration
 
   node-current:
-    image: node:19.8-alpine3.16
+    image: node:20.2-alpine3.16
     container_name: node-current
     depends_on:
       - faunadb

--- a/concourse/tasks/npm-publish.yml
+++ b/concourse/tasks/npm-publish.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: 19.8-alpine3.16
+    tag: 20.2-alpine3.16
 
 params:
   NPM_TOKEN:


### PR DESCRIPTION
Ticket(s): FE-3565

## Problem
v20 is now active
v19 end-of-life is 2023-06-01
v18.16 is also released

## Solution
Update test images and README supported runtimes

## Out of scope
n/a

## Testing
Ran the [docker-compose-fauna.yml](https://github.com/fauna/fauna-js/blob/main/concourse/scripts/docker-compose-fauna.yml) locally. I got an error initially, but that appears to be transient. It passes in additional runs.

Initial errors, for the record:
```shell
node-current  | [3/4] Linking dependencies...
node-current  | error An unexpected error occurred: "EEXIST: file already exists, symlink '../../../parser/bin/babel-parser.js' -> '/tmp/app/node_modules/@babel/traverse/node_modules/.bin/parser'".
node-current  | info If you think this is a bug, please open a bug report with the information provided in "/tmp/app/yarn-error.log".
node-current  | info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
node-current  | /bin/sh: jest: not found
node-current  | error Command failed with exit code 127.
node-current  | info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
node-current exited with code 127
```
and this one, too
```shell
node-current  | [4/4] Building fresh packages...
node-current  | $ husky install
node-current  | husky - git command not found, skipping install
node-current  | Test Suites: 0 of 7 total
node-current  | Tests:       0 total
node-current  | Snapshots:   0 total
node-current  | Time:        0.594 s, estimated 18 s
node-current  | Ran all test suites matching /.\/__tests__\/integration/i.
node-current  | Error: Cannot find module '/tmp/app/node_modules/jest-runner/build/index.js'
```

concourse pipelines will also validate latest images work.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
