### PR TITLE
[DOCS-3025] Bump Node.js current and LTS versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See the [Fauna Documentation](https://docs.fauna.com/fauna/current/) for additio
 
 **Server-side**
 
-Node.js - [Active LTS versions](https://nodejs.org/en/about/releases/):
+Node.js - [Active LTS version](https://nodejs.org/en/about/releases/):
 
 - LTS - v20
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ See the [Fauna Documentation](https://docs.fauna.com/fauna/current/) for additio
 
 **Server-side**
 
-Node.js - [Current and active LTS versions](https://nodejs.org/en/about/releases/):
+Node.js - [Active LTS versions](https://nodejs.org/en/about/releases/):
 
-- Current - v22
 - LTS - v20
 
 **Cloud providers**

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ See the [Fauna Documentation](https://docs.fauna.com/fauna/current/) for additio
 
 Node.js - [Current and active LTS versions](https://nodejs.org/en/about/releases/):
 
-- Current - v20
-- LTS - v18
+- Current - v22
+- LTS - v20
 
 **Cloud providers**
 


### PR DESCRIPTION
Ticket(s): [DOCS-3025](https://faunadb.atlassian.net/browse/DOCS-3025)

## Problem

As of writing, Node.js current vers is v22, and LTS is v20.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[DOCS-3025]: https://faunadb.atlassian.net/browse/DOCS-3025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ