### PR TITLE
Support users embedding fql snippets in objects and arrays

### DIFF
--- a/__tests__/integration/query-limits.test.ts
+++ b/__tests__/integration/query-limits.test.ts
@@ -1,5 +1,5 @@
-import { Client, fql, Module } from "../../src";
-import { getClient, getDefaultSecretAndEndpoint } from "../client";
+import { Client, fql } from "../../src";
+import { getClient } from "../client";
 
 const rootClient = getClient();
 const clients = new Array<Client>();

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -518,7 +518,73 @@ describe("query can encode / decode QueryValue correctly", () => {
       if (e instanceof TypeError) {
         expect(e.name).toBe("TypeError");
         expect(e.message).toBe(
-          "Passing undefined as a QueryValue is not supported",
+          "Passing undefined as a QueryArgument is not supported",
+        );
+      }
+    }
+  });
+
+  it("symbol arguments throw a TypeError", async () => {
+    expect.assertions(2);
+    // whack in a symbol
+    // @ts-expect-error Type 'symbol' is not assignable to type 'QueryValue'
+    let symbolValue: QueryValue = Symbol("foo");
+    try {
+      await client.query(fql`{ foo: ${symbolValue} }`);
+    } catch (e) {
+      if (e instanceof TypeError) {
+        expect(e.name).toBe("TypeError");
+        expect(e.message).toBe(
+          "Passing symbol as a QueryArgument is not supported",
+        );
+      }
+    }
+  });
+
+  it("function arguments throw a TypeError", async () => {
+    expect.assertions(2);
+    // whack in a function
+    let fnValue: QueryValue = () => {};
+    try {
+      await client.query(fql`{ foo: ${fnValue} }`);
+    } catch (e) {
+      if (e instanceof TypeError) {
+        expect(e.name).toBe("TypeError");
+        expect(e.message).toBe(
+          "Passing function as a QueryArgument is not supported",
+        );
+      }
+    }
+  });
+
+  it("symbol arguments throw a TypeError in arguments", async () => {
+    expect.assertions(2);
+    // whack in a symbol
+    // @ts-expect-error Type 'symbol' is not assignable to type 'QueryValue'
+    let symbolValue: QueryValue = Symbol("foo");
+    try {
+      await client.query(fql`foo`, { arguments: { foo: symbolValue } });
+    } catch (e) {
+      if (e instanceof TypeError) {
+        expect(e.name).toBe("TypeError");
+        expect(e.message).toBe(
+          "Passing symbol as a QueryArgument is not supported",
+        );
+      }
+    }
+  });
+
+  it("function arguments throw a TypeError in arguments", async () => {
+    expect.assertions(2);
+    // whack in a function
+    let fnValue: QueryValue = () => {};
+    try {
+      await client.query(fql`foo`, { arguments: { foo: fnValue } });
+    } catch (e) {
+      if (e instanceof TypeError) {
+        expect(e.name).toBe("TypeError");
+        expect(e.message).toBe(
+          "Passing function as a QueryArgument is not supported",
         );
       }
     }

--- a/__tests__/unit/query-builder.test.ts
+++ b/__tests__/unit/query-builder.test.ts
@@ -3,68 +3,62 @@ import { fql } from "../../src";
 describe("fql method producing Querys", () => {
   it("parses with no variables", () => {
     const queryBuilder = fql`'foo'.length`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({ fql: ["'foo'.length"] });
-    expect(queryRequest.arguments).toBeUndefined();
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({ fql: ["'foo'.length"] });
   });
 
   it("parses with a string variable", () => {
     const str = "foo";
     const queryBuilder = fql`${str}.length`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: [{ value: "foo" }, ".length"],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with a number variable", () => {
     const num = 8;
     const queryBuilder = fql`'foo'.length == ${num}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: ["'foo'.length == ", { value: { "@int": "8" } }],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with a boolean variable", () => {
     const bool = true;
     const queryBuilder = fql`val.enabled == ${bool}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: ["val.enabled == ", { value: true }],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with a null variable", () => {
     const queryBuilder = fql`value: ${null}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: ["value: ", { value: null }],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with an object variable", () => {
     const obj = { foo: "bar", bar: "baz" };
     const queryBuilder = fql`value: ${obj}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: [
         "value: ",
         { object: { bar: { value: "baz" }, foo: { value: "bar" } } },
       ],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with an object variable having a toQuery property", () => {
     const obj = { foo: "bar", bar: "baz", toQuery: "hehe" };
     const queryBuilder = fql`value: ${obj}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: [
         "value: ",
         {
@@ -76,14 +70,13 @@ describe("fql method producing Querys", () => {
         },
       ],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with an array variable", () => {
     const arr = [1, 2, 3];
     const queryBuilder = fql`value: ${arr}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: [
         "value: ",
         {
@@ -96,18 +89,16 @@ describe("fql method producing Querys", () => {
         ,
       ],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with multiple variables", () => {
     const str = "bar";
     const num = 17;
     const queryBuilder = fql`${str}.length == ${num + 3}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: [{ value: "bar" }, ".length == ", { value: { "@int": "20" } }],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses nested expressions", () => {
@@ -115,15 +106,14 @@ describe("fql method producing Querys", () => {
     const num = 17;
     const innerQuery = fql`Math.add(${num}, 3)`;
     const queryBuilder = fql`${str}.length == ${innerQuery}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: [
         { value: "baz" },
         ".length == ",
         { fql: ["Math.add(", { value: { "@int": "17" } }, ", 3)"] },
       ],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses deep nested expressions", () => {
@@ -135,8 +125,8 @@ describe("fql method producing Querys", () => {
     const deeperBuilder = fql`Math.add(${num}, 3)`;
     const innerQuery = fql`Math.add(${deeperBuilder}, ${otherNum})`;
     const queryBuilder = fql`${deepFirst}.length == ${innerQuery}`;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: [
         { fql: ["(", { value: "baz" }, " + ", { value: "bar" }, ")"] },
         ".length == ",
@@ -151,7 +141,6 @@ describe("fql method producing Querys", () => {
         },
       ],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with FQL string interpolation", async () => {
@@ -160,14 +149,13 @@ describe("fql method producing Querys", () => {
       let name = ${codeName}
       "Hello, #{name}"
     `;
-    const queryRequest = queryBuilder.toQuery();
-    expect(queryRequest.query).toEqual({
+    const fragment = queryBuilder.encode();
+    expect(fragment).toEqual({
       fql: [
         "\n      let name = ",
         { value: "Alice" },
         '\n      "Hello, #{name}"\n    ',
       ],
     });
-    expect(queryRequest.arguments).toBeUndefined();
   });
 });

--- a/__tests__/unit/query-builder.test.ts
+++ b/__tests__/unit/query-builder.test.ts
@@ -5,7 +5,7 @@ describe("fql method producing Querys", () => {
     const queryBuilder = fql`'foo'.length`;
     const queryRequest = queryBuilder.toQuery();
     expect(queryRequest.query).toEqual({ fql: ["'foo'.length"] });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with a string variable", () => {
@@ -15,7 +15,7 @@ describe("fql method producing Querys", () => {
     expect(queryRequest.query).toEqual({
       fql: [{ value: "foo" }, ".length"],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with a number variable", () => {
@@ -25,7 +25,7 @@ describe("fql method producing Querys", () => {
     expect(queryRequest.query).toEqual({
       fql: ["'foo'.length == ", { value: { "@int": "8" } }],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with a boolean variable", () => {
@@ -35,7 +35,7 @@ describe("fql method producing Querys", () => {
     expect(queryRequest.query).toEqual({
       fql: ["val.enabled == ", { value: true }],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with a null variable", () => {
@@ -44,7 +44,7 @@ describe("fql method producing Querys", () => {
     expect(queryRequest.query).toEqual({
       fql: ["value: ", { value: null }],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with an object variable", () => {
@@ -52,9 +52,12 @@ describe("fql method producing Querys", () => {
     const queryBuilder = fql`value: ${obj}`;
     const queryRequest = queryBuilder.toQuery();
     expect(queryRequest.query).toEqual({
-      fql: ["value: ", { value: { bar: "baz", foo: "bar" } }],
+      fql: [
+        "value: ",
+        { object: { bar: { value: "baz" }, foo: { value: "bar" } } },
+      ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with an object variable having a toQuery property", () => {
@@ -62,9 +65,18 @@ describe("fql method producing Querys", () => {
     const queryBuilder = fql`value: ${obj}`;
     const queryRequest = queryBuilder.toQuery();
     expect(queryRequest.query).toEqual({
-      fql: ["value: ", { value: { bar: "baz", foo: "bar", toQuery: "hehe" } }],
+      fql: [
+        "value: ",
+        {
+          object: {
+            bar: { value: "baz" },
+            foo: { value: "bar" },
+            toQuery: { value: "hehe" },
+          },
+        },
+      ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with an array variable", () => {
@@ -74,10 +86,17 @@ describe("fql method producing Querys", () => {
     expect(queryRequest.query).toEqual({
       fql: [
         "value: ",
-        { value: [{ "@int": "1" }, { "@int": "2" }, { "@int": "3" }] },
+        {
+          array: [
+            { value: { "@int": "1" } },
+            { value: { "@int": "2" } },
+            { value: { "@int": "3" } },
+          ],
+        },
+        ,
       ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with multiple variables", () => {
@@ -88,7 +107,7 @@ describe("fql method producing Querys", () => {
     expect(queryRequest.query).toEqual({
       fql: [{ value: "bar" }, ".length == ", { value: { "@int": "20" } }],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses nested expressions", () => {
@@ -104,7 +123,7 @@ describe("fql method producing Querys", () => {
         { fql: ["Math.add(", { value: { "@int": "17" } }, ", 3)"] },
       ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses deep nested expressions", () => {
@@ -132,38 +151,7 @@ describe("fql method producing Querys", () => {
         },
       ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
-  });
-
-  it("adds headers if passed in", () => {
-    const str = "baz";
-    const num = 17;
-    const innerQuery = fql`Math.add(${num}, 3)`;
-    const queryBuilder = fql`${str}.length == ${innerQuery}`;
-    const queryRequest = queryBuilder.toQuery({
-      linearized: true,
-      query_timeout_ms: 600,
-      max_contention_retries: 4,
-      query_tags: { a: "tag" },
-      traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00",
-      typecheck: false,
-    });
-    expect(queryRequest).toMatchObject({
-      linearized: true,
-      query_timeout_ms: 600,
-      max_contention_retries: 4,
-      query_tags: { a: "tag" },
-      traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-5669e71839eca76b-00",
-      typecheck: false,
-    });
-    expect(queryRequest.query).toEqual({
-      fql: [
-        { value: "baz" },
-        ".length == ",
-        { fql: ["Math.add(", { value: { "@int": "17" } }, ", 3)"] },
-      ],
-    });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 
   it("parses with FQL string interpolation", async () => {
@@ -180,6 +168,6 @@ describe("fql method producing Querys", () => {
         '\n      "Hello, #{name}"\n    ',
       ],
     });
-    expect(queryRequest.arguments).toStrictEqual({});
+    expect(queryRequest.arguments).toBeUndefined();
   });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -26,6 +26,7 @@ import { TaggedTypeFormat } from "./tagged-type";
 import { getDriverEnv } from "./util/environment";
 import { EmbeddedSet, Page, SetIterator, StreamToken } from "./values";
 import {
+  EncodedObject,
   isQueryFailure,
   isQuerySuccess,
   QueryOptions,
@@ -253,7 +254,15 @@ export class Client {
       );
     }
 
-    const request = query.toQuery(options?.arguments);
+    const request: QueryRequest = {
+      query: query.encode(),
+    };
+
+    if (options?.arguments) {
+      request.arguments = TaggedTypeFormat.encode(
+        options.arguments,
+      ) as EncodedObject;
+    }
 
     return this.#queryWithRetries(request, options);
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,11 +28,11 @@ import { EmbeddedSet, Page, SetIterator, StreamToken } from "./values";
 import {
   isQueryFailure,
   isQuerySuccess,
-  QueryInterpolation,
+  QueryOptions,
+  QueryRequest,
   StreamEvent,
   StreamEventData,
   StreamEventStatus,
-  type QueryOptions,
   type QuerySuccess,
   type QueryValue,
 } from "./wire-protocol";
@@ -253,13 +253,9 @@ export class Client {
       );
     }
 
-    // QueryInterpolation values must always be encoded.
-    // TODO: The Query implementation never set the QueryRequest arguments.
-    //   When we separate query building from query encoding we should be able
-    //   to simply do `const queryInterpolation: TaggedTypeFormat.encode(query)`
-    const queryInterpolation = query.toQuery(options).query;
+    const request = query.toQuery(options?.arguments);
 
-    return this.#queryWithRetries(queryInterpolation, options);
+    return this.#queryWithRetries(request, options);
   }
 
   /**
@@ -348,8 +344,8 @@ export class Client {
   }
 
   async #queryWithRetries<T extends QueryValue>(
-    queryInterpolation: string | QueryInterpolation,
-    options?: QueryOptions,
+    queryRequest: QueryRequest,
+    queryOptions?: QueryOptions,
     attempt = 0,
   ): Promise<QuerySuccess<T>> {
     const maxBackoff =
@@ -363,11 +359,11 @@ export class Client {
     attempt += 1;
 
     try {
-      return await this.#query<T>(queryInterpolation, options, attempt);
+      return await this.#query<T>(queryRequest, queryOptions, attempt);
     } catch (error) {
       if (error instanceof ThrottlingError && attempt < maxAttempts) {
         await wait(backoffMs);
-        return this.#queryWithRetries<T>(queryInterpolation, options, attempt);
+        return this.#queryWithRetries<T>(queryRequest, queryOptions, attempt);
       }
       throw error;
     }
@@ -462,14 +458,14 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
   }
 
   async #query<T extends QueryValue>(
-    queryInterpolation: string | QueryInterpolation,
-    options?: QueryOptions,
+    queryRequest: QueryRequest,
+    queryOptions?: QueryOptions,
     attempt = 0,
   ): Promise<QuerySuccess<T>> {
     try {
       const requestConfig = {
         ...this.#clientConfiguration,
-        ...options,
+        ...queryOptions,
       };
 
       const headers = {
@@ -479,24 +475,13 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
 
       const isTaggedFormat = requestConfig.format === "tagged";
 
-      const queryArgs = requestConfig.arguments
-        ? isTaggedFormat
-          ? TaggedTypeFormat.encode(requestConfig.arguments)
-          : requestConfig.arguments
-        : undefined;
-
-      const requestData = {
-        query: queryInterpolation,
-        arguments: queryArgs,
-      };
-
       const client_timeout_ms =
         requestConfig.query_timeout_ms +
         this.#clientConfiguration.client_timeout_buffer_ms;
 
       const response = await this.#httpClient.request({
         client_timeout_ms,
-        data: requestData,
+        data: queryRequest,
         headers,
         method: "POST",
       });

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -75,19 +75,16 @@ export class Query {
   }
 
   /**
-   * Converts this Query to a {@link QueryRequest} you can send
+   * Converts this Query to an {@link FQLFragment} you can send
    * to Fauna.
-   * @param options - optional {@link QueryOptions} to include
-   *   in the request (and thus override the defaults in your {@link ClientConfiguration}.
-   *   If not passed in, no headers will be set as overrides.
-   * @returns a {@link QueryRequest}.
+   * @returns a {@link FQLFragment}.
    * @example
    * ```typescript
    *  const num = 8;
    *  const queryBuilder = fql`'foo'.length == ${num}`;
    *  const queryRequest = queryBuilder.toQuery();
    *  // produces:
-   *  { query: { fql: ["'foo'.length == ", { value: { "@int": "8" } }, ""] }}
+   *  { fql: ["'foo'.length == ", { value: { "@int": "8" } }, ""] }
    * ```
    */
   encode(): FQLFragment {

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -8,16 +8,17 @@ import type {
 /**
  * A QueryArgumentObject is a plain javascript object where each property is a
  * valid QueryArgument.
- * These objects can be set as values in the {@link fql} function.
  */
 export type QueryArgumentObject = {
   [key: string]: QueryArgument;
 };
 
 /**
- * A QueryArgument is a plain javascript object where each property is a
- * valid QueryArgument.
- * These objects can be set as values in the {@link fql} function.
+ * A QueryArgument represents all possible values that can be encoded and passed
+ * to Fauna as a query argument.
+ *
+ * The {@link fql} tagged template function requires all arguments to be of type
+ * QueryArgument.
  */
 export type QueryArgument =
   | QueryValue

--- a/src/query-builder.ts
+++ b/src/query-builder.ts
@@ -3,8 +3,6 @@ import type {
   FQLFragment,
   QueryValue,
   QueryInterpolation,
-  QueryRequest,
-  EncodedObject,
 } from "./wire-protocol";
 
 /**
@@ -92,20 +90,7 @@ export class Query {
    *  { query: { fql: ["'foo'.length == ", { value: { "@int": "8" } }, ""] }}
    * ```
    */
-  toQuery(queryArgs?: QueryArgumentObject): QueryRequest<FQLFragment> {
-    const result: QueryRequest<FQLFragment> = {
-      query: this.#render_query(),
-    };
-
-    if (queryArgs) {
-      // Type cast safety: A QueryArgumentObject will always encode into an EncodedObject
-      result.arguments = TaggedTypeFormat.encode(queryArgs) as EncodedObject;
-    }
-
-    return result;
-  }
-
-  #render_query(): FQLFragment {
+  encode(): FQLFragment {
     if (this.#queryFragments.length === 1) {
       return { fql: [this.#queryFragments[0]] };
     }

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -14,7 +14,26 @@ import {
   EmbeddedSet,
   StreamToken,
 } from "./values";
-import { QueryValueObject, QueryValue } from "./wire-protocol";
+import {
+  QueryValue,
+  QueryInterpolation,
+  ObjectFragment,
+  ArrayFragment,
+  FQLFragment,
+  ValueFragment,
+  TaggedType,
+  TaggedLong,
+  TaggedInt,
+  TaggedDouble,
+  TaggedObject,
+  EncodedObject,
+  TaggedTime,
+  TaggedDate,
+  TaggedMod,
+  TaggedRef,
+  TaggedBytes,
+} from "./wire-protocol";
+import { Query, QueryArgument, QueryArgumentObject } from "./query-builder";
 
 export interface DecodeOptions {
   long_type: "number" | "bigint";
@@ -25,13 +44,23 @@ export interface DecodeOptions {
  */
 export class TaggedTypeFormat {
   /**
-   * Encode the Object to the Tagged Type format for Fauna
+   * Encode the value to the Tagged Type format for Fauna
    *
-   * @param obj - Object that will be encoded
+   * @param input - value that will be encoded
    * @returns Map of result
    */
-  static encode(obj: any): any {
-    return encode(obj);
+  static encode(input: QueryArgument): TaggedType {
+    return encode(input);
+  }
+
+  /**
+   * Encode the value to a QueryInterpolation to send to Fauna
+   *
+   * @param input - value that will be encoded
+   * @returns Map of result
+   */
+  static encodeInterpolation(input: QueryArgument): QueryInterpolation {
+    return encodeInterpolation(input);
   }
 
   /**
@@ -109,20 +138,6 @@ Returning as Number with loss of precision. Use long_type 'bigint' instead.`);
   }
 }
 
-type TaggedBytes = { "@bytes": string };
-type TaggedDate = { "@date": string };
-type TaggedDouble = { "@double": string };
-type TaggedInt = { "@int": string };
-type TaggedLong = { "@long": string };
-type TaggedMod = { "@mod": string };
-type TaggedObject = { "@object": QueryValueObject };
-type TaggedRef = {
-  "@ref": { id: string; coll: TaggedMod } | { name: string; coll: TaggedMod };
-};
-// WIP: core does not accept `@set` tagged values
-// type TaggedSet = { "@set": { data: QueryValue[]; after?: string } };
-type TaggedTime = { "@time": string };
-
 export const LONG_MIN = BigInt("-9223372036854775808");
 export const LONG_MAX = BigInt("9223372036854775807");
 export const INT_MIN = -(2 ** 31);
@@ -166,9 +181,9 @@ const encodeMap = {
   string: (value: string): string => {
     return value;
   },
-  object: (input: QueryValueObject): TaggedObject | QueryValueObject => {
+  object: (input: QueryArgumentObject): TaggedObject | EncodedObject => {
     let wrapped = false;
-    const _out: QueryValueObject = {};
+    const _out: EncodedObject = {};
 
     for (const k in input) {
       if (k.startsWith("@")) {
@@ -180,11 +195,7 @@ const encodeMap = {
     }
     return wrapped ? { "@object": _out } : _out;
   },
-  array: (input: Array<QueryValue>): Array<QueryValue> => {
-    const _out: QueryValue = [];
-    for (const i in input) _out.push(encode(input[i]));
-    return _out;
-  },
+  array: (input: QueryArgument[]): TaggedType[] => input.map(encode),
   date: (dateValue: Date): TaggedTime => ({
     "@time": dateValue.toISOString(),
   }),
@@ -225,10 +236,7 @@ const encodeMap = {
   }),
 };
 
-const encode = (input: QueryValue): QueryValue => {
-  if (input === undefined) {
-    throw new TypeError("Passing undefined as a QueryValue is not supported");
-  }
+const encode = (input: QueryArgument): TaggedType => {
   switch (typeof input) {
     case "bigint":
       return encodeMap["bigint"](input);
@@ -275,12 +283,89 @@ const encode = (input: QueryValue): QueryValue => {
         throw new ClientError(
           "Error encoding TypedArray to Fauna Bytes. Convert your TypedArray to Uint8Array or ArrayBuffer before passing it to Fauna. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray",
         );
+      } else if (input instanceof Query) {
+        throw new TypeError(
+          "Cannot encode instance of type 'Query'. Try using TaggedTypeFormat.encodeInterpolation instead.",
+        );
       } else {
         return encodeMap["object"](input);
       }
+    default:
+      // catch "undefined", "symbol", and "function"
+      throw new TypeError(
+        `Passing ${typeof input} as a QueryArgument is not supported`,
+      );
   }
   // anything here would be unreachable code
 };
+
+const encodeInterpolation = (input: QueryArgument): QueryInterpolation => {
+  switch (typeof input) {
+    case "bigint":
+    case "string":
+    case "number":
+    case "boolean":
+      return encodeValueInterpolation(encode(input));
+    case "object":
+      if (
+        input == null ||
+        input instanceof Date ||
+        input instanceof DateStub ||
+        input instanceof TimeStub ||
+        input instanceof Module ||
+        input instanceof DocumentReference ||
+        input instanceof NamedDocumentReference ||
+        input instanceof Page ||
+        input instanceof EmbeddedSet ||
+        input instanceof StreamToken ||
+        input instanceof Uint8Array ||
+        input instanceof ArrayBuffer ||
+        ArrayBuffer.isView(input)
+      ) {
+        return encodeValueInterpolation(encode(input));
+      } else if (input instanceof NullDocument) {
+        return encodeInterpolation(input.ref);
+      } else if (input instanceof Query) {
+        return encodeQueryInterpolation(input);
+      } else if (Array.isArray(input)) {
+        return encodeArrayInterpolation(input);
+      } else {
+        return encodeObjectInterpolation(input);
+      }
+    default:
+      // catch "undefined", "symbol", and "function"
+      throw new TypeError(
+        `Passing ${typeof input} as a QueryArgument is not supported`,
+      );
+  }
+};
+
+const encodeObjectInterpolation = (
+  input: QueryArgumentObject,
+): ObjectFragment => {
+  const _out: EncodedObject = {};
+
+  for (const k in input) {
+    if (input[k] !== undefined) {
+      _out[k] = encodeInterpolation(input[k]);
+    }
+  }
+  return { object: _out };
+};
+
+const encodeArrayInterpolation = (
+  input: Array<QueryArgument>,
+): ArrayFragment => {
+  const encodedItems = input.map(encodeInterpolation);
+  return { array: encodedItems };
+};
+
+const encodeQueryInterpolation = (value: Query): FQLFragment =>
+  value.toQuery().query;
+
+const encodeValueInterpolation = (value: TaggedType): ValueFragment => ({
+  value,
+});
 
 function base64toBuffer(value: string): Uint8Array {
   return base64.toByteArray(value);

--- a/src/tagged-type.ts
+++ b/src/tagged-type.ts
@@ -360,8 +360,7 @@ const encodeArrayInterpolation = (
   return { array: encodedItems };
 };
 
-const encodeQueryInterpolation = (value: Query): FQLFragment =>
-  value.toQuery().query;
+const encodeQueryInterpolation = (value: Query): FQLFragment => value.encode();
 
 const encodeValueInterpolation = (value: TaggedType): ValueFragment => ({
   value,


### PR DESCRIPTION
Ticket(s): [FE-3501](https://faunadb.atlassian.net/browse/FE-3501)

## Problem
`Query` instances (i.e. results from the `fql` function) cannot be encoded when embedded in objects or arrays.

The `QueryValue` type is incorrectly used for types over the wire.

## Solution
The database now accepts a query interpolation fragments for `array` and `object`, where the existing `fql` fragment can now be nested under the `array` and `object` fragments. Add new `encodeInterpolation` method to encode with the new fragments.

Query `arguments` do not use interpolation, so they still need the `@object` tag. Encoding arguments still uses the existing `encode` method.

Update types to better distinguish between
- Arguments to be encoded
  - allow `Query` within objects and arrays
  - `QueryValue` should remain a valid `QueryArgument` to ensure round-trip-ability
- Encoded values sent over the wire
  - Updated fragment types and remove `QueryValue` from fragments
- Decoded values
  - Specify `QueryValue` type only where we decode values from Fauna.

## Result
Queries can be encoded in QueryInterpolations.

Queries can be embedded within JS arrays and objects.

Type changes are corrections to the internal implementation. No user-facing changes were made to types (except `QueryArgument`)

## Out of scope
n/a

## Testing
Updated existing tests and added new ones for embedding queries in arrays and objects.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-3501]: https://faunadb.atlassian.net/browse/FE-3501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ