### PR TITLE
Fix incorrect paths type on ConstraintFailure

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -229,7 +229,7 @@ describe("query", () => {
   });
 
   it("Includes constraint failures when present", async () => {
-    expect.assertions(6);
+    expect.assertions(4);
     try {
       await client.query(
         fql`Function.create({"name": "my_double", "body": "x => x * 2"})`,
@@ -241,14 +241,15 @@ describe("query", () => {
       if (e instanceof ServiceError) {
         expect(e.httpStatus).toBe(400);
         expect(e.code).toBe("constraint_failure");
-        expect(e.queryInfo?.summary).toBeDefined();
-        if (e.constraint_failures !== undefined) {
-          expect(e.constraint_failures.length).toBe(1);
-          for (let constraintFailure of e.constraint_failures) {
-            expect(constraintFailure.message).toBeDefined();
-            expect(constraintFailure.paths).toBeDefined();
-          }
-        }
+        expect(e.queryInfo).toMatchObject({
+          summary: expect.any(String),
+        });
+        expect(e.constraint_failures).toEqual([
+          {
+            message: expect.any(String),
+            paths: expect.arrayContaining([expect.any(Array)]),
+          },
+        ]);
       }
     }
   });

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -200,7 +200,7 @@ export type ConstraintFailure = {
   /** Name of the failed constraint */
   name?: string;
   /** Path into the write input data to which the failure applies */
-  paths?: Array<number | string>;
+  paths?: Array<Array<number | string>>;
 };
 
 export type QueryResponse<T extends QueryValue> =


### PR DESCRIPTION
Ticket(s): [FE-5552](https://faunadb.atlassian.net/browse/FE-5552)

## Problem

The type `ConstraintFailure["paths"]` was set to be `Array<number | string>`. However, the wire response for `paths` is actually an array of arrays. Anyone trying to interact with `paths` using the declared types would have a runtime error. The existing integration tests only check `paths` is defined.

## Solution

Fix the the types to match the current response, and update the integration tests to actually test the array of array data structure. The `expect` statements were updated to use more "complex" matchers to reduce the number of assertions while visually documenting the data structures.

## Result

The types now match the expected wire result and the integration tests validate that structure more concretely.

## Out of scope

N/A.

## Testing

Updated the existing constraint failure query tests.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-5552]: https://faunadb.atlassian.net/browse/FE-5552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ