### PR TITLE
add schema version to drivers

### DIFF
--- a/__tests__/integration/schema-version.test.ts
+++ b/__tests__/integration/schema-version.test.ts
@@ -5,13 +5,13 @@ describe("schema version is returned by the client", () => {
   const client = getClient();
   it("returns the schema version", async () => {
     const resTs = await client.query(fql`
-    Collection.create({ name: "TestColl" })
+      Collection.create({ name: "TestColl" })
     `);
 
     const expectedSchemaVersion = resTs.txn_ts;
 
     const res = await client.query(fql`
-    Customers.all()
+      Customers.all()
     `);
 
     expect(res.schema_version).toEqual(expectedSchemaVersion);

--- a/__tests__/integration/schema-version.test.ts
+++ b/__tests__/integration/schema-version.test.ts
@@ -1,0 +1,19 @@
+import { fql } from "../../src";
+import { getClient } from "../client";
+
+describe("schema version is returned by the client", () => {
+  const client = getClient();
+  it("returns the schema version", async () => {
+    const resTs = await client.query(fql`
+    Collection.create({ name: "TestColl" })
+    `);
+
+    const expectedSchemaVersion = resTs.txn_ts;
+
+    const res = await client.query(fql`
+    Customers.all()
+    `);
+
+    expect(res.schema_version).toEqual(expectedSchemaVersion);
+  });
+});

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -129,6 +129,8 @@ export type QueryStats = {
 export type QueryInfo = {
   /** The last transaction timestamp of the query. A Unix epoch in microseconds. */
   txn_ts?: number;
+  /** The schema version that was used for the query execution. */
+  schema_version?: number;
   /** A readable summary of any warnings or logs emitted by the query. */
   summary?: string;
   /** The value of the x-query-tags header, if it was provided. */


### PR DESCRIPTION
Leaving this as draft for now as the change to add the schema version hasn't made it out to prod yet.

ENG-5237
This builds on a change to core that started including the schema version in the query API response: https://github.com/fauna/core/blob/master/ext/api/src/main/resources/openapi.yml#L393 This schema version can be used by the dashboard to determine when it needs to refresh the schema.  This includes both displaying schema to users as well as refreshing the environment used by the language library to provide intellisense.

