### PR TITLE
Add Github action the honors the pr/do-not-merge tag

### DIFF
--- a/.github/workflows/pr_donotmerge.yml
+++ b/.github/workflows/pr_donotmerge.yml
@@ -1,0 +1,20 @@
+name: Validate pull request (do not merge)
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize, ready_for_review]
+
+jobs:
+  do_not_merge-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Has tag
+        if: github.base_ref == 'main' && contains( github.event.pull_request.labels.*.name, 'pr/do-not-merge')
+        run: |
+          echo "PR blocked: [tag: pr/do-not-merge]"
+          exit 1
+
+      - name: All good
+        if: ${{ success() }}
+        run: |
+          echo "All good"


### PR DESCRIPTION
Ticket(s): BT-4101

## Problem

We don't have a way to tag PRs that block them from being merged.

## Solution

Add a workflow that blocks when a PR is tagged with `pr/do-not-merge`.

## Result

We can safely stage PRs without them being accidentally merged.

## Testing

None

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
