### PR TITLE
Move query limits tests to separate docker-compose file

### DIFF
--- a/concourse/scripts/docker-compose-fauna-limits.yml
+++ b/concourse/scripts/docker-compose-fauna-limits.yml
@@ -1,0 +1,25 @@
+version: "3.5"
+
+networks:
+  limit-net:
+    external: true
+    name: limit-net
+
+services:
+  query-limits-tests:
+    image: node:20.2-alpine3.16
+    container_name: node-current-limits-test
+    networks:
+      - limit-net
+    volumes:
+      - "../../:/tmp/app"
+    working_dir: "/tmp/app"
+    environment:
+      FAUNA_ENDPOINT: ${FAUNA_ENDPOINT:-http://fauna-limits:8443}
+      QUERY_LIMITS_DB: ${QUERY_LIMITS_DB}
+      QUERY_LIMITS_COLL: ${QUERY_LIMITS_COLL}
+    command:
+      - /bin/sh
+      - -cxe
+      - |
+        yarn test:query-limits

--- a/concourse/scripts/docker-compose-fauna.yml
+++ b/concourse/scripts/docker-compose-fauna.yml
@@ -1,9 +1,4 @@
-version: "3.5"
-
-networks:
-  limit-net:
-    external: true
-    name: limit-net
+version: "3.3"
 
 services:
   faunadb:
@@ -49,21 +44,3 @@ services:
         apk add --no-cache curl
         ./wait-for-it.sh http://faunadb:8443/ping
         yarn test:integration
-
-  query-limits-tests:
-    image: node:20.2-alpine3.16
-    container_name: node-current-limits-test
-    networks:
-      - limit-net
-    volumes:
-      - "../../:/tmp/app"
-    working_dir: "/tmp/app"
-    environment:
-      FAUNA_ENDPOINT: ${FAUNA_ENDPOINT:-http://fauna-limits:8443}
-      QUERY_LIMITS_DB: ${QUERY_LIMITS_DB}
-      QUERY_LIMITS_COLL: ${QUERY_LIMITS_COLL}
-    command:
-      - /bin/sh
-      - -cxe
-      - |
-        yarn test:query-limits

--- a/concourse/tasks/query-limits-tests.yml
+++ b/concourse/tasks/query-limits-tests.yml
@@ -26,7 +26,7 @@ run:
       # setup Fauna container
       docker-compose -f testtools-repo/fauna-driver-query-limits-tests/docker-compose.yml run setup
       # run tests
-      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna.yml run query-limits-tests
+      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna-limits.yml run query-limits-tests
       # stop and remove containers
-      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna.yml down
+      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna-limits.yml down
       docker-compose -f testtools-repo/fauna-driver-query-limits-tests/docker-compose.yml down


### PR DESCRIPTION
Ticket(s): FE-###

## Problem
Integ-tests are blocked by changes to docker-compose-fauna.yml

## Solution
Split the new test into its own docker-compose

## Result
No more blocking of integ-tests

## Out of scope

## Testing

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
