### PR TITLE
Add retries on throttling errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ try {
 This Driver supports and is tested on:
 
 - Browsers - Stable versions of
-  - Chrome 69+ 
+  - Chrome 69+
   - Firefox 62+
   - Safari 12.1+
   - Edge 79+
@@ -269,6 +269,8 @@ const config: ClientConfiguration = {
   format: "tagged",
   long_type: "number",
   linearized: false,
+  max_attempts: 3,
+  max_backoff: 20,
   max_contention_retries: 5,
   query_tags: { name: "readme query" },
   query_timeout_ms: 60_000,
@@ -278,6 +280,18 @@ const config: ClientConfiguration = {
 
 const client = new Client(config);
 ```
+
+### Retry
+
+#### Max Attempts
+
+The maximum number of times a query will be attempted if a retryable exception is thrown (ThrottlingError). Default 3, inclusive of the initial call. The retry strategy implemented is a simple exponential backoff.
+
+To disable retries, pass max_attempts less than or equal to 1.
+
+#### Max Backoff
+
+The maximum backoff in seconds to be observed between each retry. Default 20 seconds.
 
 ### Timeouts
 

--- a/__tests__/unit/fetch-client.test.ts
+++ b/__tests__/unit/fetch-client.test.ts
@@ -29,6 +29,7 @@ const dummyStats = {
   storage_bytes_read: 0,
   storage_bytes_write: 0,
   contention_retries: 0,
+  attempts: 0,
 };
 
 describe("fetch client", () => {

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -118,6 +118,16 @@ export interface ClientConfiguration {
    * be used.
    */
   typecheck?: boolean;
+
+  /**
+   * Max attempts for retryable exceptions. Default is 3.
+   */
+  max_attempts?: number;
+
+  /**
+   * Max backoff between retries. Default is 20 seconds.
+   */
+  max_backoff?: number;
 }
 
 /**

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -129,6 +129,8 @@ export type QueryStats = {
   storage_bytes_write: number;
   /** The number of times the transaction was retried due to write contention. */
   contention_retries: number;
+  /** The number query attempts made due to retryable errors. */
+  attempts: number;
 };
 
 export type QueryInfo = {


### PR DESCRIPTION
Ticket(s): FE-2988

## Problem
We need to retry throttling errors within the client.

## Solution
* Expose max_attempts and max_backoff in client configuration
* Backoff/retry on throttling error up to max_attempts

## Result

## Out of scope

## Testing
* Added unit test

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
