### PR TITLE
Document timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ const client = new Client(config);
 
 ### Timeouts
 
-There are a few different timeout settings that can be configured
+There are a few different timeout settings that can be configured; each comes with a default setting. We recommend that most applications simply stick to the defaults.
 
 #### Query Timeout
 The query timeout is the time, in milliseconds, that Fauna will spend executing your query before aborting with a 503 Timeout error. If a query timeout occurs, the driver will throw an instance of `ServiceTimeoutError`.
@@ -295,7 +295,7 @@ The query timeout can be set using the `ClientConfiguration.query_timeout_ms` op
 const client = new Client({ query_timeout_ms: 20_000 });
 ```
 
-The query timeout can also be set to a different value for each query using the `QueryOptions.query_timeout_ms` option. Doing so overrides the client configuration.
+The query timeout can also be set to a different value for each query using the `QueryOptions.query_timeout_ms` option. Doing so overrides the client configuration when performing this query.
 
 ```javascript
 const response = await client.query(myQuery, { query_timeout_ms: 20_000 });
@@ -304,7 +304,7 @@ const response = await client.query(myQuery, { query_timeout_ms: 20_000 });
 #### Client Timeout
 The client timeout is the time, in milliseconds, that the client will wait for a network response before canceling the request. If a client timeout occurs, the driver will throw an instance of `NetworkError`.
 
-The client timeout is always the query timeout plus an additional buffer. This ensures that the client always weights for at least as long Fauna could work on your query and account for network latency. The client timeout buffer is configured by setting the `client_timeout_buffer_ms` option. The default value for the buffer if you do not provide on is 5000 ms (5 seconds), therefore the default client timeout is 10000 ms (10 s) when considering the default query timeout.
+The client timeout is always the query timeout plus an additional buffer. This ensures that the client always waits for at least as long Fauna could work on your query and account for network latency. The client timeout buffer is configured by setting the `client_timeout_buffer_ms` option. The default value for the buffer if you do not provide on is 5000 ms (5 seconds), therefore the default client timeout is 10000 ms (10 s) when considering the default query timeout.
 
 ```javascript
 const client = new Client({ client_timeout_buffer_ms: 6000 });
@@ -325,7 +325,7 @@ const client = new Client({ http2_session_idle_ms: 6000 });
 > Your application process may continue executing after all requests are completed for the duration of the session idle timeout. To prevent this, it is recommended to call `Client.close()` once all requests are complete. It is not recommended to set `http2_session_idle_ms` to small values.
 
 > **Warning**
-> Setting `http2_session_idle_ms` to small values can lead to a race condition where requests cannot be completed and you received a `ERR_HTTP2_GOAWAY_SESSION` error.
+> Setting `http2_session_idle_ms` to small values can lead to a race condition where requests cannot be transmitted before the session is closed, yielding `ERR_HTTP2_GOAWAY_SESSION` errors.
 
 
 ### Using environment variables

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ const options: QueryOptions = {
 
 const response = await client.query(fql`"Hello, ${name}!"`, options);
 
-client.close()
+client.close();
 ```
 
 ## Client Configuration

--- a/README.md
+++ b/README.md
@@ -289,12 +289,26 @@ There are a few different timeout settings that can be configured
 #### Query Timeout
 The query timeout is the time, in milliseconds, that Fauna will spend executing your query before aborting with a 503 Timeout error.
 
-Configure the query timeout using the `query_timeout_ms` option. The default value if you do not provide one is 5000 ms (5 seconds).
+The query timeout can be set using the `ClientConfiguration.query_timeout_ms` option. The default value if you do not provide one is 5000 ms (5 seconds).
+
+```javascript
+const client = new Client({ query_timeout_ms: 20_000 });
+```
+
+The query timeout can also be set to a different value for each query using the `QueryOptions.query_timeout_ms` option. Doing so overrides the client configuration.
+
+```javascript
+const response = await client.query(myQuery, { query_timeout_ms: 20_000 });
+```
 
 #### Client Timeout
 The client timeout is the time, in milliseconds, that the client will wait for a network response before canceling the request and throwing and error.
 
-The client timeout is always the query timeout plus an additional buffer. This ensures that the client always weights for at least as long Fauna could work on your query and account for network latency. The client timeout buffer is configured by setting the `client_timeout_buffer_ms` option. The default value if you do not provide on is 5000 ms (5 seconds).
+The client timeout is always the query timeout plus an additional buffer. This ensures that the client always weights for at least as long Fauna could work on your query and account for network latency. The client timeout buffer is configured by setting the `client_timeout_buffer_ms` option. The default value for the buffer if you do not provide on is 5000 ms (5 seconds), therefore the default client timeout is 10000 ms (10 s) when considering the default query timeout.
+
+```javascript
+const client = new Client({ client_timeout_buffer_ms: 6000 });
+```
 
 #### HTTP/2 Session Idle Timeout
 The HTTP/2 session idle timeout is the time, in milliseconds, that an HTTP/2 session will remain open after there is no more pending communication. Once the session idle time has elapsed the session is considered idle and the session is closed. Subsequent requests will create a new session.
@@ -302,6 +316,10 @@ The HTTP/2 session idle timeout is the time, in milliseconds, that an HTTP/2 ses
 Configure the HTTP/2 session idle timeout using the `http2_session_idle_ms` option. The default value if you do not provide one is 5000 ms (5 seconds).
 
 This setting only applies to clients using HTTP/2 implementations; for example, the default client for Node.js runtimes.
+
+```javascript
+const client = new Client({ http2_session_idle_ms: 6000 });
+```
 
 > **Note**
 > Your application process may continue executing after all requests are completed for the duration of the session idle timeout. To prevent this, it is recommended to call `Client.close()` once all requests are complete. It is not recommended to set `http2_session_idle_ms` to small values.

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ const client = new Client(config);
 There are a few different timeout settings that can be configured
 
 #### Query Timeout
-The query timeout is the time, in milliseconds, that Fauna will spend executing your query before aborting with a 503 Timeout error.
+The query timeout is the time, in milliseconds, that Fauna will spend executing your query before aborting with a 503 Timeout error. If a query timeout occurs, the driver will throw an instance of `ServiceTimeoutError`.
 
 The query timeout can be set using the `ClientConfiguration.query_timeout_ms` option. The default value if you do not provide one is 5000 ms (5 seconds).
 
@@ -302,7 +302,7 @@ const response = await client.query(myQuery, { query_timeout_ms: 20_000 });
 ```
 
 #### Client Timeout
-The client timeout is the time, in milliseconds, that the client will wait for a network response before canceling the request and throwing and error.
+The client timeout is the time, in milliseconds, that the client will wait for a network response before canceling the request. If a client timeout occurs, the driver will throw an instance of `NetworkError`.
 
 The client timeout is always the query timeout plus an additional buffer. This ensures that the client always weights for at least as long Fauna could work on your query and account for network latency. The client timeout buffer is configured by setting the `client_timeout_buffer_ms` option. The default value for the buffer if you do not provide on is 5000 ms (5 seconds), therefore the default client timeout is 10000 ms (10 s) when considering the default query timeout.
 
@@ -311,7 +311,7 @@ const client = new Client({ client_timeout_buffer_ms: 6000 });
 ```
 
 #### HTTP/2 Session Idle Timeout
-The HTTP/2 session idle timeout is the time, in milliseconds, that an HTTP/2 session will remain open after there is no more pending communication. Once the session idle time has elapsed the session is considered idle and the session is closed. Subsequent requests will create a new session.
+The HTTP/2 session idle timeout is the time, in milliseconds, that an HTTP/2 session will remain open after there is no more pending communication. Once the session idle time has elapsed the session is considered idle and the session is closed. Subsequent requests will create a new session; the session idle timeout does not result in an error.
 
 Configure the HTTP/2 session idle timeout using the `http2_session_idle_ms` option. The default value if you do not provide one is 5000 ms (5 seconds).
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ import { fql, Client, type QueryOptions } from "fauna";
 const client = new Client();
 
 const options: QueryOptions = {
-  arguments: { name: "Alice" };
+  arguments: { name: "Alice" },
   format: "tagged",
   long_type: "number",
   linearized: false,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,7 +8,7 @@ import type {
 /**
  * A common error base class for all other errors.
  */
-abstract class FaunaError extends Error {
+export abstract class FaunaError extends Error {
   constructor(...args: any[]) {
     super(...args);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   ClientError,
   ClientClosedError,
   ContendedTransactionError,
+  FaunaError,
   InvalidRequestError,
   NetworkError,
   ProtocolError,


### PR DESCRIPTION
Ticket(s): FE-3541

## Problem
We need some clarification around timeout configuration options, their relation to each other, related errors, why `Client.close()` should be used, etc.

## Solution
Update the README

Also fixed the missing export for `FaunaError` since we document using that in the README.

## Result
[preview](https://github.com/fauna/fauna-js/blob/af9655bb659f588d424a25d78ef26ca4670e7cf5/README.md)

## Out of scope
Adding every option and public function to the README. We should generate tsdocs for that.

## Testing
n/a

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
