### PR TITLE
Initial Streaming Implementation

### DIFF
--- a/.github/workflows/pr_validate.yml
+++ b/.github/workflows/pr_validate.yml
@@ -11,6 +11,8 @@ jobs:
         image: fauna/faunadb:latest
         ports:
           - 8443:8443
+        volumes:
+          - ${{ github.workspace }}/docker/feature-flags.json:/etc/feature-flag-periodic.d/feature-flags.js
       alt_core:
         image: fauna/faunadb:latest
         ports:

--- a/.github/workflows/pr_validate.yml
+++ b/.github/workflows/pr_validate.yml
@@ -12,7 +12,7 @@ jobs:
         ports:
           - 8443:8443
         volumes:
-          - ${{ github.workspace }}/docker/feature-flags.json:/etc/feature-flag-periodic.d/feature-flags.js
+          - ./docker/feature-flags.json:/etc/feature-flag-periodic.d/feature-flags.js
       alt_core:
         image: fauna/faunadb:latest
         ports:

--- a/.github/workflows/pr_validate.yml
+++ b/.github/workflows/pr_validate.yml
@@ -11,8 +11,6 @@ jobs:
         image: fauna/faunadb:latest
         ports:
           - 8443:8443
-        volumes:
-          - ./docker/feature-flags.json:/etc/feature-flag-periodic.d/feature-flags.js
       alt_core:
         image: fauna/faunadb:latest
         ports:

--- a/__tests__/functional/stream-client-configuration.test.ts
+++ b/__tests__/functional/stream-client-configuration.test.ts
@@ -1,0 +1,71 @@
+import {
+  StreamClient,
+  StreamToken,
+  getDefaultHTTPClient,
+  StreamClientConfiguration,
+} from "../../src";
+import { getDefaultHTTPClientOptions } from "../client";
+
+const defaultHttpClient = getDefaultHTTPClient(getDefaultHTTPClientOptions());
+const defaultConfig: StreamClientConfiguration = {
+  secret: "secret",
+  long_type: "number",
+  max_attempts: 3,
+  max_backoff: 20,
+  httpStreamClient: defaultHttpClient,
+};
+const dummyStreamToken = new StreamToken("dummy");
+
+describe("StreamClientConfiguration", () => {
+  it("can be instantiated directly with a token", () => {
+    new StreamClient(dummyStreamToken, defaultConfig);
+  });
+
+  it("can be instantiated directly with a lambda", async () => {
+    new StreamClient(() => Promise.resolve(dummyStreamToken), defaultConfig);
+  });
+
+  it.each`
+    fieldName
+    ${"long_type"}
+    ${"httpStreamClient"}
+    ${"max_backoff"}
+    ${"max_attempts"}
+    ${"secret"}
+  `(
+    "throws a TypeError if $fieldName provided is undefined",
+    async ({ fieldName }: { fieldName: keyof StreamClientConfiguration }) => {
+      expect.assertions(1);
+
+      const config = { ...defaultConfig };
+      delete config[fieldName];
+      try {
+        new StreamClient(dummyStreamToken, config);
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(TypeError);
+      }
+    }
+  );
+
+  it("throws a RangeError if 'max_backoff' is less than or equal to zero", async () => {
+    expect.assertions(1);
+
+    const config = { ...defaultConfig, max_backoff: 0 };
+    try {
+      new StreamClient(dummyStreamToken, config);
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(RangeError);
+    }
+  });
+
+  it("throws a RangeError if 'max_attempts' is less than or equal to zero", async () => {
+    expect.assertions(1);
+
+    const config = { ...defaultConfig, max_attempts: 0 };
+    try {
+      new StreamClient(dummyStreamToken, config);
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(RangeError);
+    }
+  });
+});

--- a/__tests__/integration/set.test.ts
+++ b/__tests__/integration/set.test.ts
@@ -36,10 +36,10 @@ describe("SetIterator", () => {
   beforeAll(async () => {
     await client.query(fql`
       if (Collection.byName("IterTestSmall") != null) {
-        IterTestSmall.definition.delete()
+        Collection.byName("IterTestSmall")!.delete()
       }
       if (Collection.byName("IterTestBig") != null) {
-        IterTestBig.definition.delete()
+        Collection.byName("IterTestBig")!.delete()
       }
     `);
     await client.query(fql`

--- a/__tests__/integration/stream.test.ts
+++ b/__tests__/integration/stream.test.ts
@@ -1,0 +1,381 @@
+import {
+  fql,
+  getDefaultHTTPClient,
+  StreamClient,
+  StreamClientConfiguration,
+  StreamToken,
+  Client,
+  DocumentT,
+  ServiceError,
+  TimeStub,
+  DateStub,
+  Document,
+} from "../../src";
+import {
+  getClient,
+  getDefaultHTTPClientOptions,
+  getDefaultSecretAndEndpoint,
+} from "../client";
+
+const defaultHttpClient = getDefaultHTTPClient(getDefaultHTTPClientOptions());
+const { secret } = getDefaultSecretAndEndpoint();
+const dummyStreamToken = new StreamToken("dummy");
+
+let client: Client;
+const STREAM_DB_NAME = "StreamTestDB";
+const STREAM_SECRET = `${secret}:${STREAM_DB_NAME}:admin`;
+const defaultStreamConfig: StreamClientConfiguration = {
+  secret: STREAM_SECRET,
+  long_type: "number",
+  max_attempts: 3,
+  max_backoff: 20,
+  httpStreamClient: defaultHttpClient,
+};
+
+type StreamTest = { value: number };
+
+beforeAll(async () => {
+  const rootClient = getClient();
+
+  // create a child database to use for Streams, since streaming FF will not
+  // work on the root database
+  await rootClient.query(fql`
+    if (Database.byName(${STREAM_DB_NAME}) == null) {
+      Database.create({ name: ${STREAM_DB_NAME} })
+    }
+  `);
+
+  // scope the client to the child db
+  client = getClient({ secret: STREAM_SECRET });
+
+  await client.query(fql`
+    if (Collection.byName("StreamTest") != null) {
+      Collection.byName("StreamTest")!.delete()
+    }
+    `);
+  await client.query(fql`
+    Collection.create({ name: "StreamTest" })
+    `);
+});
+
+afterAll(() => {
+  if (client) {
+    client.close();
+  }
+});
+
+describe("Client", () => {
+  it("can initiate a stream from a Client", async () => {
+    expect.assertions(1);
+
+    let stream: StreamClient | null = null;
+    try {
+      const response = await client.query<StreamToken>(
+        fql`StreamTest.all().toStream()`
+      );
+      const token = response.data;
+
+      stream = client.stream(token, { status_events: true });
+
+      for await (const event of stream) {
+        expect(event.type).toEqual("status");
+        break;
+      }
+    } finally {
+      stream?.close();
+    }
+  });
+
+  it("can initiate a stream from a Client, providing a query", async () => {
+    expect.assertions(1);
+
+    let stream: StreamClient | null = null;
+    try {
+      stream = client.stream(fql`StreamTest.all().toStream()`, {
+        status_events: true,
+      });
+
+      for await (const event of stream) {
+        expect(event.type).toEqual("status");
+        break;
+      }
+    } finally {
+      stream?.close();
+    }
+  });
+});
+
+describe("StreamClient", () => {
+  it("can initiate a stream", async () => {
+    expect.assertions(1);
+
+    let stream: StreamClient | null = null;
+    try {
+      const response = await client.query<StreamToken>(
+        fql`StreamTest.all().toStream()`
+      );
+      const token = response.data;
+
+      stream = new StreamClient(token, {
+        ...defaultStreamConfig,
+        status_events: true,
+      });
+
+      for await (const event of stream) {
+        expect(event.type).toEqual("status");
+        break;
+      }
+    } finally {
+      stream?.close();
+    }
+  });
+
+  it("can initiate a stream with a lambda", async () => {
+    expect.assertions(1);
+
+    let stream: StreamClient | null = null;
+    try {
+      const getToken = async () => {
+        const response = await client.query<StreamToken>(
+          fql`StreamTest.all().toStream()`
+        );
+        return response.data;
+      };
+
+      stream = new StreamClient(getToken, {
+        ...defaultStreamConfig,
+        status_events: true,
+      });
+
+      for await (const event of stream) {
+        expect(event.type).toEqual("status");
+        break;
+      }
+    } finally {
+      stream?.close();
+    }
+  });
+
+  it("can get events with async iterator", async () => {
+    expect.assertions(2);
+
+    let stream: StreamClient<DocumentT<StreamTest>> | null = null;
+    try {
+      const response = await client.query<StreamToken>(
+        fql`StreamTest.all().toStream()`
+      );
+      const token = response.data;
+
+      stream = new StreamClient(token, defaultStreamConfig);
+
+      // create some events that will be played back
+      await client.query(fql`StreamTest.create({ value: 0 })`);
+      await client.query(fql`StreamTest.create({ value: 1 })`);
+
+      let count = 0;
+      for await (const event of stream) {
+        if (event.type == "add") {
+          if (count === 0) {
+            expect(event.data.value).toEqual(0);
+          } else {
+            expect(event.data.value).toEqual(1);
+            break;
+          }
+        }
+        count++;
+      }
+    } finally {
+      stream?.close();
+    }
+  });
+
+  it("can get events with callbacks", async () => {
+    expect.assertions(2);
+
+    const response = await client.query<StreamToken>(
+      fql`StreamTest.all().toStream()`
+    );
+    const token = response.data;
+
+    const stream = new StreamClient<DocumentT<StreamTest>>(
+      token,
+      defaultStreamConfig
+    );
+
+    // create some events that will be played back
+    await client.query(fql`StreamTest.create({ value: 0 })`);
+    await client.query(fql`StreamTest.create({ value: 1 })`);
+
+    let resolve: () => void;
+    const promise = new Promise((res) => {
+      resolve = () => res(null);
+    });
+
+    let count = 0;
+    stream.start(function onEvent(event) {
+      if (event.type == "add") {
+        if (count === 0) {
+          expect(event.data.value).toEqual(0);
+        } else {
+          expect(event.data.value).toEqual(1);
+          stream.close();
+          resolve();
+        }
+      }
+      count++;
+    });
+
+    await promise;
+  });
+
+  it("catches non 200 responses when establishing a stream", async () => {
+    expect.assertions(1);
+
+    try {
+      // create a stream with a bad token
+      const stream = new StreamClient(
+        new StreamToken("2"),
+        defaultStreamConfig
+      );
+
+      for await (const _ of stream) {
+        /* do nothing */
+      }
+    } catch (e) {
+      // TODO: be more specific about the error and split into multiple tests
+      expect(e).toBeInstanceOf(ServiceError);
+    }
+  });
+
+  it("handles non 200 responses via callback when establishing a stream", async () => {
+    expect.assertions(1);
+
+    // create a stream with a bad token
+    const stream = new StreamClient(new StreamToken("2"), defaultStreamConfig);
+
+    let resolve: () => void;
+    const promise = new Promise((res) => {
+      resolve = () => res(null);
+    });
+
+    stream.start(
+      function onEvent(_) {},
+      function onError(e) {
+        // TODO: be more specific about the error and split into multiple tests
+        expect(e).toBeInstanceOf(ServiceError);
+        resolve();
+      }
+    );
+
+    await promise;
+  });
+
+  it("catches a ServiceError if an error event is received", async () => {
+    expect.assertions(1);
+
+    let stream: StreamClient<DocumentT<StreamTest>> | null = null;
+    try {
+      const response = await client.query<StreamToken>(
+        fql`StreamTest.all().map((doc) => abort("oops")).toStream()`
+      );
+      const token = response.data;
+
+      stream = new StreamClient(token, defaultStreamConfig);
+
+      // create some events that will be played back
+      await client.query(fql`StreamTest.create({ value: 0 })`);
+
+      for await (const _ of stream) {
+        /* do nothing */
+      }
+    } catch (e) {
+      // TODO: be more specific about the error and split into multiple tests
+      expect(e).toBeInstanceOf(ServiceError);
+    } finally {
+      stream?.close();
+    }
+  });
+
+  it("handles a ServiceError via callback if an error event is received", async () => {
+    expect.assertions(1);
+
+    const response = await client.query<StreamToken>(
+      fql`StreamTest.all().map((doc) => abort("oops")).toStream()`
+    );
+    const token = response.data;
+
+    const stream = new StreamClient<DocumentT<StreamTest>>(
+      token,
+      defaultStreamConfig
+    );
+
+    // create some events that will be played back
+    await client.query(fql`StreamTest.create({ value: 0 })`);
+
+    let resolve: () => void;
+    const promise = new Promise((res) => {
+      resolve = () => res(null);
+    });
+
+    stream.start(
+      function onEvent(_) {},
+      function onError(e) {
+        // TODO: be more specific about the error and split into multiple tests
+        expect(e).toBeInstanceOf(ServiceError);
+        resolve();
+      }
+    );
+
+    await promise;
+  });
+
+  it("decodes values from streams correctly", async () => {
+    expect.assertions(5);
+
+    let stream: StreamClient | null = null;
+    let stream2: StreamClient | null = null;
+    try {
+      const response = await client.query<StreamToken>(
+        fql`StreamTest.all().map((doc) => {
+          time: Time.now(),
+          date: Date.today(),
+          doc: doc,
+          bigInt: 922337036854775808,
+        }).toStream()`
+      );
+      const token = response.data;
+
+      stream = new StreamClient(token, defaultStreamConfig);
+
+      // create some events that will be played back
+      await client.query(fql`StreamTest.create({ value: 0 })`);
+
+      for await (const event of stream) {
+        if (event.type == "add") {
+          const data = event.data;
+          expect(data.time).toBeInstanceOf(TimeStub);
+          expect(data.date).toBeInstanceOf(DateStub);
+          expect(data.doc).toBeInstanceOf(Document);
+          expect(typeof data.bigInt).toBe("number");
+        }
+        break;
+      }
+
+      stream2 = new StreamClient(token, {
+        ...defaultStreamConfig,
+        long_type: "bigint",
+      });
+
+      for await (const event of stream2) {
+        if (event.type == "add") {
+          const data = event.data;
+          expect(typeof data.bigInt).toBe("bigint");
+        }
+        break;
+      }
+    } finally {
+      stream?.close();
+      stream2?.close();
+    }
+  });
+});

--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -13,12 +13,22 @@ resources:
     source:
       url: ((slack-webhook))
 
-  - name: fauna-js-repository
+  - name: main.git
     type: git
     icon: github
     source:
       uri: git@github.com:fauna/fauna-js.git
       branch: main
+      tag_filter: v*
+      private_key: ((github-ssh-key))
+      
+  - name: beta.git
+    type: git
+    icon: github
+    source:
+      uri: git@github.com:fauna/fauna-js.git
+      branch: beta
+      tag_filter: v*
       private_key: ((github-ssh-key))
 
   - name: testtools-repo
@@ -39,26 +49,36 @@ resources:
       aws_region: us-east-2
 
 groups:
-  - name: standard-release
+  - name: pipeline
     jobs:
       - set-self
       - test
       - release
+      - test-beta
+      - release-beta
+  - name: standard-release
+    jobs:
+      - test
+      - release
+  - name: beta-release
+    jobs:
+      - test-beta
+      - release-beta
 
 jobs:
   - name: set-self
     serial: true
     plan:
-      - get: fauna-js-repository
+      - get: beta.git
+      - get: main.git
         trigger: true
       - set_pipeline: self
-        file: fauna-js-repository/concourse/pipeline.yml
+        file: main.git/concourse/pipeline.yml
 
   - name: test
     serial: true
     plan:
-      - get: fauna-js-repository
-        trigger: true
+      - get: main.git
         passed:
           - set-self
 
@@ -67,7 +87,7 @@ jobs:
 
       - load_var: git-commit
         reveal: true
-        file: fauna-js-repository/.git/ref
+        file: main.git/.git/ref
 
       - in_parallel:
           fail_fast: false
@@ -102,7 +122,8 @@ jobs:
 
             - task: query-limits-tests
               privileged: true
-              file: fauna-js-repository/concourse/tasks/query-limits-tests.yml
+              file: main.git/concourse/tasks/query-limits-tests.yml
+              input_mapping: {repo.git: main.git, testtools-repo: testtools-repo}
               params:
                 QUERY_LIMITS_DB: limited
                 QUERY_LIMITS_COLL: limitCollection
@@ -119,12 +140,13 @@ jobs:
     serial: true
     public: false
     plan:
-      - get: fauna-js-repository
+      - get: main.git
         passed:
           - test
 
       - task: integration-tests
-        file: fauna-js-repository/concourse/tasks/integration-tests.yml
+        file: main.git/concourse/tasks/integration-tests.yml
+        input_mapping: {repo.git: main.git}
         privileged: true
         on_success:
           put: notify
@@ -136,9 +158,107 @@ jobs:
             text: fauna-js driver release failed integration tests
 
       - task: publish
-        file: fauna-js-repository/concourse/tasks/npm-publish.yml
+        file: main.git/concourse/tasks/npm-publish.yml
+        input_mapping: {repo.git: main.git}
         params:
           NPM_TOKEN: ((npm_token))
+        on_success:
+          put: notify
+          params:
+            text_file: slack-message/publish
+        on_failure:
+          put: notify
+          params:
+            text_file: slack-message/publish
+
+  - name: test-beta
+    serial: true
+    plan:
+      - get: beta.git
+        passed:
+          - set-self
+
+      - get: testtools-repo
+      - get: testtools-image
+
+      - load_var: git-commit
+        reveal: true
+        file: beta.git/.git/ref
+
+      - in_parallel:
+          fail_fast: false
+          steps:
+            - task: aws-lambda-tests
+              image: testtools-image
+              file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/js-aws-lambda-tests.yml
+              params:
+                GIT_COMMIT: ((.:git-commit))
+                FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
+                AWS_LAMBDA_ROLE_ARN: ((drivers-platform-tests/aws-lambda-role-arn))
+                AWS_ACCESS_KEY_ID: ((drivers-platform-tests/aws-access-key-id))
+                AWS_SECRET_ACCESS_KEY: ((drivers-platform-tests/aws-secret-key))
+
+            - task: cloudflare-tests
+              image: testtools-image
+              file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/js-cloudflare-workers-tests.yml
+              params:
+                GIT_COMMIT: ((.:git-commit))
+                CLOUDFLARE_API_TOKEN: ((drivers-platform-tests/cloudflare-api-token))
+                FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
+                VERCEL_TOKEN: ((drivers-platform-tests/vercel-token))
+
+            - task: netlify-tests
+              image: testtools-image
+              file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/js-netlify-tests.yml
+              params:
+                GIT_COMMIT: ((.:git-commit))
+                FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
+                NETLIFY_ACCOUNT: ((drivers-platform-tests/netlify-account))
+                NETLIFY_AUTH_TOKEN: ((drivers-platform-tests/netlify-auth-token))
+
+            - task: query-limits-tests
+              privileged: true
+              file: main.git/concourse/tasks/query-limits-tests.yml
+              input_mapping: {repo.git: beta.git, testtools-repo: testtools-repo}
+              params:
+                QUERY_LIMITS_DB: limited
+                QUERY_LIMITS_COLL: limitCollection
+
+            # - task: vercel-tests
+            #   image: testtools-image
+            #   file: testtools-repo/fauna-driver-platform-tests/concourse/tasks/js-vercel-tests.yml
+            #   params:
+            #     GIT_COMMIT: ((.:git-commit))
+            #     FAUNA_SECRET: ((drivers-platform-tests/fauna-secret))
+            #     VERCEL_TOKEN: ((drivers-platform-tests/vercel-token))
+
+  - name: release-beta
+    serial: true
+    public: false
+    plan:
+      - get: beta.git
+        passed:
+          - test-beta
+
+      - task: integration-tests
+        file: main.git/concourse/tasks/integration-tests.yml
+        input_mapping: {repo.git: beta.git}
+        privileged: true
+        on_success:
+          put: notify
+          params:
+            text: "fauna-js driver release passed integration tests"
+        on_failure:
+          put: notify
+          params:
+            text: fauna-js driver release failed integration tests
+
+      - task: publish
+        file: main.git/concourse/tasks/npm-publish.yml
+        input_mapping: {repo.git: beta.git}
+        params:
+          NPM_TOKEN: ((npm_token))
+          NPM_TAG: beta
         on_success:
           put: notify
           params:

--- a/concourse/scripts/publish.sh
+++ b/concourse/scripts/publish.sh
@@ -15,7 +15,12 @@ then
 
   echo "Publishing a new version..."
   echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-  npm publish
+  if [[ -z "$NPM_TAG" ]]; then
+    npm publish --tag $NPM_TAG
+  else
+    npm publish
+  fi
+
   rm .npmrc
 
   echo "fauna-js@$PACKAGE_VERSION published to npm <!subteam^S0562QFL21M>" > ../slack-message/publish

--- a/concourse/tasks/integration-tests.yml
+++ b/concourse/tasks/integration-tests.yml
@@ -15,7 +15,7 @@ params:
   FAUNA_PORT:
 
 inputs:
-  - name: fauna-js-repository
+  - name: repo.git
 
 run:
   path: entrypoint.sh
@@ -24,9 +24,9 @@ run:
     - -ceu
     - |
       # start containers
-      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna.yml run node-lts
-      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna.yml run node-current
+      docker-compose -f repo.git/concourse/scripts/docker-compose-fauna.yml run node-lts
+      docker-compose -f repo.git/concourse/scripts/docker-compose-fauna.yml run node-current
       # stop and remove containers
-      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna.yml down
+      docker-compose -f repo.git/concourse/scripts/docker-compose-fauna.yml down
       # remove volumes
       docker volume rm $(docker volume ls -q)

--- a/concourse/tasks/npm-publish.yml
+++ b/concourse/tasks/npm-publish.yml
@@ -9,12 +9,13 @@ image_resource:
 
 params:
   NPM_TOKEN:
+  NPM_TAG:
 
 inputs:
-  - name: fauna-js-repository
+  - name: repo.git
 
 outputs:
   - name: slack-message
 
 run:
-  path: ./fauna-js-repository/concourse/scripts/publish.sh
+  path: ./repo.git/concourse/scripts/publish.sh

--- a/concourse/tasks/query-limits-tests.yml
+++ b/concourse/tasks/query-limits-tests.yml
@@ -14,7 +14,7 @@ params:
   QUERY_LIMITS_COLL:
 
 inputs:
-  - name: fauna-js-repository
+  - name: repo.git
   - name: testtools-repo
 
 run:
@@ -26,7 +26,7 @@ run:
       # setup Fauna container
       docker-compose -f testtools-repo/fauna-driver-query-limits-tests/docker-compose.yml run setup
       # run tests
-      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna-limits.yml run query-limits-tests
+      docker-compose -f repo.git/concourse/scripts/docker-compose-fauna-limits.yml run query-limits-tests
       # stop and remove containers
-      docker-compose -f fauna-js-repository/concourse/scripts/docker-compose-fauna-limits.yml down
+      docker-compose -f repo.git/concourse/scripts/docker-compose-fauna-limits.yml down
       docker-compose -f testtools-repo/fauna-driver-query-limits-tests/docker-compose.yml down

--- a/docker/feature-flags.json
+++ b/docker/feature-flags.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "properties": [
+    {
+      "property_name": "cluster_name",
+      "property_value": "fauna",
+      "flags": {
+        "fql2_schema": true,
+        "fqlx_typecheck_default": true,
+        "persisted_fields": true,
+        "changes_by_collection_index": true,
+        "fql2_streams": true
+      }
+    },
+    {
+      "property_name": "account_id",
+      "property_value": 0,
+      "flags": {
+        "fql2_schema": true,
+        "fqlx_typecheck_default": true,
+        "persisted_fields": true,
+        "changes_by_collection_index": true,
+        "fql2_streams": true
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build:node": "esbuild src/index.ts --bundle --sourcemap --platform=node --outfile=dist/node/index.js",
     "build:types": "tsc -emitDeclarationOnly --declaration true",
     "lint": "eslint -f unix \"src/**/*.{ts,tsx}\"",
-    "fauna-local": "docker start faunadb-local || docker run --rm -d --name faunadb-local -p 8443:8443 -p 8084:8084 fauna/faunadb",
+    "fauna-local": "docker start faunadb-local || docker run --rm -d --name faunadb-local -p 8443:8443 -p 8084:8084 --mount type=bind,source=\"$(pwd)\"/docker/feature-flags.json,target=/etc/feature-flag-periodic.d/feature-flags.json fauna/faunadb",
     "fauna-local-alt-port": "docker start faunadb-local-alt-port || docker run --rm -d --name faunadb-local-alt-port -p 7443:8443 -p 7084:8084 fauna/faunadb",
     "prepare": "husky install",
     "test": "yarn fauna-local; yarn fauna-local-alt-port; ./prepare-test-env.sh; jest",

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -156,6 +156,24 @@ export interface Endpoints {
 }
 
 /**
+ * Configuration for a streaming client. This typically comes from the `Client`
+ * instance configuration.
+ */
+export type StreamClientConfiguration = {
+  /**
+   * A secret for your Fauna DB, used to authorize your queries.
+   * @see https://docs.fauna.com/fauna/current/security/keys
+   */
+  secret: string;
+
+  /**
+   * Controls what Javascript type to deserialize {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#long | Fauna longs} to.
+   * @see {@link ClientConfiguration.long_type}
+   */
+  long_type: "number" | "bigint";
+};
+
+/**
  * A extensible set of endpoints for calling Fauna.
  * @remarks Most clients will will not need to extend this set.
  * @example

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -171,6 +171,24 @@ export type StreamClientConfiguration = {
    * @see {@link ClientConfiguration.long_type}
    */
   long_type: "number" | "bigint";
+
+  /**
+   * Max attempts for retryable exceptions.
+   */
+  max_attempts: number;
+
+  /**
+   * Max backoff between retries.
+   */
+  max_backoff: number;
+
+  /**
+   * Indicates if stream should include "status" events, periodic events that
+   * update the client with the latest valid timestamp (in the event of a
+   * dropped connection) as well as metrics about about the cost of maintaining
+   * the stream other than the cost of the received events.
+   */
+  status_events?: boolean;
 };
 
 /**

--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -1,3 +1,4 @@
+import { HTTPStreamClient } from "./http-client";
 import type { ValueFormat } from "./wire-protocol";
 
 /**
@@ -161,10 +162,9 @@ export interface Endpoints {
  */
 export type StreamClientConfiguration = {
   /**
-   * A secret for your Fauna DB, used to authorize your queries.
-   * @see https://docs.fauna.com/fauna/current/security/keys
+   * The underlying {@link HTTPStreamClient} that will execute the actual HTTP calls
    */
-  secret: string;
+  httpStreamClient: HTTPStreamClient;
 
   /**
    * Controls what Javascript type to deserialize {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#long | Fauna longs} to.
@@ -181,6 +181,12 @@ export type StreamClientConfiguration = {
    * Max backoff between retries.
    */
   max_backoff: number;
+
+  /**
+   * A secret for your Fauna DB, used to authorize your queries.
+   * @see https://docs.fauna.com/fauna/current/security/keys
+   */
+  secret: string;
 
   /**
    * Indicates if stream should include "status" events, periodic events that

--- a/src/client.ts
+++ b/src/client.ts
@@ -719,6 +719,10 @@ export class StreamClient {
     this.closed = true;
   }
 
+  get last_ts(): number | undefined {
+    return this.#last_ts;
+  }
+
   async *#startStream(start_ts?: number): AsyncGenerator<StreamEventData> {
     // Safety: This method must only be called after a stream token has been acquired
     const streamToken = this.#streamToken as StreamToken;
@@ -748,9 +752,9 @@ export class StreamClient {
         throw new ServiceError(deserializedEvent, 400);
       }
 
-      this.#last_ts = deserializedEvent.ts;
+      this.#last_ts = deserializedEvent.txn_ts;
 
-      if (deserializedEvent.type !== "start") {
+      if (deserializedEvent.type !== "status") {
         yield deserializedEvent;
       }
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -655,7 +655,12 @@ export class StreamClient {
     return this;
   }
 
-  start(onFatalError: (error: Error) => void) {
+  start(onFatalError?: (error: Error) => void) {
+    if (onFatalError && typeof onFatalError !== "function") {
+      throw new TypeError(
+        `Expected a function as the 'onFatalError' argument, but received ${typeof onFatalError}. Please provide a valid function.`
+      );
+    }
     const run = async () => {
       try {
         for await (const event of this) {
@@ -665,8 +670,8 @@ export class StreamClient {
           }
         }
       } catch (error) {
-        if (error instanceof Error) {
-          onFatalError(error);
+        if (onFatalError) {
+          onFatalError(error as Error);
         }
       }
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -677,7 +677,6 @@ export class StreamClient {
     }
 
     if (!this.#streamToken) {
-      // TODO: Should we retry any errors when trying to get the token?
       this.#streamToken = await this.#query();
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,7 +29,7 @@ import {
   isHTTPResponse,
   type HTTPClient,
 } from "./http-client";
-import { Query, fql } from "./query-builder";
+import { Query } from "./query-builder";
 import { TaggedTypeFormat } from "./tagged-type";
 import { getDriverEnv } from "./util/environment";
 import { EmbeddedSet, Page, SetIterator, StreamToken } from "./values";

--- a/src/client.ts
+++ b/src/client.ts
@@ -637,7 +637,7 @@ export class StreamClient {
     };
 
     const streamAdapter = this.#httpStreamClient.stream({
-      data: this.#query.token,
+      data: { token: this.#query.token },
       headers,
       method: "POST",
     });
@@ -667,7 +667,7 @@ export class StreamClient {
     };
 
     const streamAdapter = this.#httpStreamClient.stream({
-      data: this.#query.token,
+      data: { token: this.#query.token },
       headers,
       method: "POST",
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -678,7 +678,7 @@ export class StreamClient {
     });
   }
 
-  async *iter(): AsyncGenerator<StreamEvent> {
+  async *[Symbol.asyncIterator](): AsyncGenerator<StreamEvent> {
     const headers = {
       Authorization: `Bearer ${this.#clientConfiguration.secret}`,
     };

--- a/src/client.ts
+++ b/src/client.ts
@@ -650,9 +650,12 @@ export class StreamClient {
         const deserializedEvent: StreamEvent = TaggedTypeFormat.decode(event, {
           long_type: this.#clientConfiguration.long_type,
         });
-        this.#callbacks[deserializedEvent.type].forEach((callback) =>
-          callback(deserializedEvent)
-        );
+        const callbacks = this.#callbacks[deserializedEvent.type];
+        if (callbacks) {
+          this.#callbacks[deserializedEvent.type].forEach((callback) =>
+            callback(deserializedEvent)
+          );
+        }
       }
     };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -760,14 +760,8 @@ export class StreamClient {
       if (deserializedEvent.type === "error") {
         // Errors sent from Fauna are assumed fatal
         this.close();
-        yield deserializedEvent;
         throw StreamError.fromStreamEventError(deserializedEvent);
       }
-
-      // TODO: handle callbacks when using the async generator?
-      // this.#callbacks[deserializedEvent.type].forEach((callback) =>
-      //   callback(deserializedEvent)
-      // );
 
       this.#last_ts = deserializedEvent.ts;
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -624,13 +624,6 @@ export type StreamEventHandler = (event: StreamEvent) => void;
 
 export class StreamClient {
   closed = false;
-  #callbacks: Record<StreamEventType, StreamEventHandler[]> = {
-    start: [],
-    add: [],
-    remove: [],
-    update: [],
-    error: [],
-  };
   #query: () => Promise<StreamToken>;
   #clientConfiguration: Record<string, any>;
   #httpStreamClient: HTTPStreamClient;
@@ -650,12 +643,15 @@ export class StreamClient {
     this.#httpStreamClient = httpStreamClient;
   }
 
-  on(type: StreamEventType, callback: StreamEventHandler) {
-    this.#callbacks[type].push(callback);
-    return this;
-  }
-
-  start(onFatalError?: (error: Error) => void) {
+  start(
+    onEvent: StreamEventHandler,
+    onFatalError: (error: Error) => void
+  ): StreamClient {
+    if (typeof onEvent !== "function") {
+      throw new TypeError(
+        `Expected a function as the 'onEvent' argument, but received ${typeof onEvent}. Please provide a valid function.`
+      );
+    }
     if (onFatalError && typeof onFatalError !== "function") {
       throw new TypeError(
         `Expected a function as the 'onFatalError' argument, but received ${typeof onFatalError}. Please provide a valid function.`
@@ -664,10 +660,7 @@ export class StreamClient {
     const run = async () => {
       try {
         for await (const event of this) {
-          const callbacks = this.#callbacks[event.type];
-          if (callbacks) {
-            this.#callbacks[event.type].forEach((callback) => callback(event));
-          }
+          onEvent(event);
         }
       } catch (error) {
         if (onFatalError) {
@@ -676,6 +669,7 @@ export class StreamClient {
       }
     };
     run();
+    return this;
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<StreamEvent> {

--- a/src/client.ts
+++ b/src/client.ts
@@ -39,7 +39,6 @@ import {
   isQuerySuccess,
   QueryInterpolation,
   StreamEvent,
-  StreamEventType,
   type QueryFailure,
   type QueryOptions,
   type QuerySuccess,
@@ -708,13 +707,6 @@ export class StreamClient {
           throw error;
         }
 
-        yield {
-          type: "error",
-          code: "network error",
-          message: error.message,
-          cause: error,
-        };
-
         this.#connectionAttempts += 1;
         await wait(backoffMs);
       }
@@ -754,12 +746,15 @@ export class StreamClient {
       if (deserializedEvent.type === "error") {
         // Errors sent from Fauna are assumed fatal
         this.close();
+        // TODO: replace with appropriate class from existing error heirarchy
         throw StreamError.fromStreamEventError(deserializedEvent);
       }
 
       this.#last_ts = deserializedEvent.ts;
 
-      yield deserializedEvent;
+      if (deserializedEvent.type !== "start") {
+        yield deserializedEvent;
+      }
     }
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -327,9 +327,9 @@ export class StreamError extends FaunaError {
   /**
    * Details about the query sent along with the response
    */
-  readonly stats: QueryStats;
+  readonly stats?: QueryStats;
 
-  constructor(message: string, code: string, stats: QueryStats) {
+  constructor(message: string, code: string, stats?: QueryStats) {
     super(message);
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,9 +2,7 @@ import type {
   ConstraintFailure,
   QueryFailure,
   QueryInfo,
-  QueryStats,
   QueryValue,
-  StreamEventError,
 } from "./wire-protocol";
 
 /**

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,7 +2,9 @@ import type {
   ConstraintFailure,
   QueryFailure,
   QueryInfo,
+  QueryStats,
   QueryValue,
+  StreamEventError,
 } from "./wire-protocol";
 
 /**
@@ -310,5 +312,37 @@ export class ProtocolError extends FaunaError {
 
     this.name = "ProtocolError";
     this.httpStatus = error.httpStatus;
+  }
+}
+
+/**
+ * An error representing a failure in a stream
+ */
+export class StreamError extends FaunaError {
+  /**
+   * Error code
+   */
+  readonly code: string;
+
+  /**
+   * Details about the query sent along with the response
+   */
+  readonly stats: QueryStats;
+
+  constructor(message: string, code: string, stats: QueryStats) {
+    super(message);
+
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, StreamError);
+    }
+
+    this.name = "StreamError";
+    this.code = code;
+    this.stats = stats;
+  }
+
+  static fromStreamEventError(event: StreamEventError) {
+    return new StreamError(event.message, event.code, event.stats);
   }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -314,35 +314,3 @@ export class ProtocolError extends FaunaError {
     this.httpStatus = error.httpStatus;
   }
 }
-
-/**
- * An error representing a failure in a stream
- */
-export class StreamError extends FaunaError {
-  /**
-   * Error code
-   */
-  readonly code: string;
-
-  /**
-   * Details about the query sent along with the response
-   */
-  readonly stats?: QueryStats;
-
-  constructor(message: string, code: string, stats?: QueryStats) {
-    super(message);
-
-    // Maintains proper stack trace for where our error was thrown (only available on V8)
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, StreamError);
-    }
-
-    this.name = "StreamError";
-    this.code = code;
-    this.stats = stats;
-  }
-
-  static fromStreamEventError(event: StreamEventError) {
-    return new StreamError(event.message, event.code, event.stats);
-  }
-}

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -104,7 +104,7 @@ export class FetchClient implements HTTPClient, HTTPStreamClient {
     return {
       read: reader(),
       close: () => {
-        abortController.abort();
+        abortController.abort("Stream closed by the client.");
       },
     };
   }

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -7,17 +7,22 @@ import {
   HTTPClientOptions,
   HTTPRequest,
   HTTPResponse,
+  HTTPStreamRequest,
+  HTTPStreamClient,
+  StreamAdapter,
 } from "./http-client";
 
 /**
  * An implementation for {@link HTTPClient} that uses the native fetch API
  */
-export class FetchClient implements HTTPClient {
-  #url: string;
+export class FetchClient implements HTTPClient, HTTPStreamClient {
+  #queryURL: string;
+  #streamURL: string;
   #keepalive: boolean;
 
   constructor({ url, fetch_keepalive }: HTTPClientOptions) {
-    this.#url = new URL("/query/1", url).toString();
+    this.#queryURL = new URL("/query/1", url).toString();
+    this.#streamURL = new URL("/stream/1", url).toString();
     this.#keepalive = fetch_keepalive;
   }
 
@@ -38,7 +43,7 @@ export class FetchClient implements HTTPClient {
           })()
         : AbortSignal.timeout(client_timeout_ms);
 
-    const response = await fetch(this.#url, {
+    const response = await fetch(this.#queryURL, {
       method,
       headers: { ...requestHeaders, "Content-Type": "application/json" },
       body: JSON.stringify(data),
@@ -64,8 +69,88 @@ export class FetchClient implements HTTPClient {
     };
   }
 
+  /** {@inheritDoc HTTPStreamClient.stream} */
+  stream({
+    data,
+    headers: requestHeaders,
+    method,
+  }: HTTPStreamRequest): StreamAdapter {
+    const request = new Request(this.#streamURL, {
+      method,
+      headers: { ...requestHeaders, "Content-Type": "application/json" },
+      body: data,
+      keepalive: this.#keepalive,
+    });
+
+    const abortController = new AbortController();
+
+    const options = {
+      signal: abortController.signal,
+    };
+
+    async function* reader() {
+      const response = await fetch(request, options);
+      const body = response.body;
+      if (!body) {
+        throw new Error("Response body is undefined.");
+      }
+      const reader = body.getReader();
+
+      for await (const line of readLines(reader)) {
+        yield line;
+      }
+    }
+
+    return {
+      read: reader(),
+      close: () => {
+        abortController.abort();
+      },
+    };
+  }
+
   /** {@inheritDoc HTTPClient.close} */
   close() {
     // no actions at this time
   }
+}
+
+/**
+ * Get individual lines from the stream
+ *
+ * The stream may be broken into arbitrary chunks, but the events are delimited by a newline character.
+ *
+ * @param reader - The stream reader
+ */
+async function* readLines(reader: ReadableStreamDefaultReader<Uint8Array>) {
+  const textDecoder = new TextDecoder();
+  let partOfLine = "";
+  for await (const chunk of readChunks(reader)) {
+    const chunkText = textDecoder.decode(chunk);
+    const chunkLines = (partOfLine + chunkText).split("\n");
+
+    // Yield all complete lines
+    for (let i = 0; i < chunkLines.length - 1; i++) {
+      yield chunkLines[i].trim();
+    }
+
+    // Store the partial line
+    partOfLine = chunkLines[chunkLines.length - 1];
+  }
+
+  // Yield the remaining partial line if any
+  if (partOfLine.trim() !== "") {
+    yield partOfLine;
+  }
+}
+
+async function* readChunks(reader: ReadableStreamDefaultReader<Uint8Array>) {
+  let done = false;
+  do {
+    const readResult = await reader.read();
+    if (readResult.value !== undefined) {
+      yield readResult.value;
+    }
+    done = readResult.done;
+  } while (!done);
 }

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -78,7 +78,7 @@ export class FetchClient implements HTTPClient, HTTPStreamClient {
     const request = new Request(this.#streamURL, {
       method,
       headers: { ...requestHeaders, "Content-Type": "application/json" },
-      body: data,
+      body: JSON.stringify(data),
       keepalive: this.#keepalive,
     });
 

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { Client } from "../client";
 // import type { Stream } from "../stream";
-import { QueryRequest } from "../wire-protocol";
+import { QueryRequest, StreamRequest } from "../wire-protocol";
 
 /**
  * An object representing an http request.
@@ -73,7 +73,8 @@ export interface HTTPClient {
  */
 export type HTTPStreamRequest = {
   /** The encoded Fauna query to send */
-  data: string; // | QueryRequest;
+  // TODO: Allow type to be a QueryRequest once implemented by the db
+  data: StreamRequest;
 
   /** Headers in object format */
   headers: Record<string, string | undefined>;

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -82,27 +82,6 @@ export type HTTPStreamRequest = {
   method: "POST";
 };
 
-// export interface Stream {
-//   /**
-//    * Register an event handler to execute for each event with specified type.
-//    * @param type - The event type to listen to {@link StreamEventType}
-//    * @param callback - The event handler to call each time an event is emitted
-//    * @returns
-//    */
-//   on: (type: StreamEventType, callback: StreamEventHandler) => Stream;
-
-//   /**
-//    * Start the stream.
-//    */
-//   // TODO: return `AsyncGenerator<StreamEvent>`?
-//   start: () => void;
-
-//   /**
-//    * Close the stream.
-//    */
-//   close: () => void;
-// }
-
 export interface StreamAdapter {
   read: AsyncGenerator<string>;
   close: () => void;

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { Client } from "../client";
+// import type { Stream } from "../stream";
 import { QueryRequest } from "../wire-protocol";
 
 /**
@@ -65,3 +66,65 @@ export interface HTTPClient {
    */
   close(): void;
 }
+
+/**
+ * An object representing an http request.
+ * The {@link Client} provides this to the {@link HTTPStreamClient} implementation.
+ */
+export type HTTPStreamRequest = {
+  /** The encoded Fauna query to send */
+  data: string; // | QueryRequest;
+
+  /** Headers in object format */
+  headers: Record<string, string | undefined>;
+
+  /** HTTP method to use */
+  method: "POST";
+};
+
+// export interface Stream {
+//   /**
+//    * Register an event handler to execute for each event with specified type.
+//    * @param type - The event type to listen to {@link StreamEventType}
+//    * @param callback - The event handler to call each time an event is emitted
+//    * @returns
+//    */
+//   on: (type: StreamEventType, callback: StreamEventHandler) => Stream;
+
+//   /**
+//    * Start the stream.
+//    */
+//   // TODO: return `AsyncGenerator<StreamEvent>`?
+//   start: () => void;
+
+//   /**
+//    * Close the stream.
+//    */
+//   close: () => void;
+// }
+
+export interface StreamAdapter {
+  read: AsyncGenerator<string>;
+  close: () => void;
+}
+
+/**
+ * An interface to provide implementation-specific, asyncronous http calls.
+ * This driver provides default implementations for common environments. Users
+ * can configure the {@link Client} to use custom implementations if desired.
+ */
+export interface HTTPStreamClient {
+  /**
+   * Makes an HTTP request and returns the response
+   * @param req - an {@link HTTPStreamRequest}
+   * @returns A Promise&lt;{@link HTTPResponse}&gt;
+   * @throws {@link NetworkError} on request timeout or other network issue.
+   */
+  stream(req: HTTPStreamRequest): StreamAdapter;
+}
+
+export const implementsStreamClient = (
+  client: Partial<HTTPStreamClient>
+): client is HTTPStreamClient => {
+  return "stream" in client && typeof client.stream === "function";
+};

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { Client } from "../client";
-// import type { Stream } from "../stream";
 import { QueryRequest, StreamRequest } from "../wire-protocol";
 
 /**

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -82,6 +82,9 @@ export type HTTPStreamRequest = {
   method: "POST";
 };
 
+/**
+ * A common interface for a StreamClient to operate a stream from any HTTPStreamClient
+ */
 export interface StreamAdapter {
   read: AsyncGenerator<string>;
   close: () => void;

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -104,9 +104,3 @@ export interface HTTPStreamClient {
    */
   stream(req: HTTPStreamRequest): StreamAdapter;
 }
-
-export const implementsStreamClient = (
-  client: Partial<HTTPStreamClient>
-): client is HTTPStreamClient => {
-  return "stream" in client && typeof client.stream === "function";
-};

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,11 +1,10 @@
 import { FetchClient } from "./fetch-client";
+import { HTTPClient, HTTPClientOptions, HTTPResponse } from "./http-client";
 import { NodeHTTP2Client } from "./node-http2-client";
-import {
-  HTTPClient,
-  HTTPClientOptions,
-  HTTPRequest,
-  HTTPResponse,
-} from "./http-client";
+
+export * from "./fetch-client";
+export * from "./http-client";
+export * from "./node-http2-client";
 
 export const getDefaultHTTPClient = (options: HTTPClientOptions): HTTPClient =>
   nodeHttp2IsSupported()
@@ -15,7 +14,7 @@ export const getDefaultHTTPClient = (options: HTTPClientOptions): HTTPClient =>
 export const isHTTPResponse = (res: any): res is HTTPResponse =>
   res instanceof Object && "body" in res && "headers" in res && "status" in res;
 
-const nodeHttp2IsSupported = () => {
+export const nodeHttp2IsSupported = () => {
   if (
     typeof process !== "undefined" &&
     process &&
@@ -30,5 +29,3 @@ const nodeHttp2IsSupported = () => {
   }
   return false;
 };
-
-export { FetchClient, NodeHTTP2Client, HTTPClient, HTTPRequest, HTTPResponse };

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -1,5 +1,10 @@
 import { FetchClient } from "./fetch-client";
-import { HTTPClient, HTTPClientOptions, HTTPResponse } from "./http-client";
+import {
+  HTTPClient,
+  HTTPClientOptions,
+  HTTPResponse,
+  HTTPStreamClient,
+} from "./http-client";
 import { NodeHTTP2Client } from "./node-http2-client";
 
 export * from "./fetch-client";
@@ -13,6 +18,12 @@ export const getDefaultHTTPClient = (options: HTTPClientOptions): HTTPClient =>
 
 export const isHTTPResponse = (res: any): res is HTTPResponse =>
   res instanceof Object && "body" in res && "headers" in res && "status" in res;
+
+export const isStreamClient = (
+  client: Partial<HTTPStreamClient>
+): client is HTTPStreamClient => {
+  return "stream" in client && typeof client.stream === "function";
+};
 
 export const nodeHttp2IsSupported = () => {
   if (

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -11,7 +11,9 @@ export * from "./fetch-client";
 export * from "./http-client";
 export * from "./node-http2-client";
 
-export const getDefaultHTTPClient = (options: HTTPClientOptions): HTTPClient =>
+export const getDefaultHTTPClient = (
+  options: HTTPClientOptions
+): HTTPClient & HTTPStreamClient =>
   nodeHttp2IsSupported()
     ? NodeHTTP2Client.getClient(options)
     : new FetchClient(options);

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -9,8 +9,11 @@ import {
   HTTPClientOptions,
   HTTPRequest,
   HTTPResponse,
+  HTTPStreamClient,
+  HTTPStreamRequest,
+  StreamAdapter,
 } from "./http-client";
-import { NetworkError } from "../errors";
+import { ServiceError, NetworkError } from "../errors";
 
 // alias http2 types
 type ClientHttp2Session = any;
@@ -22,7 +25,7 @@ type OutgoingHttpHeaders = any;
 /**
  * An implementation for {@link HTTPClient} that uses the node http package
  */
-export class NodeHTTP2Client implements HTTPClient {
+export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
   static #clients: Map<string, NodeHTTP2Client> = new Map();
 
   #http2_session_idle_ms: number;
@@ -107,6 +110,11 @@ export class NodeHTTP2Client implements HTTPClient {
     });
   }
 
+  /** {@inheritDoc HTTPStreamClient.stream} */
+  stream(req: HTTPStreamRequest): StreamAdapter {
+    return this.#doStream(req);
+  }
+
   /** {@inheritDoc HTTPClient.close} */
   close() {
     // defend against redundant close calls
@@ -170,7 +178,7 @@ export class NodeHTTP2Client implements HTTPClient {
 
         // append response data to the data string every time we receive new
         // data chunks in the response
-        req.on("data", (chunk: any) => {
+        req.on("data", (chunk: string) => {
           responseData += chunk;
         });
 
@@ -212,5 +220,110 @@ export class NodeHTTP2Client implements HTTPClient {
         rejectPromise(error);
       }
     });
+  }
+
+  /** {@inheritDoc HTTPStreamClient.stream} */
+  #doStream({
+    data: requestData,
+    headers: requestHeaders,
+    method,
+  }: HTTPStreamRequest): StreamAdapter {
+    let resolveChunk: (chunk: string) => void;
+    let rejectChunk: (reason: any) => void;
+
+    const setChunkPromise = () =>
+      new Promise<string>((res, rej) => {
+        resolveChunk = res;
+        rejectChunk = rej;
+      });
+
+    let chunkPromise = setChunkPromise();
+
+    let req: ClientHttp2Stream;
+    const onResponse = (
+      http2ResponseHeaders: IncomingHttpHeaders & IncomingHttpStatusHeader
+    ) => {
+      const status = Number(
+        http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS]
+      );
+      if (!(status >= 200 && status < 400)) {
+        // Get the error body and then throw an error
+        let responseData = "";
+
+        // append response data to the data string every time we receive new
+        // data chunks in the response
+        req.on("data", (chunk: string) => {
+          responseData += chunk;
+        });
+
+        // Once the response is finished, resolve the promise
+        // TODO: The Client contains the information for how to parse an error
+        // into the appropriate class, so lift this logic out of the HTTPClient.
+        req.on("end", () => {
+          rejectChunk(new ServiceError(JSON.parse(responseData), status));
+        });
+      } else {
+        let partOfLine = "";
+
+        // append response data to the data string every time we receive new
+        // data chunks in the response
+        req.on("data", (chunk: string) => {
+          const chunkLines = (partOfLine + chunk).split("\n");
+
+          // Yield all complete lines
+          for (let i = 0; i < chunkLines.length - 1; i++) {
+            resolveChunk(chunkLines[i].trim());
+            chunkPromise = setChunkPromise();
+          }
+
+          // Store the partial line
+          partOfLine = chunkLines[chunkLines.length - 1];
+        });
+
+        // Once the response is finished, resolve the promise
+        req.on("end", () => {
+          resolveChunk(partOfLine);
+        });
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+
+    async function* reader(): AsyncGenerator<string> {
+      const httpRequestHeaders: OutgoingHttpHeaders = {
+        ...requestHeaders,
+        [http2.constants.HTTP2_HEADER_PATH]: "/stream/1",
+        [http2.constants.HTTP2_HEADER_METHOD]: method,
+      };
+
+      const session = self.#connect();
+      req = session
+        .request(httpRequestHeaders)
+        .setEncoding("utf8")
+        .on("error", (error: any) => {
+          rejectChunk(error);
+        })
+        .on("response", onResponse);
+
+      const body = JSON.stringify(requestData);
+
+      req.write(body, "utf8");
+
+      req.end();
+
+      while (true) {
+        yield await chunkPromise;
+      }
+    }
+
+    return {
+      read: reader(),
+      close: () => {
+        if (req) {
+          req.close();
+        }
+      },
+    };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
-export { Client } from "./client";
+export { Client, StreamClient } from "./client";
 export {
   endpoints,
   type ClientConfiguration,
   type Endpoints,
+  type StreamClientConfiguration,
 } from "./client-configuration";
 export {
   AbortError,
@@ -42,7 +43,6 @@ export {
   DateStub,
   Document,
   DocumentReference,
-  type DocumentT,
   EmbeddedSet,
   Module,
   NamedDocument,
@@ -50,14 +50,19 @@ export {
   NullDocument,
   Page,
   SetIterator,
+  StreamToken,
   TimeStub,
+  type DocumentT,
 } from "./values";
 export {
   FetchClient,
   getDefaultHTTPClient,
   isHTTPResponse,
+  isStreamClient,
   NodeHTTP2Client,
   type HTTPClient,
   type HTTPRequest,
   type HTTPResponse,
+  type HTTPStreamClient,
+  type StreamAdapter,
 } from "./http-client";

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -10,6 +10,7 @@ import {
   Page,
   NullDocument,
   EmbeddedSet,
+  StreamToken,
 } from "./values";
 import { QueryValueObject, QueryValue } from "./wire-protocol";
 
@@ -95,6 +96,8 @@ Returning as Number with loss of precision. Use long_type 'bigint' instead.`);
         return TimeStub.from(value["@time"]);
       } else if (value["@object"]) {
         return value["@object"];
+      } else if (value["@stream"]) {
+        return new StreamToken(value["@stream"]);
       }
 
       return value;
@@ -209,6 +212,9 @@ const encodeMap = {
     //   "@set": { data: encodeMap["array"](value.data), after: value.after },
     // };
   },
+  // TODO: encode as a tagged value if provided as a query arg?
+  // streamToken: (value: StreamToken): TaggedStreamToken => ({ "@stream": value.token }),
+  streamToken: (value: StreamToken): string => value.token,
 };
 
 const encode = (input: QueryValue): QueryValue => {
@@ -253,6 +259,8 @@ const encode = (input: QueryValue): QueryValue => {
         return encodeMap["set"](input);
       } else if (input instanceof EmbeddedSet) {
         return encodeMap["set"](input);
+      } else if (input instanceof StreamToken) {
+        return encodeMap["streamToken"](input);
       } else {
         return encodeMap["object"](input);
       }

--- a/src/values/index.ts
+++ b/src/values/index.ts
@@ -1,3 +1,4 @@
 export * from "./date-time";
 export * from "./doc";
 export * from "./set";
+export * from "./stream";

--- a/src/values/stream.ts
+++ b/src/values/stream.ts
@@ -1,0 +1,26 @@
+/**
+ * A token used to initiate a Fauna stream at a particular snapshot in time.
+ *
+ * The example below shows how to request a stream token from Fauna and use it
+ * to establish an event steam.
+ *
+ * @example
+ * ```javascript
+ *  const response = await client.query(fql`
+ *    Messages.byRecipient(User.byId("1234"))
+ *  `);
+ *  const token = response.data;
+ *
+ *  const stream = client.stream(token)
+ *    .on("add", (event) => console.log("New message", event))
+ *
+ *  stream.start();
+ * ```
+ */
+export class StreamToken {
+  readonly token: string;
+
+  constructor(token: string) {
+    this.token = token;
+  }
+}

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -328,11 +328,11 @@ export type StreamRequest = {
 export type StreamEventType = "start" | "add" | "remove" | "update" | "error";
 export type StreamEventStart = {
   type: "start";
-  ts: TimeStub;
+  ts: number;
 };
 export type StreamEventData = {
   type: "add" | "remove" | "update";
-  ts: TimeStub;
+  ts: number;
   // TODO: Different type for StreamStats?
   stats: QueryStats;
   data: QueryValue;

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -320,6 +320,11 @@ export type QueryValue =
   | EmbeddedSet
   | StreamToken;
 
+export type StreamRequest = {
+  token: string;
+  start_ts?: number;
+};
+
 export type StreamEventType = "start" | "add" | "remove" | "update" | "error";
 export type StreamEventStart = {
   type: "start";

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -331,14 +331,14 @@ export type StreamEventStatus = {
   txn_ts: number;
   stats: QueryStats;
 };
-export type StreamEventData = {
+export type StreamEventData<T extends QueryValue> = {
   type: "add" | "remove" | "update";
   txn_ts: number;
   stats: QueryStats;
-  data: QueryValue;
+  data: T;
 };
 export type StreamEventError = { type: "error" } & QueryFailure;
-export type StreamEvent =
+export type StreamEvent<T extends QueryValue> =
   | StreamEventStatus
-  | StreamEventData
+  | StreamEventData<T>
   | StreamEventError;

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -326,7 +326,7 @@ export type StreamRequest = {
 };
 
 export type StreamEventType = "status" | "add" | "remove" | "update" | "error";
-export type StreamEventStart = {
+export type StreamEventStatus = {
   type: "status";
   txn_ts: number;
   stats: QueryStats;
@@ -338,4 +338,7 @@ export type StreamEventData = {
   data: QueryValue;
 };
 export type StreamEventError = { type: "error" } & QueryFailure;
-export type StreamEvent = StreamEventStart | StreamEventData | StreamEventError;
+export type StreamEvent =
+  | StreamEventStatus
+  | StreamEventData
+  | StreamEventError;

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -337,12 +337,5 @@ export type StreamEventData = {
   stats: QueryStats;
   data: QueryValue;
 };
-export type StreamEventError = {
-  type: "error";
-  code: string;
-  message: string;
-  // TODO: Different type for StreamStats?
-  stats?: QueryStats;
-  cause?: Error;
-};
+export type StreamEventError = { type: "error" } & QueryFailure;
 export type StreamEvent = StreamEventStart | StreamEventData | StreamEventError;

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -342,6 +342,7 @@ export type StreamEventError = {
   code: string;
   message: string;
   // TODO: Different type for StreamStats?
-  stats: QueryStats;
+  stats?: QueryStats;
+  cause?: Error;
 };
 export type StreamEvent = StreamEventStart | StreamEventData | StreamEventError;

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -325,15 +325,15 @@ export type StreamRequest = {
   start_ts?: number;
 };
 
-export type StreamEventType = "start" | "add" | "remove" | "update" | "error";
+export type StreamEventType = "status" | "add" | "remove" | "update" | "error";
 export type StreamEventStart = {
-  type: "start";
-  ts: number;
+  type: "status";
+  txn_ts: number;
+  stats: QueryStats;
 };
 export type StreamEventData = {
   type: "add" | "remove" | "update";
-  ts: number;
-  // TODO: Different type for StreamStats?
+  txn_ts: number;
   stats: QueryStats;
   data: QueryValue;
 };

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -10,6 +10,7 @@ import {
   NamedDocumentReference,
   NullDocument,
   Page,
+  StreamToken,
   TimeStub,
 } from "./values";
 
@@ -316,4 +317,26 @@ export type QueryValue =
   | NamedDocumentReference
   | NullDocument
   | Page<QueryValue>
-  | EmbeddedSet;
+  | EmbeddedSet
+  | StreamToken;
+
+export type StreamEventType = "start" | "add" | "remove" | "update" | "error";
+export type StreamEventStart = {
+  type: "start";
+  ts: TimeStub;
+};
+export type StreamEventData = {
+  type: "add" | "remove" | "update";
+  ts: TimeStub;
+  // TODO: Different type for StreamStats?
+  stats: QueryStats;
+  data: QueryValue;
+};
+export type StreamEventError = {
+  type: "error";
+  code: string;
+  message: string;
+  // TODO: Different type for StreamStats?
+  stats: QueryStats;
+};
+export type StreamEvent = StreamEventStart | StreamEventData | StreamEventError;


### PR DESCRIPTION
Ticket(s): FE-4969

This is an initial go at implementing streaming events for the v10 API. Anything here is up for review and comment.

## Problem
Implement the v10 Fauna streaming API

We need to support browsers and Node. We would also like to support other runtimes if possible.

## Solution
Provide a `StreamClient` class which provides the primary user interface to establish a stream and handle events.

Provide a lower-level `HTTPStreamClient` interface that can be implemented for different environments.

The `StreamClient` contains an instance of an `HTTPStreamClient`, which mirrors the existing lower-level `HTTPClient` interface that enables different backend implementations for the `Client` class.

The `HTTPStreamClient` is responsible for initiating a request and returning an object that implements the `StreamAdapter` interface. The `StreamAdapter` contains an asyncronous generator function that yields Fauna streaming events as raw strings for the `StreamClient` to use. The `StreamAdapter` also provides a `close` method to provide a mechanism to close the stream.

The `StreamClient` is responsible for parsing the raw-string events into valid types. Streaming events always return data in the "tagged" format. The `StreamClient` must be configured with how to handle decoding of `Long` types.

An instance of `StreamClient` is created on each call to `Client.stream`. Each instance tracks it's own handlers for events. The underlying HTTP connections should be reused when possible.

## Result
Streams can be used in the browser and Node.js.

This does not work in public Fauna environments or the docker image yet.

### Usage

Two ways to use the stream are enabled: 
1. Async Iterator
2. Callbacks

_Async Iterator example_
```javascript
import { Client, fql } from "fauna"
const client = new Client({ secret: FAUNA_SECRET })

const response = await client.query(fql`MyCollection.all().toStream()`);
const streamToken = response.data;

const stream = client.stream(streamToken)

try {
  for await (const event of stream) {
    switch (event.type) {
      case "update":
      case "add":
      case "remove":
        console.log("Stream update:", event);
        // ...
        break;
    }
  }
} catch (error) {
  // An error will be handled here if Fauna returns a terminal, "error" event, or
  // if Fauna returns a non-200 response when trying to connect, or
  // if the max number of retries on network errors is reached.

  // ... handle fatal error
}
```

_Callbacks example_
```javascript
import { Client, fql } from "fauna"
const client = new Client({ secret: FAUNA_SECRET })

const response = await client.query(fql`MyCollection.all().toStream()`);
const streamToken = response.data;

const stream = client.stream(streamToken)
  
stream.start(
  function onEvent(event) {
    switch (event.type) {
      case "update":
      case "add":
      case "remove":
        console.log("Stream update:", event);
        // ...
        break;
    }
  },
  function onFatalError(error) {
    // An error will be handled here if Fauna returns a terminal, "error" event, or
    // if Fauna returns a non-200 response when trying to connect, or
    // if the max number of retries on network errors is reached.

    // ... handle fatal error
  }
);
```

The driver will take care of the initial request to convert to a stream if you provide a Query

```javascript
import { Client, fql } from "fauna"
const client = new Client({ secret: FAUNA_SECRET })

const stream = await client.stream(fql`MyCollection.all().toStream()`)

for await (const event of stream) {
  // ...
}
```

### Error handling

The driver tries to reestablish streaming connections when there are network errors. With current defaults, retries start quickly but have exponential backoff, capped at 10s, and will continue trying to reestablish for about 10 minutes. That's generous enough to let your internet connection drop and come back.

Network errors are hidden from the user while retries are still being attempted
 
Errors from Fauna are assumed fatal. Any error events coming from Fauna will cause an error to be thrown.

## Out of scope
N/A

## Testing
tests have been added and can be run on the most recent docker image using `yarn test`.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
