### PR TITLE
update concourse node versions

### DIFF
--- a/concourse/scripts/docker-compose-fauna.yml
+++ b/concourse/scripts/docker-compose-fauna.yml
@@ -8,7 +8,7 @@ services:
       - "8443:8443"
 
   node-lts:
-    image: node:18.16-alpine3.16
+    image: node:18.20-alpine3.19
     container_name: node-lts
     depends_on:
       - faunadb
@@ -27,7 +27,7 @@ services:
         yarn test:integration
 
   node-current:
-    image: node:20.2-alpine3.16
+    image: node:20.13-alpine3.19
     container_name: node-current
     depends_on:
       - faunadb


### PR DESCRIPTION
Ticket(s): FE-###

## Problem
We updated typescript which is only compatible with Node 18.18 or higher. Current pipeline pulls Node 18.16.

## Solution
Update node images.

## Testing
No changes. Should be fine once newer images are provided.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
