### PR TITLE
Increase query limit integration test timeout value

### DIFF
--- a/__tests__/integration/query-limits.test.ts
+++ b/__tests__/integration/query-limits.test.ts
@@ -61,5 +61,5 @@ maybeDescribe("Query with limits enabled", () => {
     );
 
     expect(throttled).toBeTruthy();
-  }, 20000);
+  }, 30000);
 });


### PR DESCRIPTION
## Problem

The query limit integration tests can sometimes timeout with at 20000. This makes our release pipeline flaky for new versions. 

## Solution

Increasing the query limit timeout to 30000 should eliminate timeout failures outside of events where dependencies are actually failing.

## Testing

None. This is a theory with minimal risk/downside.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
