### PR TITLE
endpoint falls back to FAUNA_ENDPOINT env variable

### DIFF
--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -15,12 +15,25 @@ beforeEach(() => {
   process.env = { ...PROCESS_ENV };
 });
 
+afterEach(() => {
+  process.env = PROCESS_ENV;
+});
+
 describe("ClientConfiguration", () => {
   it("Client exposes a default client configuration", () => {
     process.env["FAUNA_SECRET"] = "foo";
     const client = new Client();
     expect(Buffer.from(JSON.stringify(client)).toString()).not.toContain(
       "secret"
+    );
+  });
+
+  it("can be initialized with an endpoint from the environment", async () => {
+    process.env["FAUNA_ENDPOINT"] = "https://localhost:9999/";
+
+    const client = new Client({ secret: "secret" });
+    expect(client.clientConfiguration.endpoint?.toString()).toEqual(
+      "https://localhost:9999/"
     );
   });
 


### PR DESCRIPTION
Ticket(s): FE-4347

fixes: #205

## Problem
In the README, it states that the FAUNA_ENDPOINT environment variable can be used to override the default endpoint client configuration setting. However, this is not getting honored when set.

## Solution
Fall back on the env variable if endpoint is not explicitly set. THEN fall back on the default (https://db.fauna.com).

If the endpoint is explicitly set to `undefined`, then we still throw a TypeError, rather than fall back on any values.

## Result
env var is honored.

## Out of scope

## Testing
Added a test.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
