### PR TITLE
[DOCS-2634] Document `Client.paginate()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ See the [Fauna Documentation](https://docs.fauna.com/fauna/current/) for additio
     - [Typescript support](#typescript-support)
     - [Query options](#query-options)
     - [Query statistics](#query-statistics)
+  - [Pagination](#pagination)
   - [Event Streaming (beta)](#event-streaming-beta)
   - [Client configuration](#client-configuration)
     - [Environment variables](#environment-variables)
@@ -274,6 +275,42 @@ Example output:
   storage_bytes_write: 0,
   contention_retries: 0
 }
+```
+
+## Pagination
+
+By default, FQL paginates returned sets that contain more than 16 items.
+Use the `Client.paginate()` method to iterate through pages of results.
+
+`Client.paginate()` accepts the same [query options](#query-options) as
+`Client.query()`.
+
+Change the default items per page using FQL's `<set>.pageSize()` method.
+
+```typescript
+import { fql, Client, type SetIterator, type QueryValue } from "fauna";
+
+const client = new Client();
+
+// Adjust `pageSize()` size as needed.
+const query = fql`
+  Product
+    .byName("limes")
+    .pageSize(60) { description }`;
+
+const options = {
+  query_timeout_ms: 60_000,
+};
+
+const pages: SetIterator<QueryValue> = client.paginate(query, options);
+
+for await (const products of pages) {
+  for (const product of products) {
+    console.log(product)
+  }
+}
+
+client.close();
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -279,8 +279,7 @@ Example output:
 
 ## Pagination
 
-By default, FQL paginates returned sets that contain more than 16 items.
-Use the `Client.paginate()` method to iterate through pages of results.
+Use the `Client.paginate()` method to iterate sets that contain more than one page of results.
 
 `Client.paginate()` accepts the same [query options](#query-options) as
 `Client.query()`.


### PR DESCRIPTION
Ticket(s): [DOCS-2634](https://faunadb.atlassian.net/browse/DOCS-2634)

## Problem

We don't currently document the `Client.paginate()` method.

## Solution

Add documentation to the README.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[DOCS-2634]: https://faunadb.atlassian.net/browse/DOCS-2634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ