### PR TITLE
Initial implementation for streams with http2 module

### DIFF
--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -9,6 +9,7 @@ import {
   HTTPClientOptions,
   HTTPRequest,
   HTTPResponse,
+  HTTPStreamClient,
   HTTPStreamRequest,
   StreamAdapter,
 } from "./http-client";
@@ -24,7 +25,7 @@ type OutgoingHttpHeaders = any;
 /**
  * An implementation for {@link HTTPClient} that uses the node http package
  */
-export class NodeHTTP2Client implements HTTPClient {
+export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
   static #clients: Map<string, NodeHTTP2Client> = new Map();
 
   #http2_session_idle_ms: number;

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -290,7 +290,7 @@ export class NodeHTTP2Client implements HTTPClient {
     async function* reader(): AsyncGenerator<string> {
       const httpRequestHeaders: OutgoingHttpHeaders = {
         ...requestHeaders,
-        [http2.constants.HTTP2_HEADER_PATH]: "/query/1",
+        [http2.constants.HTTP2_HEADER_PATH]: "/stream/1",
         [http2.constants.HTTP2_HEADER_METHOD]: method,
       };
 


### PR DESCRIPTION
Ticket(s): FE-4969

## Problem
The first iteration of v10 streaming did provide a default implementation for Node.js

## Solution
Add a streaming implementation to the `NodeHTTP2Client` class

## Result
V10 streams can be used in Node.js by default

## Out of scope
There are changes to the error shape on the core side that might not initially be incorporated here.

## Testing
I am running tests with a Node.js script running locally on my machine.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
