### PR TITLE
fix: Explicitly check for browser env

### DIFF
--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -19,51 +19,55 @@ export const getDriverEnv = (): string => {
     runtime: "unknown",
   };
 
-  /**
-   * Determine if we're executing in a Node environment
-   */
-  const isNode =
-    typeof window === "undefined" &&
-    typeof process !== "undefined" &&
-    process.versions != null &&
-    process.versions.node != null;
+  try {
+    /**
+     * Determine if we're executing in a Node environment
+     */
+    const isNode =
+      typeof window === "undefined" &&
+      typeof process !== "undefined" &&
+      process.versions != null &&
+      process.versions.node != null;
 
-  /**
-   * Determine if we're executing in a Node environment
-   */
-  const isBrowser =
-    typeof window !== "undefined" && typeof window.document !== "undefined";
+    /**
+     * Determine if we're executing in a Node environment
+     */
+    const isBrowser =
+      typeof window !== "undefined" && typeof window.document !== "undefined";
 
-  /**
-   * Determine if we're executing in a Service Worker environment
-   */
-  const isServiceWorker =
-    typeof self === "object" &&
-    self.constructor &&
-    self.constructor.name === "DedicatedWorkerGlobalScope";
+    /**
+     * Determine if we're executing in a Service Worker environment
+     */
+    const isServiceWorker =
+      typeof self === "object" &&
+      self.constructor &&
+      self.constructor.name === "DedicatedWorkerGlobalScope";
 
-  /**
-   * Determine if we're executing in Vercel's Edge Runtime
-   * @see {@link https://vercel.com/docs/concepts/functions/edge-functions/edge-runtime#check-if-you're-running-on-the-edge-runtime}
-   */
-  // @ts-expect-error Cannot find name 'EdgeRuntime'
-  const isVercelEdgeRuntime = typeof EdgeRuntime !== "string";
+    /**
+     * Determine if we're executing in Vercel's Edge Runtime
+     * @see {@link https://vercel.com/docs/concepts/functions/edge-functions/edge-runtime#check-if-you're-running-on-the-edge-runtime}
+     */
+    // @ts-expect-error Cannot find name 'EdgeRuntime'
+    const isVercelEdgeRuntime = typeof EdgeRuntime !== "string";
 
-  if (isNode) {
-    driverEnv.runtime = ["nodejs", process.version].join("-");
-    driverEnv.env = getNodeRuntimeEnv();
-    driverEnv.os = [os.platform(), os.release()].join("-");
-  } else if (isServiceWorker) {
-    driverEnv.runtime = getBrowserDetails(navigator);
-    driverEnv.env = "Service Worker";
-    driverEnv.os = getBrowserOsDetails(navigator);
-  } else if (isBrowser) {
-    driverEnv.runtime = getBrowserDetails(navigator);
-    driverEnv.env = "browser";
-    driverEnv.os = getBrowserOsDetails(navigator);
-  } else if (isVercelEdgeRuntime) {
-    driverEnv.runtime = "Vercel Edge Runtime";
-    driverEnv.env = "edge";
+    if (isNode) {
+      driverEnv.runtime = ["nodejs", process.version].join("-");
+      driverEnv.env = getNodeRuntimeEnv();
+      driverEnv.os = [os.platform(), os.release()].join("-");
+    } else if (isServiceWorker) {
+      driverEnv.runtime = getBrowserDetails(navigator);
+      driverEnv.env = "Service Worker";
+      driverEnv.os = getBrowserOsDetails(navigator);
+    } else if (isBrowser) {
+      driverEnv.runtime = getBrowserDetails(navigator);
+      driverEnv.env = "browser";
+      driverEnv.os = getBrowserOsDetails(navigator);
+    } else if (isVercelEdgeRuntime) {
+      driverEnv.runtime = "Vercel Edge Runtime";
+      driverEnv.env = "edge";
+    }
+  } catch (e) {
+    // ignore errors trying to report on user environment
   }
 
   return (


### PR DESCRIPTION
Ticket(s): [FE-3729](https://faunadb.atlassian.net/browse/FE-3729)

Fixes #173 

Leaving this as a draft while we get some testing done.

## Problem
We currently assume that if you are not running in Node or Service Worker, you are in a browser. That blows up in environments like Vercel's Edge Runtime and Fastly's Compute@Edge.

## Solution
Explicitly check for browser env before getting details from `navigator` object. If none of our env checks are true, then report unknown.

## Testing
Running locally with some edge projects.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3729]: https://faunadb.atlassian.net/browse/FE-3729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ