### PR TITLE
Add encoding/decoding for Fauna Bytes

### DIFF
--- a/__tests__/integration/template-format.test.ts
+++ b/__tests__/integration/template-format.test.ts
@@ -127,18 +127,18 @@ describe("query using template format", () => {
   });
 
   it("succeeds with an ArrayBuffer variable", async () => {
-    const buf = new Uint8Array([1, 2, 3]).buffer;
-    const queryBuilder = fql`${buf}`;
-    const response = await client.query<ArrayBuffer>(queryBuilder);
-    expect(response.data).toEqual(buf);
+    const buf = new Uint8Array([1, 2, 3]);
+    const queryBuilder = fql`${buf.buffer}`;
+    const response = await client.query<Uint8Array>(queryBuilder);
     expect(response.data.byteLength).toBe(3);
+    expect(response.data).toEqual(buf);
   });
 
   it("succeeds with ArrayBufferView variables", async () => {
     const buf1 = new Uint8Array([1]);
     const buf2 = new Int8Array([1, 2]);
-    const buf3 = new Uint16Array([1, 2, 3]);
-    const buf4 = new Int16Array([1, 2, 3, 4]);
+    const buf3 = new Uint16Array([100, 200, 300]);
+    const buf4 = new Int16Array([100, 200, 300, 400]);
     const queryBuilder = fql`
       [
         ${buf1},
@@ -148,17 +148,17 @@ describe("query using template format", () => {
       ]
     `;
     const response =
-      await client.query<[ArrayBuffer, ArrayBuffer, ArrayBuffer, ArrayBuffer]>(
+      await client.query<[Uint8Array, Uint8Array, Uint8Array, Uint8Array]>(
         queryBuilder,
       );
-    expect(response.data[0]).toEqual(buf1.buffer);
     expect(response.data[0].byteLength).toEqual(1);
-    expect(response.data[1]).toEqual(buf2.buffer);
+    expect(response.data[0]).toEqual(buf1);
     expect(response.data[1].byteLength).toEqual(2);
-    expect(response.data[2]).toEqual(buf3.buffer);
+    expect(new Int8Array(response.data[1].buffer)).toEqual(buf2);
     expect(response.data[2].byteLength).toEqual(6);
-    expect(response.data[3]).toEqual(buf4.buffer);
+    expect(new Uint16Array(response.data[2].buffer)).toEqual(buf3);
     expect(response.data[3].byteLength).toEqual(8);
+    expect(new Int16Array(response.data[3].buffer)).toEqual(buf4);
   });
 
   it("succeeds using Node Buffer to encode strings", async () => {

--- a/__tests__/unit/tagged-format.test.ts
+++ b/__tests__/unit/tagged-format.test.ts
@@ -26,13 +26,6 @@ testArrayBufferViewU8[2] = 2;
 testArrayBufferViewU8[3] = 3;
 testArrayBufferViewU8[4] = 4;
 
-const testArrayBufferI8 = new ArrayBuffer(4);
-const testArrayBufferViewI8 = new Int8Array(testArrayBufferI8);
-testArrayBufferViewI8[1] = -1;
-testArrayBufferViewI8[2] = -2;
-testArrayBufferViewI8[3] = -3;
-testArrayBufferViewI8[4] = -4;
-
 describe.each`
   long_type
   ${"number"}
@@ -215,7 +208,6 @@ describe.each`
         ),
         bytes_array_buffer: testArrayBufferU8,
         bytes_array_buffer_view_u8: testArrayBufferViewU8,
-        bytes_array_buffer_view_i8: testArrayBufferViewI8,
         bytes_from_string: testBuffer,
         // Set types
         // TODO: uncomment to add test once core accepts `@set` tagged values
@@ -257,9 +249,6 @@ describe.each`
     });
     expect(backToObj.bytes_array_buffer_view_u8).toStrictEqual({
       "@bytes": Buffer.from(testArrayBufferViewU8).toString("base64"),
-    });
-    expect(backToObj.bytes_array_buffer_view_i8).toStrictEqual({
-      "@bytes": Buffer.from(testArrayBufferViewI8).toString("base64"),
     });
     expect(backToObj.bytes_from_string).toStrictEqual({
       "@bytes": testBytesBase64,

--- a/package.json
+++ b/package.json
@@ -58,8 +58,5 @@
     "suiteNameTemplate": "{filepath}",
     "classNameTemplate": "{classname}",
     "titleTemplate": "{title}"
-  },
-  "dependencies": {
-    "base64-js": "^1.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "suiteNameTemplate": "{filepath}",
     "classNameTemplate": "{classname}",
     "titleTemplate": "{title}"
+  },
+  "dependencies": {
+    "base64-js": "^1.5.1"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export {
   ServiceInternalError,
   ThrottlingError,
 } from "./errors";
-export { type Query, fql } from "./query-builder";
+export { type Query, type QueryArgument, fql } from "./query-builder";
 export { LONG_MAX, LONG_MIN, TaggedTypeFormat } from "./tagged-type";
 export {
   type QueryValueObject,

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -7,7 +7,12 @@ import type {
   QueryOptions,
 } from "./wire-protocol";
 
-export type QueryArgument = QueryValue | Query | Date | ArrayBufferView;
+export type QueryArgument =
+  | QueryValue
+  | Query
+  | Date
+  | ArrayBuffer
+  | Uint8Array;
 
 /**
  * Creates a new Query. Accepts template literal inputs.

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -7,6 +7,8 @@ import type {
   QueryOptions,
 } from "./wire-protocol";
 
+export type QueryArgument = QueryValue | Query | Date | ArrayBufferView;
+
 /**
  * Creates a new Query. Accepts template literal inputs.
  * @param queryFragments - a {@link TemplateStringsArray} that constitute
@@ -25,7 +27,7 @@ import type {
  */
 export function fql(
   queryFragments: ReadonlyArray<string>,
-  ...queryArgs: (QueryValue | Query)[]
+  ...queryArgs: QueryArgument[]
 ): Query {
   return new Query(queryFragments, ...queryArgs);
 }
@@ -37,11 +39,11 @@ export function fql(
  */
 export class Query {
   readonly #queryFragments: ReadonlyArray<string>;
-  readonly #queryArgs: (QueryValue | Query)[];
+  readonly #queryArgs: QueryArgument[];
 
   constructor(
     queryFragments: ReadonlyArray<string>,
-    ...queryArgs: (QueryValue | Query)[]
+    ...queryArgs: QueryArgument[]
   ) {
     if (
       queryFragments.length === 0 ||

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -276,21 +276,23 @@ const encode = (input: QueryValue): QueryValue => {
   // anything here would be unreachable code
 };
 
-function base64toBuffer(value: string): Uint8Array {
-  const isNodeJs =
-    typeof process !== "undefined" && process.versions && process.versions.node;
+const isNodeJs =
+  typeof process !== "undefined" && process && process.release?.name === "node";
 
+function base64toBuffer(value: string): Uint8Array {
   if (isNodeJs) {
     const binaryBuffer = Buffer.from(value, "base64");
     return Uint8Array.from(binaryBuffer);
   } else {
+    const _atob = atob ?? window?.atob;
+
     if (typeof window?.atob === "undefined") {
       throw new ClientError(
         `Error encoding argument. This environment does not support atob. Provided: ${value}`,
       );
     }
 
-    const binaryString = window.atob(value);
+    const binaryString = _atob(value);
     const bytes = new Uint8Array(binaryString.length);
     for (let i = 0; i < binaryString.length; i++) {
       bytes[i] = binaryString.charCodeAt(i);
@@ -310,15 +312,12 @@ function bufferToBase64(value: ArrayBuffer | ArrayBufferView): string {
     arr = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
   }
 
-  const isNodeJs =
-    typeof process !== "undefined" &&
-    process &&
-    process.release?.name === "node";
-
   if (isNodeJs) {
     return Buffer.from(arr).toString("base64");
   } else {
-    if (typeof window?.btoa === "undefined") {
+    const _btoa = btoa ?? window?.btoa;
+
+    if (typeof _btoa === "undefined") {
       throw new ClientError(
         `Error encoding argument. This environment does not support btoa. Provided: ${value}`,
       );
@@ -328,6 +327,6 @@ function bufferToBase64(value: ArrayBuffer | ArrayBufferView): string {
     for (let i = 0; i < arr.length; i++) {
       binaryString += String.fromCharCode(arr[i]);
     }
-    return window.btoa(binaryString);
+    return _btoa(binaryString);
   }
 }

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -1,3 +1,5 @@
+import base64 from "base64-js";
+
 import { ClientError } from "./errors";
 import {
   DateStub,
@@ -276,29 +278,8 @@ const encode = (input: QueryValue): QueryValue => {
   // anything here would be unreachable code
 };
 
-const isNodeJs =
-  typeof process !== "undefined" && process && process.release?.name === "node";
-
 function base64toBuffer(value: string): Uint8Array {
-  if (isNodeJs) {
-    const binaryBuffer = Buffer.from(value, "base64");
-    return Uint8Array.from(binaryBuffer);
-  } else {
-    const _atob = atob ?? window?.atob;
-
-    if (typeof window?.atob === "undefined") {
-      throw new ClientError(
-        `Error encoding argument. This environment does not support atob. Provided: ${value}`,
-      );
-    }
-
-    const binaryString = _atob(value);
-    const bytes = new Uint8Array(binaryString.length);
-    for (let i = 0; i < binaryString.length; i++) {
-      bytes[i] = binaryString.charCodeAt(i);
-    }
-    return bytes;
-  }
+  return base64.toByteArray(value);
 }
 
 function bufferToBase64(value: ArrayBuffer | ArrayBufferView): string {
@@ -312,21 +293,5 @@ function bufferToBase64(value: ArrayBuffer | ArrayBufferView): string {
     arr = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
   }
 
-  if (isNodeJs) {
-    return Buffer.from(arr).toString("base64");
-  } else {
-    const _btoa = btoa ?? window?.btoa;
-
-    if (typeof _btoa === "undefined") {
-      throw new ClientError(
-        `Error encoding argument. This environment does not support btoa. Provided: ${value}`,
-      );
-    }
-
-    let binaryString = "";
-    for (let i = 0; i < arr.length; i++) {
-      binaryString += String.fromCharCode(arr[i]);
-    }
-    return _btoa(binaryString);
-  }
+  return base64.fromByteArray(arr);
 }

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -311,7 +311,9 @@ function bufferToBase64(value: ArrayBuffer | ArrayBufferView): string {
   }
 
   const isNodeJs =
-    typeof process !== "undefined" && process.versions && process.versions.node;
+    typeof process !== "undefined" &&
+    process &&
+    process.release?.name === "node";
 
   if (isNodeJs) {
     return Buffer.from(arr).toString("base64");

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -319,7 +319,7 @@ export type QueryValue =
   | Page<QueryValue>
   | EmbeddedSet
   | StreamToken
-  | ArrayBuffer;
+  | Uint8Array;
 
 export type StreamRequest = {
   token: string;

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -318,7 +318,8 @@ export type QueryValue =
   | NullDocument
   | Page<QueryValue>
   | EmbeddedSet
-  | StreamToken;
+  | StreamToken
+  | ArrayBuffer;
 
 export type StreamRequest = {
   token: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,11 +1271,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,6 +1271,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
Ticket(s): [FE-4855](https://faunadb.atlassian.net/browse/BT-4855)

## Problem
Fauna supports a Bytes type which is transmitted as a base-64-encoded string
https://docs.fauna.com/fauna/current/reference/fql_reference/types#bytes

We also had a type issue where JS Date could not be used as a query argument, so I added Date to arg type as well as a test.

## Solution
Add encoding and decoding of the Bytes type

## Result
`ArrayBuffer`s, `TypedArray`s (e.g. Uint8Array, Int32Array, etc.), as well as Node's `Buffer` classes are encoded to Fauna Bytes.

Fauna Bytes are decoded into `Uint8Array`, which can be used to create the desired type.

See tests for examples.

## Out of scope
N/A

## Testing
Added unit and integration tests for Node. Browser is untested.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-4855]: https://faunadb.atlassian.net/browse/FE-4855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ