### PR TITLE
[DOCS-2744] Replace FQLX beta doc links in `beta` branch

### DIFF
--- a/src/client-configuration.ts
+++ b/src/client-configuration.ts
@@ -88,7 +88,7 @@ export interface ClientConfiguration {
   linearized?: boolean;
 
   /**
-   * Controls what Javascript type to deserialize {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#long | Fauna longs} to.
+   * Controls what Javascript type to deserialize {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#long | Fauna longs} to.
    * Use 'number' to deserialize longs to number. Use 'bigint' to deserialize to bigint. Defaults to 'number'.
    * Note, for extremely large maginitude numbers Javascript's number will lose precision; as Javascript's
    * 'number' can only support +/- 2^53-1 whereas Fauna's long is 64 bit. If this is detected, a warning will
@@ -167,7 +167,8 @@ export type StreamClientConfiguration = {
   httpStreamClient: HTTPStreamClient;
 
   /**
-   * Controls what Javascript type to deserialize {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#long | Fauna longs} to.
+   * Controls what Javascript type to deserialize {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#long | Fauna longs} to.
+   *
    * @see {@link ClientConfiguration.long_type}
    */
   long_type: "number" | "bigint";

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -67,8 +67,6 @@ export class ServiceError extends FaunaError {
  * QueryRuntimeError's occur when a bug in your query causes an invalid execution
  * to be requested.
  * The 'code' field will vary based on the specific error cause.
- *
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryRuntimeError extends ServiceError {
   constructor(failure: QueryFailure, httpStatus?: number) {
@@ -85,8 +83,6 @@ export class QueryRuntimeError extends ServiceError {
 /**
  * An error due to a "compile-time" check of the query
  * failing.
- *
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class QueryCheckError extends ServiceError {
   constructor(failure: QueryFailure, httpStatus?: number) {
@@ -101,8 +97,6 @@ export class QueryCheckError extends ServiceError {
 /**
  * An error due to an invalid request to Fauna. Either the request body was not
  * valid JSON or did not conform to the API specification
- *
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class InvalidRequestError extends ServiceError {
   constructor(failure: QueryFailure, httpStatus?: number) {
@@ -116,8 +110,6 @@ export class InvalidRequestError extends ServiceError {
 
 /**
  * A runtime error due to failing schema constraints.
- *
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class ConstraintFailureError extends ServiceError {
   /**
@@ -142,8 +134,6 @@ export class ConstraintFailureError extends ServiceError {
 
 /**
  * An error due to calling the FQL `abort` function.
- *
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/errors#runtime-errors}
  */
 export class AbortError extends ServiceError {
   /**

--- a/src/values/date-time.ts
+++ b/src/values/date-time.ts
@@ -17,7 +17,7 @@ import * as PARSE from "../regex";
  * Converting to a Javascript date before sending to Fauna could result in loss
  * of precision.
  *
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/builtin_functions/time/time}
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#time}
  */
 export class TimeStub {
   readonly isoString: string;
@@ -104,7 +104,7 @@ export class TimeStub {
  * be taken to specify the desired date, since Javascript `Date`s use local
  * timezone info by default.
  *
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/builtin_functions/date/date}
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#date}
  */
 export class DateStub {
   readonly dateString: string;

--- a/src/values/doc.ts
+++ b/src/values/doc.ts
@@ -19,6 +19,8 @@ import { TimeStub } from "./date-time";
  *  const id = userDocumentReference.id;
  *  id === "101"; // returns true
  * ```
+ *
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#special}
  */
 export class DocumentReference {
   readonly coll: Module;
@@ -57,6 +59,8 @@ export class DocumentReference {
  *
  * @remarks The {@link Document} class cannot be generic because classes cannot
  * extend generic type arguments.
+ *
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#special}
  */
 export class Document extends DocumentReference {
   readonly ts: TimeStub;
@@ -97,6 +101,8 @@ export class Document extends DocumentReference {
  *  const collectionName = namedDocumentReference.name;
  *  collectionName === "Users"; // returns true
  * ```
+ *
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#special}
  */
 export class NamedDocumentReference {
   readonly coll: Module;
@@ -145,6 +151,8 @@ export class NamedDocumentReference {
  *
  *  const metadata = userCollection.data.metadata;
  * ```
+ *
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#special}
  */
 export class NamedDocument<
   T extends QueryValueObject = Record<string, never>,
@@ -187,6 +195,8 @@ export class NamedDocument<
  *  `);
  *  const allUserDocuments = response.data;
  * ```
+ *
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#module}
  */
 export class Module {
   readonly name: string;
@@ -221,6 +231,8 @@ export class Module {
  *    const color = maybeUserDocument.color;
  *  }
  * ```
+ *
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#nulldoc}
  */
 export class NullDocument {
   readonly ref: DocumentReference | NamedDocumentReference;

--- a/src/values/set.ts
+++ b/src/values/set.ts
@@ -4,7 +4,7 @@ import { QueryOptions, QueryValue } from "../wire-protocol";
 
 /**
  * A materialized view of a Set.
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#set}
  */
 export class Page<T extends QueryValue> {
   /** A materialized page of data */
@@ -26,7 +26,7 @@ export class Page<T extends QueryValue> {
  * A un-materialized Set. Typically received when a materialized Set contains
  * another set, the EmbeddedSet does not contain any data to avoid potential
  * issues such as self-reference and infinite recursion
- * @see {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#set}
+ * @see {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#set}
  */
 export class EmbeddedSet {
   /**

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -53,7 +53,7 @@ export interface QueryOptions {
   linearized?: boolean;
 
   /**
-   * Controls what Javascript type to deserialize {@link https://fqlx-beta--fauna-docs.netlify.app/fqlx/beta/reference/language/types#long | Fauna longs} to.
+   * Controls what Javascript type to deserialize {@link https://docs.fauna.com/fauna/current/reference/fql_reference/types#long | Fauna longs} to.
    * Use 'number' to deserialize longs to number. Use 'bigint' to deserialize to bigint. Defaults to 'number'.
    * Note, for extremely large maginitude numbers Javascript's number will lose precision; as Javascript's
    * 'number' can only support +/- 2^53-1 whereas Fauna's long is 64 bit. If this is detected, a warning will


### PR DESCRIPTION
Ticket(s): [DOCS-2744](https://faunadb.atlassian.net/browse/DOCS-2744)

## Problem
Links to docs are still using the old FQL beta urls.

## Solution
Update the links!

## Out of scope
N/A

## Testing
No functional changes.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[DOCS-2744]: https://faunadb.atlassian.net/browse/DOCS-2744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ