### PR TITLE
[DOCS-3140] Fix query tag bug is JS driver readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ const config: ClientConfiguration = {
   max_attempts: 3,
   max_backoff: 20,
   max_contention_retries: 5,
-  query_tags: { name: "readme query" },
+  query_tags: { name: "readme_query" },
   query_timeout_ms: 60_000,
   traceparent: "00-750efa5fb6a131eb2cf4db39f28366cb-000000000000000b-00",
   typecheck: true,


### PR DESCRIPTION
Ticket(s): [DOCS-3140](https://faunadb.atlassian.net/browse/DOCS-3140)

## Problem

Query tag values can't contain spaces.

## Solution

Fixes a bad example in the README.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[DOCS-3140]: https://faunadb.atlassian.net/browse/DOCS-3140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ