### PR TITLE
docs(readme): fix quickstart variable use

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ try {
   // build queries using the `fql` function
   const collectionQuery = fql`Collection.create({ name: "Dogs" })`;
   // execute the query
-  const collectionResponse = await client.query(collection_query);
+  const collectionResponse = await client.query(collectionQuery);
 
   // define some data in your app
   const dog = { name: "Scout" };
@@ -69,7 +69,7 @@ try {
   `;
 
   // execute the query
-  const response = await client.query(document_query);
+  const response = await client.query(documentQuery);
 } catch (error) {
   if (error instanceof FaunaError) {
     // handle errors


### PR DESCRIPTION
## Problem

Quickstart invokes a variable that doesn't exist.

## Solution

Update the quickstart to use the defined variable.

## Result

## Out of scope

## Testing

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
