### PR TITLE
Fix setting args to undefined adding them to headers

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -153,6 +153,31 @@ describe("query", () => {
     }
   );
 
+  it(
+    "respects typechecked: undefined", async () => {
+      const httpClient: HTTPClient = {
+        async request(req) {
+          const contains = new Set(Object.keys(req.headers)).has("x-typecheck");
+          expect(contains).toBe(false);
+          return dummyResponse;
+        },
+        close() {},
+      };
+
+      let clientConfiguration: Partial<ClientConfiguration> = {
+        typecheck: true,
+      };
+      let myClient = getClient(clientConfiguration, httpClient);
+      await myClient.query<number>(fql`"taco".length`, { typecheck: undefined });
+      myClient.close();
+
+      clientConfiguration = { typecheck: undefined };
+      myClient = getClient(clientConfiguration, httpClient);
+      await myClient.query<number>(fql`"taco".length`);
+      myClient.close();
+    }
+  );
+
   it("can send arguments directly", async () => {
     const foo = {
       double: 4.14,

--- a/src/client.ts
+++ b/src/client.ts
@@ -519,6 +519,10 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
           "query_tags",
         ].includes(entry[0])
       ) {
+        if (entry[1] === undefined) {
+          continue;
+        }
+
         let headerValue: string;
         let headerKey = `x-${entry[0].replaceAll("_", "-")}`;
         if ("query_tags" === entry[0]) {


### PR DESCRIPTION
Ticket(s): FE-4675

Setting args to `undefined` serializes them, causing the database to complain about the string `undefined` in a header.
