### PR TITLE
Fix error code for ThrottlingError

### DIFF
--- a/__tests__/unit/error.test.ts
+++ b/__tests__/unit/error.test.ts
@@ -56,7 +56,7 @@ describe("query", () => {
     ${401}       | ${"unauthorized"}                   | ${AuthenticationError}
     ${403}       | ${"forbidden"}                      | ${AuthorizationError}
     ${409}       | ${"contended_transaction"}          | ${ContendedTransactionError}
-    ${429}       | ${"throttle"}                       | ${ThrottlingError}
+    ${429}       | ${"limit_exceeded"}                 | ${ThrottlingError}
     ${440}       | ${"time_out"}                       | ${QueryTimeoutError}
     ${503}       | ${"time_out"}                       | ${QueryTimeoutError}
     ${500}       | ${"internal_error"}                 | ${ServiceInternalError}

--- a/__tests__/unit/error.test.ts
+++ b/__tests__/unit/error.test.ts
@@ -44,7 +44,7 @@ describe("query", () => {
     ${400}       | ${"invalid_time"}                   | ${QueryRuntimeError}
     ${400}       | ${"invalid_unit"}                   | ${QueryRuntimeError}
     ${400}       | ${"invalid_date"}                   | ${QueryRuntimeError}
-    ${400}       | ${"limit_exceeded"}                 | ${QueryRuntimeError}
+    ${400}       | ${"limit_exceeded"}                 | ${ThrottlingError}
     ${400}       | ${"stack_overflow"}                 | ${QueryRuntimeError}
     ${400}       | ${"invalid_computed_field_access"}  | ${QueryRuntimeError}
     ${400}       | ${"disabled_feature"}               | ${QueryRuntimeError}

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -35,7 +35,7 @@ describe("query", () => {
     ${403}     | ${AuthorizationError}   | ${{ code: "forbidden", message: "nope" }}
     ${440}     | ${QueryTimeoutError}    | ${{ code: "time_out", message: "too slow - increase your timeout" }}
     ${999}     | ${ServiceError}         | ${{ code: "error_not_yet_subclassed_in_client", message: "who knows!!!" }}
-    ${429}     | ${ThrottlingError}      | ${{ code: "throttle", message: "too much" }}
+    ${429}     | ${ThrottlingError}      | ${{ code: "limit_exceeded", message: "too much" }}
     ${500}     | ${ServiceInternalError} | ${{ code: "internal_error", message: "unexpected error" }}
     ${503}     | ${QueryTimeoutError}    | ${{ code: "time_out", message: "too slow on our side" }}
   `(
@@ -64,7 +64,7 @@ describe("query", () => {
     ${403}     | ${AuthorizationError}   | ${{ code: "forbidden", message: "nope" }}
     ${440}     | ${QueryTimeoutError}    | ${{ code: "time_out", message: "too slow - increase your timeout" }}
     ${999}     | ${ServiceError}         | ${{ code: "error_not_yet_subclassed_in_client", message: "who knows!!!" }}
-    ${429}     | ${ThrottlingError}      | ${{ code: "throttle", message: "too much" }}
+    ${429}     | ${ThrottlingError}      | ${{ code: "limit_exceeded", message: "too much" }}
     ${500}     | ${ServiceInternalError} | ${{ code: "internal_error", message: "unexpected error" }}
     ${503}     | ${QueryTimeoutError}    | ${{ code: "time_out", message: "too slow on our side" }}
   `(
@@ -97,7 +97,7 @@ describe("query", () => {
 
   it("retries throttling errors and then succeeds", async () => {
     const throttlingResponse = JSON.stringify({
-      error: { code: "throttle", message: "too much" },
+      error: { code: "limit_exceeded", message: "too much" },
       summary: "the summary",
     });
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -362,7 +362,7 @@ export const getServiceError = (
     case "contended_transaction":
       return new ContendedTransactionError(failure, httpStatus);
 
-    case "throttle":
+    case "limit_exceeded":
       return new ThrottlingError(failure, httpStatus);
 
     case "time_out":

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -362,7 +362,7 @@ export const getServiceError = (
     case "contended_transaction":
       return new ContendedTransactionError(failure, httpStatus);
 
-    case "limit_exceeded":
+    case "throttle":
       return new ThrottlingError(failure, httpStatus);
 
     case "time_out":


### PR DESCRIPTION
Ticket(s): FE-###

## Problem
The error code for 429 throttling errors is `limit_exceeded`, but we are using `throttle`, an incorrect placeholder from preexisting code.

See canonical list of error codes from core:
https://github.com/fauna/core/blob/395d2a23d83a95c42102d5b9d02d2b49b191720c/ext/api/src/main/scala/api/fql2/FQL2Response.scala#L281

## Solution
Update the error code.

## Result
Correct handling of 429 limit-exceeded errors.

## Out of scope
Run query limits tests locally by default: [FE-5412](https://faunadb.atlassian.net/browse/FE-5412)

## Testing
Concourse pipeline covers tests for exceeding query limits.

I installed the local driver in an App I have that is known to have throughput issues. Before this fix, I incorrectly get `QueryRuntimeError`'s. After this fix, I correctly get `ThrottlingError`'s and automatic retries work.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-5412]: https://faunadb.atlassian.net/browse/FE-5412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ