### PR TITLE
Update docstring and readme with changes requested in #277

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See the [Fauna Documentation](https://docs.fauna.com/fauna/current/) for additio
   - [Contributing](#contributing)
     - [Set up the repo](#set-up-the-repo)
     - [Run tests](#run-tests)
+    - [Asserting types](#asserting-types)
     - [Lint your code](#lint-your-code)
   - [License](#license)
 
@@ -602,7 +603,7 @@ Don't forget to give the project a star! Thanks again!
 1. Start a docker desktop or other docker platform.
 2. Run `yarn test`. This will start local fauna containers, verify they're up and run all tests.
 
-### Asserting type behavior
+### Asserting types
 
 In cases where you are modifying types and need to test type enforcement, you can use `@ts-expect-error`. Using `@ts-expect-error` will supress any type errors on the following line. Conversely, if there's no error, TypeScript will report its usage as not being neccessary.
 

--- a/README.md
+++ b/README.md
@@ -602,6 +602,12 @@ Don't forget to give the project a star! Thanks again!
 1. Start a docker desktop or other docker platform.
 2. Run `yarn test`. This will start local fauna containers, verify they're up and run all tests.
 
+### Asserting type behavior
+
+In cases where you are modifying types and need to test type enforcement, you can use `@ts-expect-error`. Using `@ts-expect-error` will supress any type errors on the following line. Conversely, if there's no error, TypeScript will report its usage as not being neccessary.
+
+To learn more about `@ts-expect-error`, you can read more about it in the TypeScript [release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#-ts-expect-error-comments).
+
 ### Lint your code
 
 Linting runs automatically on each commit.

--- a/src/client.ts
+++ b/src/client.ts
@@ -271,7 +271,7 @@ export class Client {
   /**
    * Initialize a streaming request to Fauna
    * @typeParam T - The expected type of the response from Fauna. T can be inferred
-   *   if theprovided query used a type parameter.
+   *   if the provided query used a type parameter.
    * @param query - A string-encoded streaming token, or a {@link Query}
    * @returns A {@link StreamClient} that which can be used to listen to a stream
    *   of events


### PR DESCRIPTION
Ticket(s): [FE-5389](https://faunadb.atlassian.net/browse/FE-5389)

## Problem

#277 introduced a typo in a client docstring and new type testing techniques that are not explicitly called out in the README.

## Solution

* Fix spacing typo
* Add a new "Asserting type behavior" in the "Contributing" section of the readme

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


[FE-5389]: https://faunadb.atlassian.net/browse/FE-5389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ