### PR TITLE
[DOCS-2646] Document `<stream>.close()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,33 @@ stream.start(
 );
 ```
 
+_Close a stream_
+
+Use the `<stream>.close()` method to close a stream.
+
+```javascript
+import { Client, fql } from "fauna"
+const client = new Client()
+
+const stream = await client.stream(fql`Product.all().toStream()`)
+
+let count = 0;
+for await (const event of stream) {
+  console.log(event.type)
+  console.log(event.data)
+  count++;
+
+  // Close the stream after 2 events
+  if (count === 2) {
+    console.log("Closing the stream ...")
+    stream.close()
+    break;
+  }
+}
+
+client.close();
+```
+
 # Contributing
 
 Any contributions are from the community are greatly appreciated!


### PR DESCRIPTION
Ticket(s): [DOCS-2646](https://faunadb.atlassian.net/browse/DOCS-2646)

## Problem

The `<stream>.close()` method for Event Streaming is undocumented.

## Solution

Documents the method.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

[DOCS-2646]: https://faunadb.atlassian.net/browse/DOCS-2646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ