### PR TITLE
Get tests to pass when type checking is on.

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -477,7 +477,6 @@ describe("query can encode / decode QueryValue correctly", () => {
     const docCreated = await client.query<any>(
       fql`UndefinedTest.create(${toughInput})`
     );
-    client.close();
     expect(docCreated.data.should_exist).toBeUndefined();
     expect(docCreated.data.nested_object.i_dont_exist).toBeUndefined();
     expect(docCreated.data.foo).toBe("bar");
@@ -490,7 +489,7 @@ describe("query can encode / decode QueryValue correctly", () => {
     // @ts-expect-error Type 'undefined' is not assignable to type 'QueryValue'
     let undefinedValue: QueryValue = undefined;
     try {
-      client.query(fql`{ foo: ${undefinedValue} }`);
+      await client.query(fql`{ foo: ${undefinedValue} }`);
     } catch (e) {
       if (e instanceof TypeError) {
         expect(e.name).toBe("TypeError");
@@ -498,8 +497,6 @@ describe("query can encode / decode QueryValue correctly", () => {
           "Passing undefined as a QueryValue is not supported"
         );
       }
-    } finally {
-      client.close();
     }
   });
 });

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -186,7 +186,7 @@ describe("query", () => {
       if (e instanceof QueryCheckError) {
         expect(e.httpStatus).toBe(400);
         expect(e.message).toBeDefined();
-        expect(e.code).toBeDefined();
+        expect(e.code).toBe("invalid_query");
         expect(e.queryInfo?.summary).toBeDefined();
       }
     }
@@ -195,7 +195,7 @@ describe("query", () => {
   it("throws a QueryRuntimeError if the query hits a runtime error", async () => {
     expect.assertions(3);
     try {
-      await client.query(fql`"taco".length + "taco"`);
+      await client.query(fql`2 + "2"`, { typecheck: false });
     } catch (e) {
       if (e instanceof QueryRuntimeError) {
         expect(e.httpStatus).toBe(400);
@@ -458,7 +458,6 @@ describe("query", () => {
 
 describe("query can encode / decode QueryValue correctly", () => {
   it("treats undefined as unprovided when in object", async () => {
-    const client = getClient();
     const collectionName = "UndefinedTest";
     await client.query(fql`
       if (Collection.byName(${collectionName}) == null) {
@@ -474,8 +473,10 @@ describe("query can encode / decode QueryValue correctly", () => {
         i_dont_exist: undefined,
       },
     };
-    const docCreated = await client.query<any>(fql`
-        ${new Module(collectionName)}.create(${toughInput})`);
+    // Do not use a dynamic Collection name by using `${new Module(collectionName)}`. See ENG-5003
+    const docCreated = await client.query<any>(
+      fql`UndefinedTest.create(${toughInput})`
+    );
     client.close();
     expect(docCreated.data.should_exist).toBeUndefined();
     expect(docCreated.data.nested_object.i_dont_exist).toBeUndefined();
@@ -483,27 +484,13 @@ describe("query can encode / decode QueryValue correctly", () => {
     expect(docCreated.data.nested_object.i_exist).toBe(true);
   });
 
-  it("treats undefined as unprovided passed directly as value", async () => {
+  it("undefined arguments throw a TypeError", async () => {
     expect.assertions(2);
-    const client = getClient();
-    const collectionName = "UndefinedTest";
-    await client.query(fql`
-      if (Collection.byName(${collectionName}) == null) {
-        Collection.create({ name: ${collectionName}})
-      }`);
     // whack in undefined
     // @ts-expect-error Type 'undefined' is not assignable to type 'QueryValue'
     let undefinedValue: QueryValue = undefined;
     try {
-      await client.query(fql`
-        ${new Module(collectionName)}.create({
-          foo: "bar",
-          shouldnt_exist: ${undefinedValue},
-          nested_object: {
-            i_exist: true,
-            i_dont_exist: ${undefinedValue}
-          }
-        })`);
+      client.query(fql`{ foo: ${undefinedValue} }`);
     } catch (e) {
       if (e instanceof TypeError) {
         expect(e.name).toBe("TypeError");


### PR DESCRIPTION
Ticket(s): 

## Problem
Some tests fail when static type-checking is on by default.

## Solution
Update failing tests.

## Out of scope
n/a

## Testing
run integration tests on env with typechecking on by default

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
