### PR TITLE
Allow setting arbitrary headers

### DIFF
--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -128,6 +128,11 @@ export interface ClientConfiguration {
    * Max backoff between retries. Default is 20 seconds.
    */
   max_backoff?: number;
+
+  /**
+   * Any extra headers to send with the request. These headers will overwrite any headers set by the driver.
+   */
+  headers?: Record<string, string>;
 }
 
 /**

--- a/src/client.ts
+++ b/src/client.ts
@@ -426,10 +426,15 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
         ...options,
       };
 
-      const headers = {
+      const headerPartial = {
         Authorization: `Bearer ${requestConfig.secret}`,
       };
-      this.#setHeaders(requestConfig, headers);
+      this.#setHeaders(requestConfig, headerPartial);
+
+      const headers = {
+        ...headerPartial,
+        ...requestConfig.headers,
+      };
 
       const isTaggedFormat = requestConfig.format === "tagged";
 

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -98,6 +98,11 @@ export interface QueryOptions {
    * Secret to use instead of the client's secret.
    */
   secret?: string;
+
+  /**
+   * Any extra headers to send with the request. These headers will overwrite any headers set by the driver.
+   */
+  headers?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
Ticket(s): FE-4378

Allows setting arbitrary headers in the initial config and in `query`. These headers will overwrite any headers the driver sets up.
