### PR TITLE
Allow overriding the client's secret

### DIFF
--- a/__tests__/unit/client.test.ts
+++ b/__tests__/unit/client.test.ts
@@ -13,8 +13,8 @@ import {
 
 describe("Client", () => {
   it("Allows setting a secret in query", async () => {
-    expect.assertions(1)
-  
+    expect.assertions(1);
+
     const client = getClient();
     try {
       await client.query(fql`Role.create({ name: "hi" })`, {

--- a/__tests__/unit/client.test.ts
+++ b/__tests__/unit/client.test.ts
@@ -13,6 +13,8 @@ import {
 
 describe("Client", () => {
   it("Allows setting a secret in query", async () => {
+    expect.assertions(1)
+  
     const client = getClient();
     try {
       await client.query(fql`Role.create({ name: "hi" })`, {

--- a/__tests__/unit/client.test.ts
+++ b/__tests__/unit/client.test.ts
@@ -1,4 +1,10 @@
-import { Client, ClientClosedError, fql, NodeHTTP2Client } from "../../src";
+import {
+  Client,
+  ClientClosedError,
+  QueryRuntimeError,
+  fql,
+  NodeHTTP2Client,
+} from "../../src";
 import {
   getClient,
   getDefaultHTTPClientOptions,
@@ -6,6 +12,24 @@ import {
 } from "../client";
 
 describe("Client", () => {
+  it("Allows setting a secret in query", async () => {
+    const client = getClient();
+    try {
+      await client.query(fql`Role.create({ name: "hi" })`, {
+        secret: client.clientConfiguration.secret + ":server",
+      });
+      throw new Error("shouldn't work");
+    } catch (e) {
+      if (e instanceof QueryRuntimeError) {
+        expect(e.message).toEqual(
+          "Insufficient privileges to perform the action."
+        );
+      } else {
+        throw new Error(`wrong error ${e}`);
+      }
+    }
+  });
+
   it("Refuses further requests after close", async () => {
     expect.assertions(1);
     const client = getClient();

--- a/src/client.ts
+++ b/src/client.ts
@@ -394,7 +394,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
       };
 
       const headers = {
-        Authorization: `Bearer ${this.#clientConfiguration.secret}`,
+        Authorization: `Bearer ${requestConfig.secret}`,
       };
       this.#setHeaders(requestConfig, headers);
 

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -93,6 +93,11 @@ export interface QueryOptions {
    * Overrides the optional setting on the {@link ClientConfiguration}.
    */
   typecheck?: boolean;
+
+  /**
+   * Secret to use instead of the client's secret.
+   */
+  secret?: string;
 }
 
 /**


### PR DESCRIPTION
Ticket(s): FE-4356

This allows overriding the client's secret on a `query` call.

This might screw up `last_txn_ts` if you switch region groups. That should quickly resolve itself, as the last_txn_ts will catch up quickly.
