### PR TITLE
Revert "Bump word-wrap from 1.2.3 to 1.2.5 (#190)"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3172,9 +3172,9 @@ which@^2.0.1:
     isexe "^2.0.0"
 
 word-wrap@^1.2.3:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
-  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
This reverts commit 484aa440f4032fe059fa29af51a3219f0e96a299.


## Problem

The commit being reverted broke many tests.

## Solution

Revert it. Also, turn mandatory test runs back on in the branch protection (commit was merged via auto-merge which did not require a test run).

## Result
Tip of main works.

## Testing

Ran full suite locally. Actions will do the same.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
