### PR TITLE
Provide exactly one handler for events and another for fatal errors

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -643,12 +643,10 @@ export class StreamClient {
     this.#httpStreamClient = httpStreamClient;
   }
 
-  on(type: StreamEventType, callback: StreamEventHandler) {
-    this.#callbacks[type].push(callback);
-    return this;
-  }
-    
-  start(onEvent: StreamEventHandler, onFatalError?: (error: Error) => void) {
+  start(
+    onEvent: StreamEventHandler,
+    onFatalError: (error: Error) => void
+  ): StreamClient {
     if (typeof onEvent !== "function") {
       throw new TypeError(
         `Expected a function as the 'onEvent' argument, but received ${typeof onEvent}. Please provide a valid function.`
@@ -671,6 +669,7 @@ export class StreamClient {
       }
     };
     run();
+    return this;
   }
 
   async *[Symbol.asyncIterator](): AsyncGenerator<StreamEvent> {


### PR DESCRIPTION
Ticket(s): [FE-4969](https://faunadb.atlassian.net/browse/FE-4969)

Small breaking change, but looking for feedback first. Compared to the callback example in https://github.com/fauna/fauna-js/pull/232, this would remove the concept of registering one or more callbacks before the `start` method. There is no adding or removing of callbacks, and no more no ambiguity about how the async interface should work if you have registered callbacks. Here is a modified example:

```javascript
import { Client, fql } from "fauna"
const client = new Client({ secret: FAUNA_SECRET })

const stream = client.stream(fql`MyCollection.all().toStream()`)

stream.start(
  function onEvent(event) {
    switch (event.type) {
      case "start":
        console.log("Stream start", event);
        // ...
        break;

      case "update":
      case "add":
      case "remove":
        console.log("Stream update:", event);
        // ...
        break;
    }
  },
  function onFatalError(error) {
    // An error will be handled here if Fauna returns a terminal, "error" event, or
    // if Fauna returns a non-200 response when trying to connect, or
    // if the max number of retries on network errors is reached.

    // ... handle fatal error
  }
);
```

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-4969]: https://faunadb.atlassian.net/browse/FE-4969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ