### PR TITLE
Run integ test script in sh not bash

### DIFF
--- a/concourse/tasks/integration-tests.yml
+++ b/concourse/tasks/integration-tests.yml
@@ -18,7 +18,7 @@ inputs:
 run:
   path: dockerd-entrypoint.sh
   args:
-    - bash
+    - sh
     - -ceu
     - |
       # start containers


### PR DESCRIPTION
## Problem
bash is not supported in this entry point script.
## Solution
use sh

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
