### PR TITLE
No need to `docker volume rm` in pipeline

### DIFF
--- a/concourse/tasks/query-limits-tests.yml
+++ b/concourse/tasks/query-limits-tests.yml
@@ -30,5 +30,3 @@ run:
       # stop and remove containers
       docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna.yml down
       docker-compose -f testtools-repo/fauna-driver-query-limits-tests/docker-compose.yml down
-      # remove volumes
-      docker volume rm $(docker volume ls -q)


### PR DESCRIPTION
Volumes are ephemeral in concourse pipeline, so no need to prune/rm them.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
