### PR TITLE
Check typeof process before you use it

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -298,6 +298,7 @@ export class Client {
   #getSecret(partialClientConfig?: ClientConfiguration): string {
     let fallback = undefined;
     if (
+      typeof process !== "undefined" &&
       process &&
       typeof process === "object" &&
       process.env &&

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -16,7 +16,11 @@ export const isHTTPResponse = (res: any): res is HTTPResponse =>
   res instanceof Object && "body" in res && "headers" in res && "status" in res;
 
 const nodeHttp2IsSupported = () => {
-  if (typeof process !== "undefined" && process.release?.name === "node") {
+  if (
+    typeof process !== "undefined" &&
+    process &&
+    process.release?.name === "node"
+  ) {
     try {
       require("node:http2");
       return true;


### PR DESCRIPTION

## Problem
- in certain engined you get a ReferenceError if you call a variable that has never been declared.
## Solution
- check typeof process before using it.
## Result
- we can run on CloudFlare
## Out of scope
- N/A
## Testing
Testing Nuxt and will test clouflare in Pipeline
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
