### PR TITLE
refresh session when destroyed

### DIFF
--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -135,7 +135,7 @@ export class NodeHTTP2Client implements HTTPClient {
 
   #connect() {
     // create the session if it does not exist or is closed
-    if (!this.#session || this.#session.closed) {
+    if (!this.#session || this.#session.closed || this.#session.destroyed) {
       const new_session: ClientHttp2Session = http2
         .connect(this.#url, {
           peerMaxConcurrentStreams: this.#http2_max_streams,


### PR DESCRIPTION
ENG-5289
I noticed while working on the vs code extension that if I lose connectivity to core it ends up destroying the session and then it continues to fail even if I regain connectivity. Small change here to also refresh the session if it ended up getting destroyed.

https://nodejs.org/api/http2.html#http2sessiondestroyed