### PR TITLE
Add test helpers

### DIFF
--- a/__tests__/integration/schema-version.test.ts
+++ b/__tests__/integration/schema-version.test.ts
@@ -1,15 +1,18 @@
 import { fql } from "../../src";
-import { getClient } from "../client";
+import { newDB } from "../client";
+import { Client } from "../../src";
 
 describe("schema version is returned by the client", () => {
-  const client = getClient();
+  let client: Client;
+
+  // make a fresh db each run
+  beforeAll(async () => {
+    client = await newDB("SchemaTest");
+  });
+
   it("returns the schema version", async () => {
     const resTs = await client.query(fql`
-      if (Collection.byName("TestColl") == null) {
-        Collection.create({ name: "TestColl" })
-      } else {
-        TestColl.definition.update({})
-      }
+      Collection.create({ name: "TestColl" })
     `);
 
     const expectedSchemaVersion = resTs.txn_ts;

--- a/__tests__/integration/schema-version.test.ts
+++ b/__tests__/integration/schema-version.test.ts
@@ -1,6 +1,5 @@
-import { fql } from "../../src";
+import { Client, fql } from "../../src";
 import { newDB } from "../client";
-import { Client } from "../../src";
 
 describe("schema version is returned by the client", () => {
   let client: Client;


### PR DESCRIPTION
Adds a test helper we have in the database (`newDB`), which creates a fresh DB for each run.

It then uses this helper to fix the schema version test.
