### PR TITLE
Pin fauna version in pipeline

### DIFF
--- a/concourse/scripts/docker-compose-fauna.yml
+++ b/concourse/scripts/docker-compose-fauna.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   faunadb:
-    image: fauna/faunadb
+    image: fauna/faunadb:4.28
     container_name: faunadb
     ports:
       - "8443:8443"

--- a/concourse/scripts/docker-compose-fauna.yml
+++ b/concourse/scripts/docker-compose-fauna.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   faunadb:
-    image: fauna/faunadb:4.28
+    image: fauna/faunadb:4.28.0
     container_name: faunadb
     ports:
       - "8443:8443"

--- a/concourse/tasks/integration-tests.yml
+++ b/concourse/tasks/integration-tests.yml
@@ -3,8 +3,7 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: docker
-    variant: dind
+    repository: karlkfi/concourse-dcind
 
 params:
   FAUNA_ROOT_KEY:
@@ -16,9 +15,9 @@ inputs:
   - name: fauna-js-repository
 
 run:
-  path: dockerd-entrypoint.sh
+  path: entrypoint.sh
   args:
-    - sh
+    - bash
     - -ceu
     - |
       # start containers


### PR DESCRIPTION

## Problem
The pipeline is stuck because we cannot run integration tests successfully due to compatibility issues in the docker images we use inside our CD pipeline.
## Solution
A temporary work around for this is to pin the fauna db image we use in the CD pipeline to 4.28
## Result
We can run the pipeline.

## Testing
Made this same work around on the pipeline for a private repo and it works as expected.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
