### PR TITLE
BT-4181: Query limits test case and pipeline collateral

### DIFF
--- a/__tests__/integration/query-limits.test.ts
+++ b/__tests__/integration/query-limits.test.ts
@@ -1,0 +1,63 @@
+import { Client, fql, Module } from "../../src";
+import { getClient, getDefaultSecretAndEndpoint } from "../client";
+
+const rootClient = getClient();
+const clients = new Array<Client>();
+const limitedDbName = process.env["QUERY_LIMITS_DB"] || "";
+const collectionName = process.env["QUERY_LIMITS_COLL"] || "";
+
+beforeAll(async () => {
+  // Create Key for test database and create clients with the secret
+  let secret = await rootClient
+    .query<{ secret: string }>(
+      fql`
+    if (Database.byName(${limitedDbName}).exists()) {
+      Key.create({ role: "admin", database: ${limitedDbName} }) { secret }
+    } else {
+      abort("Database not found.")
+    }`
+    )
+    .then((res) => res.data.secret)
+    .catch((err) => {
+      console.log(err);
+      throw err;
+    });
+
+  for (let i = 0; i < 5; i++) {
+    clients.push(getClient({ secret: secret }));
+  }
+});
+
+afterAll(() => {
+  rootClient.close();
+  clients.forEach((x) => x.close());
+});
+
+if (process.env["QUERY_LIMITS_DB"] && process.env["QUERY_LIMITS_COLL"]) {
+  describe("Query with limits enabled", () => {
+    it("succeeds on retry after getting throttled", async () => {
+      expect.assertions(1);
+
+      let throttled = false;
+      await Promise.all(
+        clients.map((client) => {
+          // Target DB needs read_ops limit of 100; call .paginate(50) several times
+          // simultaneously to get throttled, all calls should succeed on client retry
+          return client
+            .query(fql`${fql([collectionName])}.all().paginate(50)`)
+            .then((res) => {
+              if (res.stats?.attempts && res.stats.attempts > 1) {
+                throttled = true;
+              }
+            })
+            .catch((err) => {
+              console.log(err);
+              throw err;
+            });
+        })
+      );
+
+      expect(throttled).toBeTruthy();
+    }, 20000);
+  });
+}

--- a/__tests__/integration/query-limits.test.ts
+++ b/__tests__/integration/query-limits.test.ts
@@ -5,6 +5,10 @@ const rootClient = getClient();
 const clients = new Array<Client>();
 const limitedDbName = process.env["QUERY_LIMITS_DB"] || "";
 const collectionName = process.env["QUERY_LIMITS_COLL"] || "";
+const maybeDescribe =
+  process.env["QUERY_LIMITS_DB"] && process.env["QUERY_LIMITS_COLL"]
+    ? describe
+    : describe.skip;
 
 beforeAll(async () => {
   // Create Key for test database and create clients with the secret
@@ -33,31 +37,29 @@ afterAll(() => {
   clients.forEach((x) => x.close());
 });
 
-if (process.env["QUERY_LIMITS_DB"] && process.env["QUERY_LIMITS_COLL"]) {
-  describe("Query with limits enabled", () => {
-    it("succeeds on retry after getting throttled", async () => {
-      expect.assertions(1);
+maybeDescribe("Query with limits enabled", () => {
+  it("succeeds on retry after getting throttled", async () => {
+    expect.assertions(1);
 
-      let throttled = false;
-      await Promise.all(
-        clients.map((client) => {
-          // Target DB needs read_ops limit of 100; call .paginate(50) several times
-          // simultaneously to get throttled, all calls should succeed on client retry
-          return client
-            .query(fql`${fql([collectionName])}.all().paginate(50)`)
-            .then((res) => {
-              if (res.stats?.attempts && res.stats.attempts > 1) {
-                throttled = true;
-              }
-            })
-            .catch((err) => {
-              console.log(err);
-              throw err;
-            });
-        })
-      );
+    let throttled = false;
+    await Promise.all(
+      clients.map((client) => {
+        // Target DB needs read_ops limit of 100; call .paginate(50) several times
+        // simultaneously to get throttled, all calls should succeed on client retry
+        return client
+          .query(fql`${fql([collectionName])}.all().paginate(50)`)
+          .then((res) => {
+            if (res.stats?.attempts && res.stats.attempts > 1) {
+              throttled = true;
+            }
+          })
+          .catch((err) => {
+            console.log(err);
+            throw err;
+          });
+      })
+    );
 
-      expect(throttled).toBeTruthy();
-    }, 20000);
-  });
-}
+    expect(throttled).toBeTruthy();
+  }, 20000);
+});

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -42,7 +42,7 @@ groups:
   - name: standard-release
     jobs:
       - set-self
-      - test 
+      - test
       - release
 
 jobs:
@@ -99,6 +99,12 @@ jobs:
                 FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
                 NETLIFY_ACCOUNT: ((drivers-platform-tests/netlify-account))
                 NETLIFY_AUTH_TOKEN: ((drivers-platform-tests/netlify-auth-token))
+
+            - task: query-limits-tests
+              file: fauna-js-repository/concourse/tasks/query-limits-tests.yml
+              params:
+                QUERY_LIMITS_DB: limited
+                QUERY_LIMITS_COLL: limitCollection
 
             # - task: vercel-tests
             #   image: testtools-image

--- a/concourse/scripts/docker-compose-fauna.yml
+++ b/concourse/scripts/docker-compose-fauna.yml
@@ -1,4 +1,9 @@
-version: "3.3"
+version: "3.5"
+
+networks:
+  limit-net:
+    external: true
+    name: limit-net
 
 services:
   faunadb:
@@ -44,3 +49,21 @@ services:
         apk add --no-cache curl
         ./wait-for-it.sh http://faunadb:8443/ping
         yarn test:integration
+
+  query-limits-tests:
+    image: node:20.2-alpine3.16
+    container_name: node-current-limits-test
+    networks:
+      - limit-net
+    volumes:
+      - "../../:/tmp/app"
+    working_dir: "/tmp/app"
+    environment:
+      FAUNA_ENDPOINT: ${FAUNA_ENDPOINT:-http://fauna-limits:8443}
+      QUERY_LIMITS_DB: ${QUERY_LIMITS_DB}
+      QUERY_LIMITS_COLL: ${QUERY_LIMITS_COLL}
+    command:
+      - /bin/sh
+      - -cxe
+      - |
+        yarn test:query-limits

--- a/concourse/tasks/query-limits-tests.yml
+++ b/concourse/tasks/query-limits-tests.yml
@@ -1,0 +1,34 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: shared-concourse-dind
+    aws_access_key_id: ((prod-images-aws-access-key-id))
+    aws_secret_access_key: ((prod-images-aws-secret-key))
+    aws_region: us-east-2
+
+params:
+  FAUNA_ENDPOINT: http://fauna-limits:8443
+  QUERY_LIMITS_DB:
+  QUERY_LIMITS_COLL:
+
+inputs:
+  - name: fauna-js-repository
+  - name: testtools-repo
+
+run:
+  path: entrypoint.sh
+  args:
+    - bash
+    - -ceu
+    - |
+      # setup Fauna container
+      docker-compose -f testtools-repo/fauna-driver-query-limits-tests/concourse/scripts/docker-compose.yml run setup
+      # run tests
+      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna.yml run query-limits-tests
+      # stop and remove containers
+      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna.yml down
+      docker-compose -f testtools-repo/fauna-driver-query-limits-tests/concourse/scripts/docker-compose.yml down
+      # remove volumes
+      docker volume rm $(docker volume ls -q)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "prepare": "husky install",
     "test": "yarn fauna-local; yarn fauna-local-alt-port; ./prepare-test-env.sh; jest",
     "test:ci": "yarn install; jest --ci --reporters=default --reporters=jest-junit",
-    "test:integration": "yarn install; jest --run-in-band ./__tests__/integration"
+    "test:integration": "yarn install; jest --run-in-band ./__tests__/integration",
+    "test:query-limits": "yarn install; jest ./__tests__/integration/query-limits.test.ts"
   },
   "jest-junit": {
     "outputDirectory": "reports",


### PR DESCRIPTION
Ticket(s): BT-4181

## Problem
We don't currently have integration test coverage of the query-limit and throttling behavior.

## Solution
Add a test case that runs against a specially-configured database with query limits and validate that the queries that are throttled succeed on the Client retry logic.

Depends on this PR: https://github.com/fauna/testtools/pull/86

## Result
New test case added and running in pipeline.

## Out of scope

## Testing
Ran the test many times locally; will need to validate in the pipeline that the Concourse collateral is setup correctly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
