### PR TITLE
Fix Query Options README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,13 +237,13 @@ const options: QueryOptions = {
   long_type: "number",
   linearized: false,
   max_contention_retries: 5,
-  query_tags: { name: "readme query" },
+  query_tags: { name: "readme_query" },
   query_timeout_ms: 60_000,
   traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-000000000000000b-00",
   typecheck: true,
 };
 
-const response = await client.query(fql`"Hello, ${name}!"`, options);
+const response = await client.query(fql`"Hello, #{name}!"`, options);
 
 client.close();
 ```


### PR DESCRIPTION
Ticket(s): 

## Problem
fixes #175

1. The example is supposed to demonstrate arguments through query options, not interpolation.
2. Spaces are not allowed in query tags. Per the API spec, each key and each value may only contain the characters [a-zA-Z0-9_].

## Solution
Update the example.

## Result
Example is now runnable.

## Out of scope
n/a

## Testing
tested examples locally

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
