### PR TITLE
Expose the secret in `client.clientConfiguration`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -141,12 +141,11 @@ export class Client {
   }
 
   /**
-   * Return the {@link ClientConfiguration} of this client, save for the secret.
+   * Return the {@link ClientConfiguration} of this client.
    */
-  get clientConfiguration(): Omit<ClientConfiguration, "secret"> {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { secret, ...rest } = this.#clientConfiguration;
-    return rest;
+  get clientConfiguration(): ClientConfiguration {
+    const { ...copy } = this.#clientConfiguration;
+    return copy;
   }
 
   /**


### PR DESCRIPTION
Ticket(s): FE-###

I'm not sure why we hid this in the first place. The code to construct the client needs to know the secret, and this just lets you avoid passing the secret around alongside the client.
