### PR TITLE
Rework process.env typeguards due to platform test failures

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -296,7 +296,14 @@ export class Client {
   }
 
   #getSecret(partialClientConfig?: ClientConfiguration): string {
-    const fallback = process?.env?.FAUNA_SECRET;
+    let fallback = undefined;
+    if (
+      process?.env !== undefined &&
+      process?.env !== null &&
+      typeof process.env === "object"
+    ) {
+      fallback = process.env["FAUNA_SECRET"];
+    }
 
     const maybeSecret = partialClientConfig?.secret || fallback;
     if (maybeSecret === undefined) {

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -241,9 +241,12 @@ const crossGlobal =
 const getNodeRuntimeEnv = (): string => {
   // return early if process variables are not available
   if (
-    process?.env === undefined ||
-    process?.env === null ||
-    typeof process.env !== "object"
+    !(
+      typeof process !== "undefined" &&
+      process &&
+      process.env &&
+      typeof process.env !== undefined
+    )
   ) {
     return "unknown";
   }

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -240,8 +240,12 @@ const crossGlobal =
  */
 const getNodeRuntimeEnv = (): string => {
   // return early if process variables are not available
-  if (typeof process?.env !== "object" || process.env === null) {
-    return "unkown";
+  if (
+    process?.env === undefined ||
+    process?.env === null ||
+    typeof process.env !== "object"
+  ) {
+    return "unknown";
   }
 
   const runtimeEnvs = [


### PR DESCRIPTION

## Problem
- platform test failures
## Solution
- are old code was passing our platform tests fine - so go back to using a syntax closer to what we have before
## Result
- platform tests 

## Testing
Testing against Nuxt JS
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
