### PR TITLE
Allow more retries when testing query limits

### DIFF
--- a/__tests__/integration/query-limits.test.ts
+++ b/__tests__/integration/query-limits.test.ts
@@ -19,7 +19,7 @@ beforeAll(async () => {
       Key.create({ role: "admin", database: ${limitedDbName} }) { secret }
     } else {
       abort("Database not found.")
-    }`
+    }`,
     )
     .then((res) => res.data.secret)
     .catch((err) => {
@@ -28,7 +28,7 @@ beforeAll(async () => {
     });
 
   for (let i = 0; i < 5; i++) {
-    clients.push(getClient({ secret: secret }));
+    clients.push(getClient({ secret: secret, max_attempts: 30 }));
   }
 });
 
@@ -57,7 +57,7 @@ maybeDescribe("Query with limits enabled", () => {
             console.log(err);
             throw err;
           });
-      })
+      }),
     );
 
     expect(throttled).toBeTruthy();


### PR DESCRIPTION
Ticket(s): FE-###

## Problem
The query limits test requires a successful result after retrying. However, the current iteration requires too many retries, and a `ThrottlingError` is thrown instead. 

## Solution
Configure the clients to allow more retries during this test, so we ensure that a successful response is ultimately returned.

## Result
Hopefully this test passes.

## Out of scope

## Testing
I'm having trouble getting the query limits tests running locally, so relying on concourse pipeline to validate the change.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
