### PR TITLE
Move off abanodned docker image and use straight docker for integration tests

### DIFF
--- a/concourse/tasks/integration-tests.yml
+++ b/concourse/tasks/integration-tests.yml
@@ -3,7 +3,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: karlkfi/concourse-dcind
+    repository: docker
+    variant: dind
 
 params:
   FAUNA_ROOT_KEY:


### PR DESCRIPTION
Ticket(s): FE-###

## Problem

## Solution

## Result

## Out of scope

## Testing

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
