### PR TITLE
Sort service errors into the proper subclass

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -127,13 +127,13 @@ describe("query", () => {
             expect(req.headers[expectedHeader.key]).toBe(expectedHeader.value);
           });
           expect(req.headers["x-driver-env"]).toEqual(
-            expect.stringContaining("driver=")
+            expect.stringContaining("driver="),
           );
           expect(req.headers["x-driver-env"]).toEqual(
-            expect.stringContaining("os=")
+            expect.stringContaining("os="),
           );
           expect(req.headers["x-driver-env"]).toEqual(
-            expect.stringContaining("runtime=")
+            expect.stringContaining("runtime="),
           );
           return dummyResponse;
         },
@@ -150,33 +150,31 @@ describe("query", () => {
       const headers = { [fieldName]: fieldValue };
       await myClient.query<number>(fql`"taco".length`, headers);
       myClient.close();
-    }
+    },
   );
 
-  it(
-    "respects typechecked: undefined", async () => {
-      const httpClient: HTTPClient = {
-        async request(req) {
-          const contains = new Set(Object.keys(req.headers)).has("x-typecheck");
-          expect(contains).toBe(false);
-          return dummyResponse;
-        },
-        close() {},
-      };
+  it("respects typechecked: undefined", async () => {
+    const httpClient: HTTPClient = {
+      async request(req) {
+        const contains = new Set(Object.keys(req.headers)).has("x-typecheck");
+        expect(contains).toBe(false);
+        return dummyResponse;
+      },
+      close() {},
+    };
 
-      let clientConfiguration: Partial<ClientConfiguration> = {
-        typecheck: true,
-      };
-      let myClient = getClient(clientConfiguration, httpClient);
-      await myClient.query<number>(fql`"taco".length`, { typecheck: undefined });
-      myClient.close();
+    let clientConfiguration: Partial<ClientConfiguration> = {
+      typecheck: true,
+    };
+    let myClient = getClient(clientConfiguration, httpClient);
+    await myClient.query<number>(fql`"taco".length`, { typecheck: undefined });
+    myClient.close();
 
-      clientConfiguration = { typecheck: undefined };
-      myClient = getClient(clientConfiguration, httpClient);
-      await myClient.query<number>(fql`"taco".length`);
-      myClient.close();
-    }
-  );
+    clientConfiguration = { typecheck: undefined };
+    myClient = getClient(clientConfiguration, httpClient);
+    await myClient.query<number>(fql`"taco".length`);
+    myClient.close();
+  });
 
   it("can send arguments directly", async () => {
     const foo = {
@@ -234,10 +232,10 @@ describe("query", () => {
     expect.assertions(6);
     try {
       await client.query(
-        fql`Function.create({"name": "my_double", "body": "x => x * 2"})`
+        fql`Function.create({"name": "my_double", "body": "x => x * 2"})`,
       );
       await client.query(
-        fql`Function.create({"name": "my_double", "body": "x => x * 2"})`
+        fql`Function.create({"name": "my_double", "body": "x => x * 2"})`,
       );
     } catch (e) {
       if (e instanceof ServiceError) {
@@ -266,7 +264,7 @@ describe("query", () => {
             data: "{}" as unknown as QueryRequest,
           };
           return getDefaultHTTPClient(getDefaultHTTPClientOptions()).request(
-            bad_req
+            bad_req,
           );
         },
         close() {},
@@ -307,7 +305,7 @@ describe("query", () => {
     } catch (e) {
       if (e instanceof QueryTimeoutError) {
         expect(e.message).toEqual(
-          expect.stringContaining("aggressive deadline")
+          expect.stringContaining("aggressive deadline"),
         );
         expect(e.httpStatus).toBe(440);
         expect(e.code).toBe("time_out");
@@ -366,7 +364,7 @@ describe("query", () => {
   });
 
   it("throws a NetworkError on client timeout", async () => {
-    expect.assertions(2);
+    expect.assertions(3);
 
     const httpClient = getDefaultHTTPClient(getDefaultHTTPClientOptions());
     const badHTTPClient = {
@@ -384,6 +382,7 @@ describe("query", () => {
     try {
       await badClient.query(fql``);
     } catch (e: any) {
+      expect(e).toBeInstanceOf(NetworkError);
       if (e instanceof NetworkError) {
         expect(e.message).toBe("The network connection encountered a problem.");
         expect(e.cause).toBeDefined();
@@ -403,7 +402,7 @@ describe("query", () => {
       {
         query_timeout_ms: 60,
       },
-      httpClient
+      httpClient,
     );
     try {
       await badClient.query(fql`foo`);
@@ -411,7 +410,7 @@ describe("query", () => {
       if (e instanceof ClientError) {
         expect(e.cause).toBeDefined();
         expect(e.message).toBe(
-          "A client level error occurred. Fauna was not called."
+          "A client level error occurred. Fauna was not called.",
         );
       }
     } finally {
@@ -440,13 +439,13 @@ describe("query", () => {
 
   it("session is closed regardless of number of clients", async () => {
     const httpClient1 = NodeHTTP2Client.getClient(
-      getDefaultHTTPClientOptions()
+      getDefaultHTTPClientOptions(),
     );
     const httpClient2 = NodeHTTP2Client.getClient(
-      getDefaultHTTPClientOptions()
+      getDefaultHTTPClientOptions(),
     );
     const httpClient3 = NodeHTTP2Client.getClient(
-      getDefaultHTTPClientOptions()
+      getDefaultHTTPClientOptions(),
     );
     const client1 = getClient({}, httpClient1);
     const client2 = getClient({}, httpClient2);
@@ -500,7 +499,7 @@ describe("query can encode / decode QueryValue correctly", () => {
     };
     // Do not use a dynamic Collection name by using `${new Module(collectionName)}`. See ENG-5003
     const docCreated = await client.query<any>(
-      fql`UndefinedTest.create(${toughInput})`
+      fql`UndefinedTest.create(${toughInput})`,
     );
     expect(docCreated.data.should_exist).toBeUndefined();
     expect(docCreated.data.nested_object.i_dont_exist).toBeUndefined();
@@ -519,7 +518,7 @@ describe("query can encode / decode QueryValue correctly", () => {
       if (e instanceof TypeError) {
         expect(e.name).toBe("TypeError");
         expect(e.message).toBe(
-          "Passing undefined as a QueryValue is not supported"
+          "Passing undefined as a QueryValue is not supported",
         );
       }
     }

--- a/__tests__/integration/stream.test.ts
+++ b/__tests__/integration/stream.test.ts
@@ -247,7 +247,7 @@ describe("StreamClient", () => {
     }
   });
 
-  it("handles InvalidRequestError when via callback when establishing a stream", async () => {
+  it("handles InvalidRequestError via callback when establishing a stream", async () => {
     expect.assertions(1);
 
     // create a stream with a bad token

--- a/__tests__/integration/stream.test.ts
+++ b/__tests__/integration/stream.test.ts
@@ -289,7 +289,7 @@ describe("StreamClient", () => {
       }
     } catch (e: any) {
       expect(e).toBeInstanceOf(AbortError);
-      expect(e.httpStatus).toBe(-1);
+      expect(e.httpStatus).toBeUndefined();
       expect(e.abort).toBe("oops");
     } finally {
       stream?.close();
@@ -316,7 +316,7 @@ describe("StreamClient", () => {
       }
     } catch (e: any) {
       expect(e).toBeInstanceOf(QueryRuntimeError);
-      expect(e.httpStatus).toBe(-1);
+      expect(e.httpStatus).toBeUndefined();
     } finally {
       stream?.close();
     }
@@ -347,7 +347,7 @@ describe("StreamClient", () => {
       function onEvent(_) {},
       function onError(e) {
         if (e instanceof AbortError) {
-          expect(e.httpStatus).toBe(-1);
+          expect(e.httpStatus).toBeUndefined();
           expect(e.abort).toBe("oops");
         }
         resolve();
@@ -382,7 +382,7 @@ describe("StreamClient", () => {
       function onEvent(_) {},
       function onError(e) {
         if (e instanceof QueryRuntimeError) {
-          expect(e.httpStatus).toBe(-1);
+          expect(e.httpStatus).toBeUndefined();
         }
         resolve();
       },

--- a/__tests__/integration/stream.test.ts
+++ b/__tests__/integration/stream.test.ts
@@ -1,15 +1,16 @@
 import {
-  fql,
-  getDefaultHTTPClient,
+  AbortError,
+  Client,
+  DocumentT,
+  DateStub,
+  Document,
+  InvalidRequestError,
   StreamClient,
   StreamClientConfiguration,
   StreamToken,
-  Client,
-  DocumentT,
-  ServiceError,
   TimeStub,
-  DateStub,
-  Document,
+  fql,
+  getDefaultHTTPClient,
 } from "../../src";
 import {
   getClient,
@@ -19,7 +20,6 @@ import {
 
 const defaultHttpClient = getDefaultHTTPClient(getDefaultHTTPClientOptions());
 const { secret } = getDefaultSecretAndEndpoint();
-const dummyStreamToken = new StreamToken("dummy");
 
 let client: Client;
 const STREAM_DB_NAME = "StreamTestDB";
@@ -228,7 +228,7 @@ describe("StreamClient", () => {
     await promise;
   });
 
-  it("catches non 200 responses when establishing a stream", async () => {
+  it("catches InvalidRequestError when establishing a stream", async () => {
     expect.assertions(1);
 
     try {
@@ -242,12 +242,11 @@ describe("StreamClient", () => {
         /* do nothing */
       }
     } catch (e) {
-      // TODO: be more specific about the error and split into multiple tests
-      expect(e).toBeInstanceOf(ServiceError);
+      expect(e).toBeInstanceOf(InvalidRequestError);
     }
   });
 
-  it("handles non 200 responses via callback when establishing a stream", async () => {
+  it("handles InvalidRequestError when via callback when establishing a stream", async () => {
     expect.assertions(1);
 
     // create a stream with a bad token
@@ -261,8 +260,7 @@ describe("StreamClient", () => {
     stream.start(
       function onEvent(_) {},
       function onError(e) {
-        // TODO: be more specific about the error and split into multiple tests
-        expect(e).toBeInstanceOf(ServiceError);
+        expect(e).toBeInstanceOf(InvalidRequestError);
         resolve();
       }
     );
@@ -270,7 +268,8 @@ describe("StreamClient", () => {
     await promise;
   });
 
-  it("catches a ServiceError if an error event is received", async () => {
+  // TODO: fail in other ways
+  it("catches an AbortError if abort is called when processing an event", async () => {
     expect.assertions(1);
 
     let stream: StreamClient<DocumentT<StreamTest>> | null = null;
@@ -289,14 +288,14 @@ describe("StreamClient", () => {
         /* do nothing */
       }
     } catch (e) {
-      // TODO: be more specific about the error and split into multiple tests
-      expect(e).toBeInstanceOf(ServiceError);
+      expect(e).toBeInstanceOf(AbortError);
     } finally {
       stream?.close();
     }
   });
 
-  it("handles a ServiceError via callback if an error event is received", async () => {
+  // TODO: fail in other ways
+  it("handles an AbortError via callback if abort is called when processing an event", async () => {
     expect.assertions(1);
 
     const response = await client.query<StreamToken>(
@@ -320,8 +319,7 @@ describe("StreamClient", () => {
     stream.start(
       function onEvent(_) {},
       function onError(e) {
-        // TODO: be more specific about the error and split into multiple tests
-        expect(e).toBeInstanceOf(ServiceError);
+        expect(e).toBeInstanceOf(AbortError);
         resolve();
       }
     );

--- a/__tests__/integration/stream.test.ts
+++ b/__tests__/integration/stream.test.ts
@@ -72,7 +72,7 @@ describe("Client", () => {
     let stream: StreamClient | null = null;
     try {
       const response = await client.query<StreamToken>(
-        fql`StreamTest.all().toStream()`
+        fql`StreamTest.all().toStream()`,
       );
       const token = response.data;
 
@@ -113,7 +113,7 @@ describe("StreamClient", () => {
     let stream: StreamClient | null = null;
     try {
       const response = await client.query<StreamToken>(
-        fql`StreamTest.all().toStream()`
+        fql`StreamTest.all().toStream()`,
       );
       const token = response.data;
 
@@ -138,7 +138,7 @@ describe("StreamClient", () => {
     try {
       const getToken = async () => {
         const response = await client.query<StreamToken>(
-          fql`StreamTest.all().toStream()`
+          fql`StreamTest.all().toStream()`,
         );
         return response.data;
       };
@@ -163,7 +163,7 @@ describe("StreamClient", () => {
     let stream: StreamClient<DocumentT<StreamTest>> | null = null;
     try {
       const response = await client.query<StreamToken>(
-        fql`StreamTest.all().toStream()`
+        fql`StreamTest.all().toStream()`,
       );
       const token = response.data;
 
@@ -194,13 +194,13 @@ describe("StreamClient", () => {
     expect.assertions(2);
 
     const response = await client.query<StreamToken>(
-      fql`StreamTest.all().toStream()`
+      fql`StreamTest.all().toStream()`,
     );
     const token = response.data;
 
     const stream = new StreamClient<DocumentT<StreamTest>>(
       token,
-      defaultStreamConfig
+      defaultStreamConfig,
     );
 
     // create some events that will be played back
@@ -236,7 +236,7 @@ describe("StreamClient", () => {
       // create a stream with a bad token
       const stream = new StreamClient(
         new StreamToken("2"),
-        defaultStreamConfig
+        defaultStreamConfig,
       );
 
       for await (const _ of stream) {
@@ -263,7 +263,7 @@ describe("StreamClient", () => {
       function onError(e) {
         expect(e).toBeInstanceOf(InvalidRequestError);
         resolve();
-      }
+      },
     );
 
     await promise;
@@ -275,7 +275,7 @@ describe("StreamClient", () => {
     let stream: StreamClient<DocumentT<StreamTest>> | null = null;
     try {
       const response = await client.query<StreamToken>(
-        fql`StreamTest.all().map((doc) => abort("oops")).toStream()`
+        fql`StreamTest.all().map((doc) => abort("oops")).toStream()`,
       );
       const token = response.data;
 
@@ -289,7 +289,7 @@ describe("StreamClient", () => {
       }
     } catch (e: any) {
       expect(e).toBeInstanceOf(AbortError);
-      expect(e.httpStatus).toBe(400);
+      expect(e.httpStatus).toBe(-1);
       expect(e.abort).toBe("oops");
     } finally {
       stream?.close();
@@ -302,7 +302,7 @@ describe("StreamClient", () => {
     let stream: StreamClient<DocumentT<StreamTest>> | null = null;
     try {
       const response = await client.query<StreamToken>(
-        fql`StreamTest.all().map((doc) => notARealFn(doc)).toStream()`
+        fql`StreamTest.all().map((doc) => notARealFn(doc)).toStream()`,
       );
       const token = response.data;
 
@@ -316,7 +316,7 @@ describe("StreamClient", () => {
       }
     } catch (e: any) {
       expect(e).toBeInstanceOf(QueryRuntimeError);
-      expect(e.httpStatus).toBe(400);
+      expect(e.httpStatus).toBe(-1);
     } finally {
       stream?.close();
     }
@@ -326,13 +326,13 @@ describe("StreamClient", () => {
     expect.assertions(2);
 
     const response = await client.query<StreamToken>(
-      fql`StreamTest.all().map((doc) => abort("oops")).toStream()`
+      fql`StreamTest.all().map((doc) => abort("oops")).toStream()`,
     );
     const token = response.data;
 
     const stream = new StreamClient<DocumentT<StreamTest>>(
       token,
-      defaultStreamConfig
+      defaultStreamConfig,
     );
 
     // create some events that will be played back
@@ -347,11 +347,11 @@ describe("StreamClient", () => {
       function onEvent(_) {},
       function onError(e) {
         if (e instanceof AbortError) {
-          expect(e.httpStatus).toBe(400);
+          expect(e.httpStatus).toBe(-1);
           expect(e.abort).toBe("oops");
         }
         resolve();
-      }
+      },
     );
 
     await promise;
@@ -361,13 +361,13 @@ describe("StreamClient", () => {
     expect.assertions(1);
 
     const response = await client.query<StreamToken>(
-      fql`StreamTest.all().map((doc) => notARealFn(doc)).toStream()`
+      fql`StreamTest.all().map((doc) => notARealFn(doc)).toStream()`,
     );
     const token = response.data;
 
     const stream = new StreamClient<DocumentT<StreamTest>>(
       token,
-      defaultStreamConfig
+      defaultStreamConfig,
     );
 
     // create some events that will be played back
@@ -382,16 +382,14 @@ describe("StreamClient", () => {
       function onEvent(_) {},
       function onError(e) {
         if (e instanceof QueryRuntimeError) {
-          expect(e.httpStatus).toBe(400);
+          expect(e.httpStatus).toBe(-1);
         }
         resolve();
-      }
+      },
     );
 
     await promise;
   });
-
-  // TODO: test other error events
 
   it("decodes values from streams correctly", async () => {
     expect.assertions(5);
@@ -405,7 +403,7 @@ describe("StreamClient", () => {
           date: Date.today(),
           doc: doc,
           bigInt: 922337036854775808,
-        }).toStream()`
+        }).toStream()`,
       );
       const token = response.data;
 
@@ -456,7 +454,7 @@ describe("StreamClient", () => {
       await client.query(fql`StreamTest.all().forEach(.delete())`);
 
       const response = await client.query<StreamToken>(
-        fql`StreamTest.all().toStream()`
+        fql`StreamTest.all().toStream()`,
       );
       const token = response.data;
 

--- a/__tests__/unit/error.test.ts
+++ b/__tests__/unit/error.test.ts
@@ -2,71 +2,74 @@ import {
   AbortError,
   AuthenticationError,
   AuthorizationError,
+  ConstraintFailureError,
   ContendedTransactionError,
   InvalidRequestError,
   QueryCheckError,
   QueryFailure,
   QueryRuntimeError,
   QueryTimeoutError,
-  ServiceError,
   ServiceInternalError,
-  ServiceTimeoutError,
   ThrottlingError,
 } from "../../src";
 import { getServiceError } from "../../src/errors";
 
 describe("query", () => {
   it.each`
-    httpStatus | code                                    | errorClass
-    ${400}     | ${"invalid_function_definition"}        | ${QueryCheckError}
-    ${400}     | ${"invalid_identifier"}                 | ${QueryCheckError}
-    ${400}     | ${"invalid_query"}                      | ${QueryCheckError}
-    ${400}     | ${"invalid_syntax"}                     | ${QueryCheckError}
-    ${400}     | ${"invalid_type"}                       | ${QueryCheckError}
-    ${400}     | ${"unbound_variable"}                   | ${QueryRuntimeError}
-    ${400}     | ${"index_out_of_bounds"}                | ${QueryRuntimeError}
-    ${400}     | ${"type_mismatch"}                      | ${QueryRuntimeError}
-    ${400}     | ${"invalid_argument"}                   | ${QueryRuntimeError}
-    ${400}     | ${"invalid_bounds"}                     | ${QueryRuntimeError}
-    ${400}     | ${"invalid_regex"}                      | ${QueryRuntimeError}
-    ${400}     | ${"constraint_failure"}                 | ${QueryRuntimeError}
-    ${400}     | ${"invalid_schema"}                     | ${QueryRuntimeError}
-    ${400}     | ${"invalid_document_id"}                | ${QueryRuntimeError}
-    ${400}     | ${"document_id_exists"}                 | ${QueryRuntimeError}
-    ${400}     | ${"document_not_found"}                 | ${QueryRuntimeError}
-    ${400}     | ${"document_deleted"}                   | ${QueryRuntimeError}
-    ${400}     | ${"invalid_function_invocation"}        | ${QueryRuntimeError}
-    ${400}     | ${"invalid_index_invocation"}           | ${QueryRuntimeError}
-    ${400}     | ${"null_value"}                         | ${QueryRuntimeError}
-    ${400}     | ${"invalid_null_access"}                | ${QueryRuntimeError}
-    ${400}     | ${"invalid_cursor"}                     | ${QueryRuntimeError}
-    ${400}     | ${"permission_denied"}                  | ${QueryRuntimeError}
-    ${400}     | ${"invalid_effect"}                     | ${QueryRuntimeError}
-    ${400}     | ${"invalid_write"}                      | ${QueryRuntimeError}
-    ${400}     | ${"internal_failure"}                   | ${QueryRuntimeError}
-    ${400}     | ${"divide_by_zero"}                     | ${QueryRuntimeError}
-    ${400}     | ${"invalid_id"}                         | ${QueryRuntimeError}
-    ${400}     | ${"invalid_secret"}                     | ${QueryRuntimeError}
-    ${400}     | ${"invalid_time"}                       | ${QueryRuntimeError}
-    ${400}     | ${"invalid_unit"}                       | ${QueryRuntimeError}
-    ${400}     | ${"invalid_date"}                       | ${QueryRuntimeError}
-    ${400}     | ${"limit_exceeded"}                     | ${QueryRuntimeError}
-    ${400}     | ${"stack_overflow"}                     | ${QueryRuntimeError}
-    ${400}     | ${"invalid_computed_field_access"}      | ${QueryRuntimeError}
-    ${400}     | ${"disabled_feature"}                   | ${QueryRuntimeError}
-    ${400}     | ${"invalid_receiver"}                   | ${QueryRuntimeError}
-    ${400}     | ${"invalid_timestamp_field_access"}     | ${QueryRuntimeError}
-    ${400}     | ${"invalid_request"}                    | ${InvalidRequestError}
-    ${400}     | ${"abort"}                              | ${AbortError}
-    ${401}     | ${"unauthorized"}                       | ${AuthenticationError}
-    ${403}     | ${"forbidden"}                          | ${AuthorizationError}
-    ${409}     | ${"contended_transaction"}              | ${ContendedTransactionError}
-    ${429}     | ${"throttle"}                           | ${ThrottlingError}
-    ${440}     | ${"time_out"}                           | ${QueryTimeoutError}
-    ${503}     | ${"time_out"}                           | ${ServiceTimeoutError}
-    ${500}     | ${"internal_error"}                     | ${ServiceInternalError}
-    ${999}     | ${"error_not_yet_subclassed_in_client"} | ${ServiceError}
-    ${-1}      | ${"error_not_yet_subclassed_in_client"} | ${ServiceError}
+    httpStatus   | code                                | errorClass
+    ${400}       | ${"invalid_query"}                  | ${QueryCheckError}
+    ${400}       | ${"unbound_variable"}               | ${QueryRuntimeError}
+    ${400}       | ${"index_out_of_bounds"}            | ${QueryRuntimeError}
+    ${400}       | ${"type_mismatch"}                  | ${QueryRuntimeError}
+    ${400}       | ${"invalid_argument"}               | ${QueryRuntimeError}
+    ${400}       | ${"invalid_bounds"}                 | ${QueryRuntimeError}
+    ${400}       | ${"invalid_regex"}                  | ${QueryRuntimeError}
+    ${400}       | ${"invalid_schema"}                 | ${QueryRuntimeError}
+    ${400}       | ${"invalid_document_id"}            | ${QueryRuntimeError}
+    ${400}       | ${"document_id_exists"}             | ${QueryRuntimeError}
+    ${400}       | ${"document_not_found"}             | ${QueryRuntimeError}
+    ${400}       | ${"document_deleted"}               | ${QueryRuntimeError}
+    ${400}       | ${"invalid_function_invocation"}    | ${QueryRuntimeError}
+    ${400}       | ${"invalid_index_invocation"}       | ${QueryRuntimeError}
+    ${400}       | ${"null_value"}                     | ${QueryRuntimeError}
+    ${400}       | ${"invalid_null_access"}            | ${QueryRuntimeError}
+    ${400}       | ${"invalid_cursor"}                 | ${QueryRuntimeError}
+    ${400}       | ${"permission_denied"}              | ${QueryRuntimeError}
+    ${400}       | ${"invalid_effect"}                 | ${QueryRuntimeError}
+    ${400}       | ${"invalid_write"}                  | ${QueryRuntimeError}
+    ${400}       | ${"internal_failure"}               | ${QueryRuntimeError}
+    ${400}       | ${"divide_by_zero"}                 | ${QueryRuntimeError}
+    ${400}       | ${"invalid_id"}                     | ${QueryRuntimeError}
+    ${400}       | ${"invalid_secret"}                 | ${QueryRuntimeError}
+    ${400}       | ${"invalid_time"}                   | ${QueryRuntimeError}
+    ${400}       | ${"invalid_unit"}                   | ${QueryRuntimeError}
+    ${400}       | ${"invalid_date"}                   | ${QueryRuntimeError}
+    ${400}       | ${"limit_exceeded"}                 | ${QueryRuntimeError}
+    ${400}       | ${"stack_overflow"}                 | ${QueryRuntimeError}
+    ${400}       | ${"invalid_computed_field_access"}  | ${QueryRuntimeError}
+    ${400}       | ${"disabled_feature"}               | ${QueryRuntimeError}
+    ${400}       | ${"invalid_receiver"}               | ${QueryRuntimeError}
+    ${400}       | ${"invalid_timestamp_field_access"} | ${QueryRuntimeError}
+    ${400}       | ${"invalid_request"}                | ${InvalidRequestError}
+    ${400}       | ${"abort"}                          | ${AbortError}
+    ${400}       | ${"constraint_failure"}             | ${ConstraintFailureError}
+    ${401}       | ${"unauthorized"}                   | ${AuthenticationError}
+    ${403}       | ${"forbidden"}                      | ${AuthorizationError}
+    ${409}       | ${"contended_transaction"}          | ${ContendedTransactionError}
+    ${429}       | ${"throttle"}                       | ${ThrottlingError}
+    ${440}       | ${"time_out"}                       | ${QueryTimeoutError}
+    ${503}       | ${"time_out"}                       | ${QueryTimeoutError}
+    ${500}       | ${"internal_error"}                 | ${ServiceInternalError}
+    ${400}       | ${"some unhandled code"}            | ${QueryRuntimeError}
+    ${401}       | ${"some unhandled code"}            | ${QueryRuntimeError}
+    ${403}       | ${"some unhandled code"}            | ${QueryRuntimeError}
+    ${409}       | ${"some unhandled code"}            | ${QueryRuntimeError}
+    ${429}       | ${"some unhandled code"}            | ${QueryRuntimeError}
+    ${440}       | ${"some unhandled code"}            | ${QueryRuntimeError}
+    ${500}       | ${"some unhandled code"}            | ${QueryRuntimeError}
+    ${503}       | ${"some unhandled code"}            | ${QueryRuntimeError}
+    ${999}       | ${"some unhandled code"}            | ${QueryRuntimeError}
+    ${undefined} | ${"some unhandled code"}            | ${QueryRuntimeError}
   `(
     "QueryFailures with status '$httpStatus' and code '$code' are correctly mapped to $errorClass",
     ({ httpStatus, code, errorClass }) => {
@@ -75,14 +78,19 @@ describe("query", () => {
           message: "error message",
           code,
           abort: "oops",
+          constraint_failures: [{ message: "oops" }],
         },
       };
 
       const error = getServiceError(failure, httpStatus);
-
       expect(error).toBeInstanceOf(errorClass);
       expect(error.httpStatus).toEqual(httpStatus);
       expect(error.code).toEqual(code);
+
+      const error_no_status = getServiceError(failure);
+      expect(error_no_status).toBeInstanceOf(errorClass);
+      expect(error_no_status.httpStatus).toBeUndefined();
+      expect(error_no_status.code).toEqual(code);
     },
   );
 });

--- a/__tests__/unit/error.test.ts
+++ b/__tests__/unit/error.test.ts
@@ -1,0 +1,88 @@
+import {
+  AbortError,
+  AuthenticationError,
+  AuthorizationError,
+  ContendedTransactionError,
+  InvalidRequestError,
+  QueryCheckError,
+  QueryFailure,
+  QueryRuntimeError,
+  QueryTimeoutError,
+  ServiceError,
+  ServiceInternalError,
+  ServiceTimeoutError,
+  ThrottlingError,
+} from "../../src";
+import { getServiceError } from "../../src/errors";
+
+describe("query", () => {
+  it.each`
+    httpStatus | code                                    | errorClass
+    ${400}     | ${"invalid_function_definition"}        | ${QueryCheckError}
+    ${400}     | ${"invalid_identifier"}                 | ${QueryCheckError}
+    ${400}     | ${"invalid_query"}                      | ${QueryCheckError}
+    ${400}     | ${"invalid_syntax"}                     | ${QueryCheckError}
+    ${400}     | ${"invalid_type"}                       | ${QueryCheckError}
+    ${400}     | ${"unbound_variable"}                   | ${QueryRuntimeError}
+    ${400}     | ${"index_out_of_bounds"}                | ${QueryRuntimeError}
+    ${400}     | ${"type_mismatch"}                      | ${QueryRuntimeError}
+    ${400}     | ${"invalid_argument"}                   | ${QueryRuntimeError}
+    ${400}     | ${"invalid_bounds"}                     | ${QueryRuntimeError}
+    ${400}     | ${"invalid_regex"}                      | ${QueryRuntimeError}
+    ${400}     | ${"constraint_failure"}                 | ${QueryRuntimeError}
+    ${400}     | ${"invalid_schema"}                     | ${QueryRuntimeError}
+    ${400}     | ${"invalid_document_id"}                | ${QueryRuntimeError}
+    ${400}     | ${"document_id_exists"}                 | ${QueryRuntimeError}
+    ${400}     | ${"document_not_found"}                 | ${QueryRuntimeError}
+    ${400}     | ${"document_deleted"}                   | ${QueryRuntimeError}
+    ${400}     | ${"invalid_function_invocation"}        | ${QueryRuntimeError}
+    ${400}     | ${"invalid_index_invocation"}           | ${QueryRuntimeError}
+    ${400}     | ${"null_value"}                         | ${QueryRuntimeError}
+    ${400}     | ${"invalid_null_access"}                | ${QueryRuntimeError}
+    ${400}     | ${"invalid_cursor"}                     | ${QueryRuntimeError}
+    ${400}     | ${"permission_denied"}                  | ${QueryRuntimeError}
+    ${400}     | ${"invalid_effect"}                     | ${QueryRuntimeError}
+    ${400}     | ${"invalid_write"}                      | ${QueryRuntimeError}
+    ${400}     | ${"internal_failure"}                   | ${QueryRuntimeError}
+    ${400}     | ${"divide_by_zero"}                     | ${QueryRuntimeError}
+    ${400}     | ${"invalid_id"}                         | ${QueryRuntimeError}
+    ${400}     | ${"invalid_secret"}                     | ${QueryRuntimeError}
+    ${400}     | ${"invalid_time"}                       | ${QueryRuntimeError}
+    ${400}     | ${"invalid_unit"}                       | ${QueryRuntimeError}
+    ${400}     | ${"invalid_date"}                       | ${QueryRuntimeError}
+    ${400}     | ${"limit_exceeded"}                     | ${QueryRuntimeError}
+    ${400}     | ${"stack_overflow"}                     | ${QueryRuntimeError}
+    ${400}     | ${"invalid_computed_field_access"}      | ${QueryRuntimeError}
+    ${400}     | ${"disabled_feature"}                   | ${QueryRuntimeError}
+    ${400}     | ${"invalid_receiver"}                   | ${QueryRuntimeError}
+    ${400}     | ${"invalid_timestamp_field_access"}     | ${QueryRuntimeError}
+    ${400}     | ${"invalid_request"}                    | ${InvalidRequestError}
+    ${400}     | ${"abort"}                              | ${AbortError}
+    ${401}     | ${"unauthorized"}                       | ${AuthenticationError}
+    ${403}     | ${"forbidden"}                          | ${AuthorizationError}
+    ${409}     | ${"contended_transaction"}              | ${ContendedTransactionError}
+    ${429}     | ${"throttle"}                           | ${ThrottlingError}
+    ${440}     | ${"time_out"}                           | ${QueryTimeoutError}
+    ${503}     | ${"time_out"}                           | ${ServiceTimeoutError}
+    ${500}     | ${"internal_error"}                     | ${ServiceInternalError}
+    ${999}     | ${"error_not_yet_subclassed_in_client"} | ${ServiceError}
+    ${-1}      | ${"error_not_yet_subclassed_in_client"} | ${ServiceError}
+  `(
+    "QueryFailures with status '$httpStatus' and code '$code' are correctly mapped to $errorClass",
+    ({ httpStatus, code, errorClass }) => {
+      const failure: QueryFailure = {
+        error: {
+          message: "error message",
+          code,
+          abort: "oops",
+        },
+      };
+
+      const error = getServiceError(failure, httpStatus);
+
+      expect(error).toBeInstanceOf(errorClass);
+      expect(error.httpStatus).toEqual(httpStatus);
+      expect(error.code).toEqual(code);
+    },
+  );
+});

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -8,7 +8,6 @@ import {
   QueryTimeoutError,
   ServiceError,
   ServiceInternalError,
-  ServiceTimeoutError,
   ThrottlingError,
 } from "../../src";
 import { getClient, getDefaultHTTPClientOptions } from "../client";
@@ -38,7 +37,7 @@ describe("query", () => {
     ${999}     | ${ServiceError}         | ${{ code: "error_not_yet_subclassed_in_client", message: "who knows!!!" }}
     ${429}     | ${ThrottlingError}      | ${{ code: "throttle", message: "too much" }}
     ${500}     | ${ServiceInternalError} | ${{ code: "internal_error", message: "unexpected error" }}
-    ${503}     | ${ServiceTimeoutError}  | ${{ code: "time_out", message: "too slow on our side" }}
+    ${503}     | ${QueryTimeoutError}    | ${{ code: "time_out", message: "too slow on our side" }}
   `(
     "throws an $expectedErrorType on a $httpStatus",
     async ({ httpStatus, expectedErrorType, expectedErrorFields }) => {
@@ -67,7 +66,7 @@ describe("query", () => {
     ${999}     | ${ServiceError}         | ${{ code: "error_not_yet_subclassed_in_client", message: "who knows!!!" }}
     ${429}     | ${ThrottlingError}      | ${{ code: "throttle", message: "too much" }}
     ${500}     | ${ServiceInternalError} | ${{ code: "internal_error", message: "unexpected error" }}
-    ${503}     | ${ServiceTimeoutError}  | ${{ code: "time_out", message: "too slow on our side" }}
+    ${503}     | ${QueryTimeoutError}    | ${{ code: "time_out", message: "too slow on our side" }}
   `(
     "Includes a summary when not present in error field but present at top-level",
     async ({ httpStatus, expectedErrorType, expectedErrorFields }) => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -791,7 +791,7 @@ export class StreamClient<T extends QueryValue = any> {
       if (deserializedEvent.type === "error") {
         // Errors sent from Fauna are assumed fatal
         this.close();
-        throw getServiceError(deserializedEvent, -1);
+        throw getServiceError(deserializedEvent);
       }
 
       this.#last_ts = deserializedEvent.txn_ts;

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,21 +4,12 @@ import {
   endpoints,
 } from "./client-configuration";
 import {
-  AuthenticationError,
-  AuthorizationError,
   ClientClosedError,
   ClientError,
-  ContendedTransactionError,
   FaunaError,
-  InvalidRequestError,
   NetworkError,
   ProtocolError,
-  QueryCheckError,
-  QueryRuntimeError,
-  QueryTimeoutError,
   ServiceError,
-  ServiceInternalError,
-  ServiceTimeoutError,
   ThrottlingError,
   getServiceError,
 } from "./errors";
@@ -113,7 +104,7 @@ export class Client {
    */
   constructor(
     clientConfiguration?: ClientConfiguration,
-    httpClient?: HTTPClient
+    httpClient?: HTTPClient,
   ) {
     this.#clientConfiguration = {
       ...DEFAULT_CLIENT_CONFIG,
@@ -169,7 +160,7 @@ export class Client {
   close() {
     if (this.#isClosed) {
       throw new ClientClosedError(
-        "Your client is closed. You cannot close it again."
+        "Your client is closed. You cannot close it again.",
       );
     }
     this.#httpClient.close();
@@ -220,7 +211,7 @@ export class Client {
    */
   paginate<T extends QueryValue>(
     iterable: Page<T> | EmbeddedSet | Query,
-    options?: QueryOptions
+    options?: QueryOptions,
   ): SetIterator<T> {
     if (iterable instanceof Query) {
       return SetIterator.fromQuery(this, iterable, options);
@@ -242,11 +233,7 @@ export class Client {
    *
    * @throws {@link ServiceError} Fauna emitted an error. The ServiceError will be
    *   one of ServiceError's child classes if the error can be further categorized,
-   *   or a concrete ServiceError if it cannot. ServiceError child types are
-   *   {@link AuthenticationError}, {@link AuthorizationError}, {@link QueryCheckError}
-   *   {@link QueryRuntimeError}, {@link QueryTimeoutError}, {@link ServiceInternalError}
-   *   {@link ServiceTimeoutError}, {@link ThrottlingError}, {@link ContendedTransactionError},
-   *   {@link InvalidRequestError}.
+   *   or a concrete ServiceError if it cannot.
    *   You can use either the type, or the underlying httpStatus + code to determine
    *   the root cause.
    * @throws {@link ProtocolError} the client a HTTP error not sent by Fauna.
@@ -258,11 +245,11 @@ export class Client {
    */
   async query<T extends QueryValue>(
     query: Query,
-    options?: QueryOptions
+    options?: QueryOptions,
   ): Promise<QuerySuccess<T>> {
     if (this.#isClosed) {
       throw new ClientClosedError(
-        "Your client is closed. No further requests can be issued."
+        "Your client is closed. No further requests can be issued.",
       );
     }
 
@@ -330,14 +317,13 @@ export class Client {
    *  );
    * ```
    */
-  // TODO: implement options
   stream<T extends QueryValue>(
     tokenOrQuery: StreamToken | Query,
-    options?: Partial<StreamClientConfiguration>
+    options?: Partial<StreamClientConfiguration>,
   ): StreamClient<T> {
     if (this.#isClosed) {
       throw new ClientClosedError(
-        "Your client is closed. No further requests can be issued."
+        "Your client is closed. No further requests can be issued.",
       );
     }
 
@@ -364,7 +350,7 @@ export class Client {
   async #queryWithRetries<T extends QueryValue>(
     queryInterpolation: string | QueryInterpolation,
     options?: QueryOptions,
-    attempt = 0
+    attempt = 0,
   ): Promise<QuerySuccess<T>> {
     const maxBackoff =
       this.clientConfiguration.max_backoff ?? DEFAULT_CLIENT_CONFIG.max_backoff;
@@ -419,7 +405,7 @@ export class Client {
       "A client level error occurred. Fauna was not called.",
       {
         cause: e,
-      }
+      },
     );
   }
 
@@ -440,7 +426,7 @@ export class Client {
       throw new TypeError(
         "You must provide a secret to the driver. Set it \
 in an environmental variable named FAUNA_SECRET or pass it to the Client\
- constructor."
+ constructor.",
       );
     }
     return maybeSecret;
@@ -455,7 +441,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
       partialClientConfig.endpoint === undefined
     ) {
       throw new TypeError(
-        `ClientConfiguration option endpoint must be defined.`
+        `ClientConfiguration option endpoint must be defined.`,
       );
     }
 
@@ -478,7 +464,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
   async #query<T extends QueryValue>(
     queryInterpolation: string | QueryInterpolation,
     options?: QueryOptions,
-    attempt = 0
+    attempt = 0,
   ): Promise<QuerySuccess<T>> {
     try {
       const requestConfig = {
@@ -565,12 +551,12 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
 
   #setHeaders(
     fromObject: QueryOptions,
-    headerObject: Record<string, string | number>
+    headerObject: Record<string, string | number>,
   ): void {
     const setHeader = <V>(
       header: string,
       value: V | undefined,
-      transform: (v: V) => string | number = (v) => String(v)
+      transform: (v: V) => string | number = (v) => String(v),
     ) => {
       if (value !== undefined) {
         headerObject[header] = transform(value);
@@ -586,7 +572,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
     setHeader("x-query-tags", fromObject.query_tags, (tags) =>
       Object.entries(tags)
         .map((tag) => tag.join("="))
-        .join(",")
+        .join(","),
     );
     setHeader("x-last-txn-ts", this.#lastTxnTs, (v) => v); // x-last-txn-ts doesn't get stringified
     setHeader("x-driver-env", Client.#driverEnvHeader);
@@ -610,7 +596,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
     required_options.forEach((option) => {
       if (config[option] === undefined) {
         throw new TypeError(
-          `ClientConfiguration option '${option}' must be defined.`
+          `ClientConfiguration option '${option}' must be defined.`,
         );
       }
     });
@@ -621,7 +607,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
 
     if (config.client_timeout_buffer_ms <= 0) {
       throw new RangeError(
-        `'client_timeout_buffer_ms' must be greater than zero.`
+        `'client_timeout_buffer_ms' must be greater than zero.`,
       );
     }
 
@@ -669,10 +655,9 @@ export class StreamClient<T extends QueryValue = any> {
    *  const streamClient = client.stream(streamToken);
    * ```
    */
-  // TODO: implement stream-specific options
   constructor(
     token: StreamToken | (() => Promise<StreamToken>),
-    clientConfiguration: StreamClientConfiguration
+    clientConfiguration: StreamClientConfiguration,
   ) {
     if (token instanceof StreamToken) {
       this.#query = () => Promise.resolve(token);
@@ -694,16 +679,16 @@ export class StreamClient<T extends QueryValue = any> {
    */
   start(
     onEvent: (event: StreamEventData<T> | StreamEventStatus) => void,
-    onError?: (error: Error) => void
+    onError?: (error: Error) => void,
   ) {
     if (typeof onEvent !== "function") {
       throw new TypeError(
-        `Expected a function as the 'onEvent' argument, but received ${typeof onEvent}. Please provide a valid function.`
+        `Expected a function as the 'onEvent' argument, but received ${typeof onEvent}. Please provide a valid function.`,
       );
     }
     if (onError && typeof onError !== "function") {
       throw new TypeError(
-        `Expected a function as the 'onError' argument, but received ${typeof onError}. Please provide a valid function.`
+        `Expected a function as the 'onError' argument, but received ${typeof onError}. Please provide a valid function.`,
       );
     }
     const run = async () => {
@@ -732,7 +717,7 @@ export class StreamClient<T extends QueryValue = any> {
         if (!(maybeStreamToken instanceof StreamToken)) {
           throw new ClientError(
             `Error requesting a stream token. Expected a StreamToken as the query result, but received ${typeof maybeStreamToken}. Your query must return the result of '<Set>.toStream' or '<Set>.changesOn')\n` +
-              `Query result: ${JSON.stringify(maybeStreamToken, null)}`
+              `Query result: ${JSON.stringify(maybeStreamToken, null)}`,
           );
         }
         return maybeStreamToken;
@@ -744,7 +729,7 @@ export class StreamClient<T extends QueryValue = any> {
       const backoffMs =
         Math.min(
           Math.random() * 2 ** this.#connectionAttempts,
-          this.#clientConfiguration.max_backoff
+          this.#clientConfiguration.max_backoff,
         ) * 1_000;
 
       try {
@@ -780,7 +765,7 @@ export class StreamClient<T extends QueryValue = any> {
   }
 
   async *#startStream(
-    start_ts?: number
+    start_ts?: number,
   ): AsyncGenerator<StreamEventData<T> | StreamEventStatus> {
     // Safety: This method must only be called after a stream token has been acquired
     const streamToken = this.#streamToken as StreamToken;
@@ -806,8 +791,7 @@ export class StreamClient<T extends QueryValue = any> {
       if (deserializedEvent.type === "error") {
         // Errors sent from Fauna are assumed fatal
         this.close();
-        // TODO: replace with appropriate class from existing error heirarchy
-        throw getServiceError(deserializedEvent, 400);
+        throw getServiceError(deserializedEvent, -1);
       }
 
       this.#last_ts = deserializedEvent.txn_ts;
@@ -841,7 +825,7 @@ export class StreamClient<T extends QueryValue = any> {
     required_options.forEach((option) => {
       if (config[option] === undefined) {
         throw new TypeError(
-          `ClientConfiguration option '${option}' must be defined.`
+          `ClientConfiguration option '${option}' must be defined.`,
         );
       }
     });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -21,7 +21,7 @@ export class ServiceError extends FaunaError {
   /**
    * The HTTP Status Code of the error.
    */
-  readonly httpStatus: number;
+  readonly httpStatus?: number;
   /**
    * A code for the error. Codes indicate the cause of the error.
    * It is safe to write programmatic logic against the code. They are
@@ -38,7 +38,7 @@ export class ServiceError extends FaunaError {
    */
   readonly constraint_failures?: Array<ConstraintFailure>;
 
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure.error.message);
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
@@ -71,7 +71,7 @@ export class ServiceError extends FaunaError {
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryRuntimeError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryRuntimeError);
@@ -89,7 +89,7 @@ export class QueryRuntimeError extends ServiceError {
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryCheckError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryCheckError);
@@ -105,12 +105,40 @@ export class QueryCheckError extends ServiceError {
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class InvalidRequestError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InvalidRequestError);
     }
     this.name = "InvalidRequestError";
+  }
+}
+
+/**
+ * A runtime error due to failing schema constraints.
+ *
+ * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
+ */
+export class ConstraintFailureError extends ServiceError {
+  /**
+   * The user provided value passed to the originating `abort()` call.
+   * Present only when the query encountered an `abort()` call, which is denoted
+   * by the error code `"abort"`
+   */
+  readonly constraint_failures: Array<ConstraintFailure>;
+
+  constructor(
+    failure: QueryFailure & {
+      error: { constraint_failures: Array<ConstraintFailure> };
+    },
+    httpStatus?: number,
+  ) {
+    super(failure, httpStatus);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, QueryCheckError);
+    }
+    this.name = "ConstraintFailureError";
+    this.constraint_failures = failure.error.constraint_failures;
   }
 }
 
@@ -129,7 +157,7 @@ export class AbortError extends ServiceError {
 
   constructor(
     failure: QueryFailure & { error: { abort: QueryValue } },
-    httpStatus: number,
+    httpStatus?: number,
   ) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
@@ -145,7 +173,7 @@ export class AbortError extends ServiceError {
  * used.
  */
 export class AuthenticationError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AuthenticationError);
@@ -159,7 +187,7 @@ export class AuthenticationError extends ServiceError {
  * permission to perform the requested action.
  */
 export class AuthorizationError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AuthorizationError);
@@ -172,7 +200,7 @@ export class AuthorizationError extends ServiceError {
  * An error due to a contended transaction.
  */
 export class ContendedTransactionError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InvalidRequestError);
@@ -186,7 +214,7 @@ export class ContendedTransactionError extends ServiceError {
  * and thus the request could not be served.
  */
 export class ThrottlingError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ThrottlingError);
@@ -196,11 +224,16 @@ export class ThrottlingError extends ServiceError {
 }
 
 /**
- * A failure due to the timeout being exceeded, but the timeout
- * was set lower than the query's expected processing time.
- * This response is distinguished from a ServiceTimeoutException
- * in that a QueryTimeoutError shows Fauna behaving in an expected
- * manner.
+ * A failure due to the query timeout being exceeded.
+ *
+ * This error can have one of two sources:
+ *     1. Fauna is behaving expectedly, but the query timeout provided was too
+ *        aggressive and lower than the query's expected processing time.
+ *     2. Fauna was not available to service the request before the timeout was
+ *        reached.
+ *
+ * In either case, consider increasing the `query_timeout_ms` configuration for
+ * your client.
  */
 export class QueryTimeoutError extends ServiceError {
   /**
@@ -208,7 +241,7 @@ export class QueryTimeoutError extends ServiceError {
    */
   readonly stats?: { [key: string]: number };
 
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryTimeoutError);
@@ -222,26 +255,12 @@ export class QueryTimeoutError extends ServiceError {
  * ServiceInternalError indicates Fauna failed unexpectedly.
  */
 export class ServiceInternalError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: number) {
+  constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ServiceInternalError);
     }
     this.name = "ServiceInternalError";
-  }
-}
-
-/**
- * ServiceTimeoutError indicates Fauna was not available to servce
- * the request before the timeout was reached.
- */
-export class ServiceTimeoutError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: number) {
-    super(failure, httpStatus);
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, ServiceTimeoutError);
-    }
-    this.name = "ServiceTimeoutError";
   }
 }
 
@@ -315,52 +334,13 @@ export class ProtocolError extends FaunaError {
 
 export const getServiceError = (
   failure: QueryFailure,
-  httpStatus: number,
+  httpStatus?: number,
 ): ServiceError => {
   const failureCode = failure.error.code;
 
   switch (failureCode) {
-    case "invalid_function_definition":
-    case "invalid_identifier":
     case "invalid_query":
-    case "invalid_syntax":
-    case "invalid_type":
       return new QueryCheckError(failure, httpStatus);
-
-    case "unbound_variable":
-    case "index_out_of_bounds":
-    case "type_mismatch":
-    case "invalid_argument":
-    case "invalid_bounds":
-    case "invalid_regex":
-    case "constraint_failure":
-    case "invalid_schema":
-    case "invalid_document_id":
-    case "document_id_exists":
-    case "document_not_found":
-    case "document_deleted":
-    case "invalid_function_invocation":
-    case "invalid_index_invocation":
-    case "null_value":
-    case "invalid_null_access":
-    case "invalid_cursor":
-    case "permission_denied":
-    case "invalid_effect":
-    case "invalid_write":
-    case "internal_failure":
-    case "divide_by_zero":
-    case "invalid_id":
-    case "invalid_secret":
-    case "invalid_time":
-    case "invalid_unit":
-    case "invalid_date":
-    case "limit_exceeded":
-    case "stack_overflow":
-    case "invalid_computed_field_access":
-    case "disabled_feature":
-    case "invalid_receiver":
-    case "invalid_timestamp_field_access":
-      return new QueryRuntimeError(failure, httpStatus);
 
     case "invalid_request":
       return new InvalidRequestError(failure, httpStatus);
@@ -372,7 +352,18 @@ export const getServiceError = (
           httpStatus,
         );
       }
-      return new QueryRuntimeError(failure, httpStatus);
+      break;
+
+    case "constraint_failure":
+      if (failure.error.constraint_failures !== undefined) {
+        return new ConstraintFailureError(
+          failure as QueryFailure & {
+            error: { constraint_failures: Array<ConstraintFailure> };
+          },
+          httpStatus,
+        );
+      }
+      break;
 
     case "unauthorized":
       return new AuthenticationError(failure, httpStatus);
@@ -387,17 +378,11 @@ export const getServiceError = (
       return new ThrottlingError(failure, httpStatus);
 
     case "time_out":
-      if (httpStatus === 440) {
-        return new QueryTimeoutError(failure, 440);
-      } else if (httpStatus === 503) {
-        return new ServiceTimeoutError(failure, 503);
-      }
-      break;
+      return new QueryTimeoutError(failure, httpStatus);
 
     case "internal_error":
       return new ServiceInternalError(failure, httpStatus);
   }
 
-  // default
-  return new ServiceError(failure, httpStatus ?? -1);
+  return new QueryRuntimeError(failure, httpStatus);
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -121,9 +121,7 @@ export class InvalidRequestError extends ServiceError {
  */
 export class ConstraintFailureError extends ServiceError {
   /**
-   * The user provided value passed to the originating `abort()` call.
-   * Present only when the query encountered an `abort()` call, which is denoted
-   * by the error code `"abort"`
+   * The list of constraints that failed.
    */
   readonly constraint_failures: Array<ConstraintFailure>;
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -71,7 +71,7 @@ export class ServiceError extends FaunaError {
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryRuntimeError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 400) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryRuntimeError);
@@ -89,7 +89,7 @@ export class QueryRuntimeError extends ServiceError {
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryCheckError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 400) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryCheckError);
@@ -105,7 +105,7 @@ export class QueryCheckError extends ServiceError {
  * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class InvalidRequestError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 400) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InvalidRequestError);
@@ -129,7 +129,7 @@ export class AbortError extends ServiceError {
 
   constructor(
     failure: QueryFailure & { error: { abort: QueryValue } },
-    httpStatus: 400
+    httpStatus: number,
   ) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
@@ -145,7 +145,7 @@ export class AbortError extends ServiceError {
  * used.
  */
 export class AuthenticationError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 401) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AuthenticationError);
@@ -159,7 +159,7 @@ export class AuthenticationError extends ServiceError {
  * permission to perform the requested action.
  */
 export class AuthorizationError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 403) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, AuthorizationError);
@@ -172,7 +172,7 @@ export class AuthorizationError extends ServiceError {
  * An error due to a contended transaction.
  */
 export class ContendedTransactionError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 409) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, InvalidRequestError);
@@ -186,7 +186,7 @@ export class ContendedTransactionError extends ServiceError {
  * and thus the request could not be served.
  */
 export class ThrottlingError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 429) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ThrottlingError);
@@ -208,7 +208,7 @@ export class QueryTimeoutError extends ServiceError {
    */
   readonly stats?: { [key: string]: number };
 
-  constructor(failure: QueryFailure, httpStatus: 440) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, QueryTimeoutError);
@@ -222,7 +222,7 @@ export class QueryTimeoutError extends ServiceError {
  * ServiceInternalError indicates Fauna failed unexpectedly.
  */
 export class ServiceInternalError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 500) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ServiceInternalError);
@@ -236,7 +236,7 @@ export class ServiceInternalError extends ServiceError {
  * the request before the timeout was reached.
  */
 export class ServiceTimeoutError extends ServiceError {
-  constructor(failure: QueryFailure, httpStatus: 503) {
+  constructor(failure: QueryFailure, httpStatus: number) {
     super(failure, httpStatus);
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, ServiceTimeoutError);
@@ -313,48 +313,91 @@ export class ProtocolError extends FaunaError {
   }
 }
 
-const QUERY_CHECK_FAILURE_CODES = [
-  "invalid_function_definition",
-  "invalid_identifier",
-  "invalid_query",
-  "invalid_syntax",
-  "invalid_type",
-];
-
 export const getServiceError = (
   failure: QueryFailure,
-  httpStatus: number
+  httpStatus: number,
 ): ServiceError => {
-  switch (httpStatus) {
-    case 400:
-      if (QUERY_CHECK_FAILURE_CODES.includes(failure.error.code)) {
-        return new QueryCheckError(failure, httpStatus);
-      }
-      if (failure.error.code === "invalid_request") {
-        return new InvalidRequestError(failure, httpStatus);
-      }
-      if (failure.error.code === "abort" && failure.error.abort !== undefined) {
+  const failureCode = failure.error.code;
+
+  switch (failureCode) {
+    case "invalid_function_definition":
+    case "invalid_identifier":
+    case "invalid_query":
+    case "invalid_syntax":
+    case "invalid_type":
+      return new QueryCheckError(failure, httpStatus);
+
+    case "unbound_variable":
+    case "index_out_of_bounds":
+    case "type_mismatch":
+    case "invalid_argument":
+    case "invalid_bounds":
+    case "invalid_regex":
+    case "constraint_failure":
+    case "invalid_schema":
+    case "invalid_document_id":
+    case "document_id_exists":
+    case "document_not_found":
+    case "document_deleted":
+    case "invalid_function_invocation":
+    case "invalid_index_invocation":
+    case "null_value":
+    case "invalid_null_access":
+    case "invalid_cursor":
+    case "permission_denied":
+    case "invalid_effect":
+    case "invalid_write":
+    case "internal_failure":
+    case "divide_by_zero":
+    case "invalid_id":
+    case "invalid_secret":
+    case "invalid_time":
+    case "invalid_unit":
+    case "invalid_date":
+    case "limit_exceeded":
+    case "stack_overflow":
+    case "invalid_computed_field_access":
+    case "disabled_feature":
+    case "invalid_receiver":
+    case "invalid_timestamp_field_access":
+      return new QueryRuntimeError(failure, httpStatus);
+
+    case "invalid_request":
+      return new InvalidRequestError(failure, httpStatus);
+
+    case "abort":
+      if (failure.error.abort !== undefined) {
         return new AbortError(
           failure as QueryFailure & { error: { abort: QueryValue } },
-          httpStatus
+          httpStatus,
         );
       }
       return new QueryRuntimeError(failure, httpStatus);
-    case 401:
+
+    case "unauthorized":
       return new AuthenticationError(failure, httpStatus);
-    case 403:
+
+    case "forbidden":
       return new AuthorizationError(failure, httpStatus);
-    case 409:
+
+    case "contended_transaction":
       return new ContendedTransactionError(failure, httpStatus);
-    case 429:
+
+    case "throttle":
       return new ThrottlingError(failure, httpStatus);
-    case 440:
-      return new QueryTimeoutError(failure, httpStatus);
-    case 500:
+
+    case "time_out":
+      if (httpStatus === 440) {
+        return new QueryTimeoutError(failure, 440);
+      } else if (httpStatus === 503) {
+        return new ServiceTimeoutError(failure, 503);
+      }
+      break;
+
+    case "internal_error":
       return new ServiceInternalError(failure, httpStatus);
-    case 503:
-      return new ServiceTimeoutError(failure, httpStatus);
-    default:
-      return new ServiceError(failure, httpStatus);
   }
+
+  // default
+  return new ServiceError(failure, httpStatus ?? -1);
 };

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -110,8 +110,15 @@ export class FetchClient implements HTTPClient, HTTPStreamClient {
       }
       const reader = body.getReader();
 
-      for await (const line of readLines(reader)) {
-        yield line;
+      try {
+        for await (const line of readLines(reader)) {
+          yield line;
+        }
+      } catch (error) {
+        throw new NetworkError(
+          "The network connection encountered a problem while streaming events.",
+          { cause: error },
+        );
       }
     }
 

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -1,7 +1,7 @@
 /** following reference needed to include types for experimental fetch API in Node */
 /// <reference lib="dom" />
 
-import { getServiceError, NetworkError, ServiceError } from "../errors";
+import { getServiceError, NetworkError } from "../errors";
 import { QueryFailure } from "../wire-protocol";
 import {
   HTTPClient,
@@ -95,7 +95,7 @@ export class FetchClient implements HTTPClient, HTTPStreamClient {
           "The network connection encountered a problem.",
           {
             cause: error,
-          }
+          },
         );
       });
       const status = response.status;

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -1,7 +1,8 @@
 /** following reference needed to include types for experimental fetch API in Node */
 /// <reference lib="dom" />
 
-import { NetworkError, ServiceError } from "../errors";
+import { getServiceError, NetworkError, ServiceError } from "../errors";
+import { QueryFailure } from "../wire-protocol";
 import {
   HTTPClient,
   HTTPClientOptions,
@@ -99,8 +100,8 @@ export class FetchClient implements HTTPClient, HTTPStreamClient {
       });
       const status = response.status;
       if (!(status >= 200 && status < 400)) {
-        const body = await response.json();
-        throw new ServiceError(body, status);
+        const failure: QueryFailure = await response.json();
+        throw getServiceError(failure, status);
       }
 
       const body = response.body;

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -205,7 +205,12 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
           .request(httpRequestHeaders)
           .setEncoding("utf8")
           .on("error", (error: any) => {
-            rejectPromise(error);
+            rejectPromise(
+              new NetworkError(
+                "The network connection encountered a problem while streaming events.",
+                { cause: error },
+              ),
+            );
           })
           .on("response", onResponse);
 
@@ -218,7 +223,12 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
 
         req.end();
       } catch (error) {
-        rejectPromise(error);
+        rejectPromise(
+          new NetworkError(
+            "The network connection encountered a problem while streaming events.",
+            { cause: error },
+          ),
+        );
       }
     });
   }

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -13,7 +13,7 @@ import {
   HTTPStreamRequest,
   StreamAdapter,
 } from "./http-client";
-import { ServiceError, NetworkError, getServiceError } from "../errors";
+import { NetworkError, getServiceError } from "../errors";
 import { QueryFailure } from "../wire-protocol";
 
 // alias http2 types
@@ -60,7 +60,7 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
     if (!NodeHTTP2Client.#clients.has(clientKey)) {
       NodeHTTP2Client.#clients.set(
         clientKey,
-        new NodeHTTP2Client(httpClientOptions)
+        new NodeHTTP2Client(httpClientOptions),
       );
     }
     // we know that we have a client here
@@ -99,7 +99,7 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
             "The network connection encountered a problem.",
             {
               cause: error,
-            }
+            },
           );
         }
         memoizedError = error;
@@ -170,10 +170,10 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
     return new Promise<HTTPResponse>((resolvePromise, rejectPromise) => {
       let req: ClientHttp2Stream;
       const onResponse = (
-        http2ResponseHeaders: IncomingHttpHeaders & IncomingHttpStatusHeader
+        http2ResponseHeaders: IncomingHttpHeaders & IncomingHttpStatusHeader,
       ) => {
         const status = Number(
-          http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS]
+          http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS],
         );
         let responseData = "";
 
@@ -242,10 +242,10 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
 
     let req: ClientHttp2Stream;
     const onResponse = (
-      http2ResponseHeaders: IncomingHttpHeaders & IncomingHttpStatusHeader
+      http2ResponseHeaders: IncomingHttpHeaders & IncomingHttpStatusHeader,
     ) => {
       const status = Number(
-        http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS]
+        http2ResponseHeaders[http2.constants.HTTP2_HEADER_STATUS],
       );
       if (!(status >= 200 && status < 400)) {
         // Get the error body and then throw an error
@@ -258,8 +258,6 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
         });
 
         // Once the response is finished, resolve the promise
-        // TODO: The Client contains the information for how to parse an error
-        // into the appropriate class, so lift this logic out of the HTTPClient.
         req.on("end", () => {
           try {
             const failure: QueryFailure = JSON.parse(responseData);
@@ -268,7 +266,7 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
             rejectChunk(
               new NetworkError("Could not process query failure.", {
                 cause: error,
-              })
+              }),
             );
           }
         });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   AuthorizationError,
   ClientError,
   ClientClosedError,
+  ConstraintFailureError,
   ContendedTransactionError,
   FaunaError,
   InvalidRequestError,
@@ -21,7 +22,6 @@ export {
   QueryTimeoutError,
   ServiceError,
   ServiceInternalError,
-  ServiceTimeoutError,
   ThrottlingError,
 } from "./errors";
 export { type Query, fql } from "./query-builder";


### PR DESCRIPTION
Ticket(s): [FE-5040](https://faunadb.atlassian.net/browse/FE-5040)

## Problem
`HTTPStreamClient` implementations need to throw service errors if the initial response is a non-200. The logic to convert `QueryFailure` responses to the appropriate sub type is currently a private method on the `Client` class.

The `StreamClient` also needs to throw the appropriate service error class when a type=error event is received.

## Solution
Move the `Client.#getServiceError` method to the `errors` module so it can be reused. Use it to throw the appropriate error if a type=error event is received or if the initial response is a non-200.

There is no http status code associated with streaming error events, so we should update error handling to rely first on the error code, then fallback to the base `ServiceError` if the error code is not matched.

## Out of scope
N/A

## Testing
Updated tests to check that the appropriate errors are thrown.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-5040]: https://faunadb.atlassian.net/browse/FE-5040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ