### PR TITLE
Extend HTTPRequest to support path overrides

### DIFF
--- a/__tests__/unit/fetch-client.test.ts
+++ b/__tests__/unit/fetch-client.test.ts
@@ -11,7 +11,7 @@ import {
   QuerySuccess,
 } from "../../src";
 import { getDefaultHTTPClientOptions } from "../client";
-import { SupportedFaunaAPIs } from "../../src/http-client";
+import { SupportedFaunaAPIPaths } from "../../src/http-client";
 
 let fetchClient: FetchClient;
 
@@ -145,6 +145,21 @@ describe("fetch client", () => {
     }
   });
 
+  it("uses the default path if one is not provided in HttpRequest", async () => {
+    expect.assertions(1);
+    fetchMock.mockResponseOnce(JSON.stringify({}), {
+      headers: { "content-type": "application/json" },
+    });
+    await fetchClient.request({
+      ...dummyRequest,
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/query/1"),
+      expect.any(Object),
+    );
+  });
+
   it("uses the path provided in the HttpRequest if provided", async () => {
     expect.assertions(1);
     fetchMock.mockResponseOnce(JSON.stringify({}), {
@@ -152,8 +167,9 @@ describe("fetch client", () => {
     });
     await fetchClient.request({
       ...dummyRequest,
-      path: "/non-the-default-api" as SupportedFaunaAPIs,
+      path: "/non-the-default-api" as SupportedFaunaAPIPaths,
     });
+
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("/non-the-default-api"),
       expect.any(Object),

--- a/__tests__/unit/fetch-client.test.ts
+++ b/__tests__/unit/fetch-client.test.ts
@@ -11,6 +11,7 @@ import {
   QuerySuccess,
 } from "../../src";
 import { getDefaultHTTPClientOptions } from "../client";
+import { SupportedFaunaAPIs } from "../../src/http-client";
 
 let fetchClient: FetchClient;
 
@@ -151,7 +152,7 @@ describe("fetch client", () => {
     });
     await fetchClient.request({
       ...dummyRequest,
-      path: "/non-the-default-api",
+      path: "/non-the-default-api" as SupportedFaunaAPIs,
     });
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("/non-the-default-api"),

--- a/__tests__/unit/fetch-client.test.ts
+++ b/__tests__/unit/fetch-client.test.ts
@@ -117,7 +117,7 @@ describe("fetch client", () => {
     } catch (e) {
       if (e instanceof NetworkError) {
         expect(e.message).toEqual(
-          "The network connection encountered a problem."
+          "The network connection encountered a problem.",
         );
         expect(e.cause).toBeDefined();
       }
@@ -128,7 +128,7 @@ describe("fetch client", () => {
     expect.assertions(2);
     fetchMock.mockResponseOnce(
       () =>
-        new Promise((resolve) => setTimeout(() => resolve({ body: "" }), 100))
+        new Promise((resolve) => setTimeout(() => resolve({ body: "" }), 100)),
     );
     try {
       const badClient = new FetchClient(getDefaultHTTPClientOptions());
@@ -137,10 +137,25 @@ describe("fetch client", () => {
     } catch (e) {
       if (e instanceof NetworkError) {
         expect(e.message).toEqual(
-          "The network connection encountered a problem."
+          "The network connection encountered a problem.",
         );
         expect(e.cause).toBeDefined();
       }
     }
+  });
+
+  it("uses the path provided in the HttpRequest if provided", async () => {
+    expect.assertions(1);
+    fetchMock.mockResponseOnce(JSON.stringify({}), {
+      headers: { "content-type": "application/json" },
+    });
+    await fetchClient.request({
+      ...dummyRequest,
+      path: "/non-the-default-api",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/non-the-default-api"),
+      expect.any(Object),
+    );
   });
 });

--- a/__tests__/unit/node-http2-client.test.ts
+++ b/__tests__/unit/node-http2-client.test.ts
@@ -2,7 +2,7 @@ import http2 from "node:http2";
 import { getDefaultHTTPClient, NodeHTTP2Client } from "../../src";
 import { HTTPRequest } from "../../src";
 import { getDefaultHTTPClientOptions } from "../client";
-import { SupportedFaunaAPIs } from "../../src/http-client";
+import { SupportedFaunaAPIPaths } from "../../src/http-client";
 
 const mockRequest = jest.fn();
 const mockClient = {
@@ -45,7 +45,7 @@ describe("node http2 client", () => {
       data: { query: "some-query" },
       headers: {},
       method: "POST",
-      path: "/some-path" as SupportedFaunaAPIs,
+      path: "/some-path" as SupportedFaunaAPIPaths,
     };
 
     // We don't actually care about the status of this request for this specific test.

--- a/__tests__/unit/node-http2-client.test.ts
+++ b/__tests__/unit/node-http2-client.test.ts
@@ -1,10 +1,61 @@
+import http2 from "node:http2";
 import { getDefaultHTTPClient, NodeHTTP2Client } from "../../src";
+import { HTTPRequest } from "../../src";
 import { getDefaultHTTPClientOptions } from "../client";
+
+const mockRequest = jest.fn();
+const mockClient = {
+  request: mockRequest,
+  once: () => mockClient,
+  setTimeout: jest.fn(),
+};
+jest.spyOn(http2, "connect").mockReturnValue(mockClient as any);
 
 const client = getDefaultHTTPClient(getDefaultHTTPClientOptions());
 
 describe("node http2 client", () => {
   it("default client for Node.js is the NodeHTTP2Client", async () => {
     expect(client).toBeInstanceOf(NodeHTTP2Client);
+  });
+
+  it("uses the default request path if none is provided", async () => {
+    const request: HTTPRequest = {
+      client_timeout_ms: 0,
+      data: { query: "some-query" },
+      headers: {},
+      method: "POST",
+    };
+
+    // We don't actually care about the status of this request for this specific test.
+    // We're just testing the path is being set correctly.
+    try {
+      await client.request(request);
+    } catch (_) {}
+
+    expect(mockRequest).toHaveBeenCalledWith({
+      ":method": "POST",
+      ":path": "/query/1",
+    });
+  });
+
+  it("uses the path provided in HttpRequest if provided", async () => {
+    const request: HTTPRequest = {
+      client_timeout_ms: 0,
+      data: { query: "some-query" },
+      headers: {},
+      method: "POST",
+      path: "/some-path",
+    };
+
+    // We don't actually care about the status of this request for this specific test.
+    // We're just testing the path is being set correctly.
+    try {
+      await client.request(request);
+    } catch (_) {}
+
+    expect(mockRequest).toHaveBeenCalledWith({
+      ":method": "POST",
+      ":path": "/some-path",
+    });
   });
 });

--- a/__tests__/unit/node-http2-client.test.ts
+++ b/__tests__/unit/node-http2-client.test.ts
@@ -2,6 +2,7 @@ import http2 from "node:http2";
 import { getDefaultHTTPClient, NodeHTTP2Client } from "../../src";
 import { HTTPRequest } from "../../src";
 import { getDefaultHTTPClientOptions } from "../client";
+import { SupportedFaunaAPIs } from "../../src/http-client";
 
 const mockRequest = jest.fn();
 const mockClient = {
@@ -44,7 +45,7 @@ describe("node http2 client", () => {
       data: { query: "some-query" },
       headers: {},
       method: "POST",
-      path: "/some-path",
+      path: "/some-path" as SupportedFaunaAPIs,
     };
 
     // We don't actually care about the status of this request for this specific test.

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -3,7 +3,7 @@
 
 import { getServiceError, NetworkError } from "../errors";
 import { QueryFailure } from "../wire-protocol";
-import { FaunaAPI } from "./paths";
+import { FaunaAPIPaths } from "./paths";
 import {
   HTTPClient,
   HTTPClientOptions,
@@ -19,8 +19,8 @@ import {
  */
 export class FetchClient implements HTTPClient, HTTPStreamClient {
   #baseUrl: string;
-  #defaultRequestPath = FaunaAPI.QUERY;
-  #defaultStreamPath = FaunaAPI.STREAM;
+  #defaultRequestPath = FaunaAPIPaths.QUERY;
+  #defaultStreamPath = FaunaAPIPaths.STREAM;
   #keepalive: boolean;
 
   constructor({ url, fetch_keepalive }: HTTPClientOptions) {

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -3,6 +3,7 @@
 
 import { getServiceError, NetworkError } from "../errors";
 import { QueryFailure } from "../wire-protocol";
+import { FaunaAPI } from "./paths";
 import {
   HTTPClient,
   HTTPClientOptions,
@@ -17,14 +18,18 @@ import {
  * An implementation for {@link HTTPClient} that uses the native fetch API
  */
 export class FetchClient implements HTTPClient, HTTPStreamClient {
-  #queryURL: string;
-  #streamURL: string;
+  #baseUrl: string;
+  #defaultRequestPath = FaunaAPI.QUERY;
+  #defaultStreamPath = FaunaAPI.STREAM;
   #keepalive: boolean;
 
   constructor({ url, fetch_keepalive }: HTTPClientOptions) {
-    this.#queryURL = new URL("/query/1", url).toString();
-    this.#streamURL = new URL("/stream/1", url).toString();
+    this.#baseUrl = url;
     this.#keepalive = fetch_keepalive;
+  }
+
+  #resolveURL(path: string): string {
+    return new URL(path, this.#baseUrl).toString();
   }
 
   /** {@inheritDoc HTTPClient.request} */
@@ -33,6 +38,7 @@ export class FetchClient implements HTTPClient, HTTPStreamClient {
     headers: requestHeaders,
     method,
     client_timeout_ms,
+    path = this.#defaultRequestPath,
   }: HTTPRequest): Promise<HTTPResponse> {
     const signal =
       AbortSignal.timeout === undefined
@@ -44,7 +50,7 @@ export class FetchClient implements HTTPClient, HTTPStreamClient {
           })()
         : AbortSignal.timeout(client_timeout_ms);
 
-    const response = await fetch(this.#queryURL, {
+    const response = await fetch(this.#resolveURL(path), {
       method,
       headers: { ...requestHeaders, "Content-Type": "application/json" },
       body: JSON.stringify(data),
@@ -75,8 +81,9 @@ export class FetchClient implements HTTPClient, HTTPStreamClient {
     data,
     headers: requestHeaders,
     method,
+    path = this.#defaultStreamPath,
   }: HTTPStreamRequest): StreamAdapter {
-    const request = new Request(this.#streamURL, {
+    const request = new Request(this.#resolveURL(path), {
       method,
       headers: { ...requestHeaders, "Content-Type": "application/json" },
       body: JSON.stringify(data),

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { Client } from "../client";
 import { QueryRequest, StreamRequest } from "../wire-protocol";
+import { SupportedFaunaAPIs } from "./paths";
 
 /**
  * An object representing an http request.
@@ -22,7 +23,7 @@ export type HTTPRequest = {
   method: "POST";
 
   /** The path of the endpoint to call if not using the default */
-  path?: string;
+  path?: SupportedFaunaAPIs;
 };
 
 /**

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -20,6 +20,9 @@ export type HTTPRequest = {
 
   /** HTTP method to use */
   method: "POST";
+
+  /** The path of the endpoint to call if not using the default */
+  path?: string;
 };
 
 /**
@@ -80,6 +83,9 @@ export type HTTPStreamRequest = {
 
   /** HTTP method to use */
   method: "POST";
+
+  /** The path of the endpoint to call if not using the default */
+  path?: string;
 };
 
 /**
@@ -91,7 +97,7 @@ export interface StreamAdapter {
 }
 
 /**
- * An interface to provide implementation-specific, asyncronous http calls.
+ * An interface to provide implementation-specific, asynchronous http calls.
  * This driver provides default implementations for common environments. Users
  * can configure the {@link Client} to use custom implementations if desired.
  */

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { Client } from "../client";
 import { QueryRequest, StreamRequest } from "../wire-protocol";
-import { SupportedFaunaAPIs } from "./paths";
+import { SupportedFaunaAPIPaths } from "./paths";
 
 /**
  * An object representing an http request.
@@ -23,7 +23,7 @@ export type HTTPRequest = {
   method: "POST";
 
   /** The path of the endpoint to call if not using the default */
-  path?: SupportedFaunaAPIs;
+  path?: SupportedFaunaAPIPaths;
 };
 
 /**

--- a/src/http-client/index.ts
+++ b/src/http-client/index.ts
@@ -7,6 +7,7 @@ import {
 } from "./http-client";
 import { NodeHTTP2Client } from "./node-http2-client";
 
+export * from "./paths";
 export * from "./fetch-client";
 export * from "./http-client";
 export * from "./node-http2-client";

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -15,7 +15,7 @@ import {
 } from "./http-client";
 import { NetworkError, getServiceError } from "../errors";
 import { QueryFailure } from "../wire-protocol";
-import { FaunaAPI } from "./paths";
+import { FaunaAPIPaths } from "./paths";
 
 // alias http2 types
 type ClientHttp2Session = any;
@@ -36,8 +36,8 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
   #numberOfUsers = 0;
   #session: ClientHttp2Session | null;
 
-  #defaultRequestPath = FaunaAPI.QUERY;
-  #defaultStreamPath = FaunaAPI.STREAM;
+  #defaultRequestPath = FaunaAPIPaths.QUERY;
+  #defaultStreamPath = FaunaAPIPaths.STREAM;
 
   private constructor({
     http2_session_idle_ms,

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -15,6 +15,7 @@ import {
 } from "./http-client";
 import { NetworkError, getServiceError } from "../errors";
 import { QueryFailure } from "../wire-protocol";
+import { FaunaAPI } from "./paths";
 
 // alias http2 types
 type ClientHttp2Session = any;
@@ -34,6 +35,9 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
   #url: string;
   #numberOfUsers = 0;
   #session: ClientHttp2Session | null;
+
+  #defaultRequestPath = FaunaAPI.QUERY;
+  #defaultStreamPath = FaunaAPI.STREAM;
 
   private constructor({
     http2_session_idle_ms,
@@ -144,18 +148,18 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
   #connect() {
     // create the session if it does not exist or is closed
     if (!this.#session || this.#session.closed || this.#session.destroyed) {
-      const new_session: ClientHttp2Session = http2
+      const newSession: ClientHttp2Session = http2
         .connect(this.#url, {
           peerMaxConcurrentStreams: this.#http2_max_streams,
         })
         .once("error", () => this.#closeForAll())
         .once("goaway", () => this.#closeForAll());
 
-      new_session.setTimeout(this.#http2_session_idle_ms, () => {
+      newSession.setTimeout(this.#http2_session_idle_ms, () => {
         this.#closeForAll();
       });
 
-      this.#session = new_session;
+      this.#session = newSession;
     }
     return this.#session;
   }
@@ -165,6 +169,7 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
     data: requestData,
     headers: requestHeaders,
     method,
+    path = this.#defaultRequestPath,
   }: HTTPRequest): Promise<HTTPResponse> {
     return new Promise<HTTPResponse>((resolvePromise, rejectPromise) => {
       let req: ClientHttp2Stream;
@@ -195,7 +200,7 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
       try {
         const httpRequestHeaders: OutgoingHttpHeaders = {
           ...requestHeaders,
-          [http2.constants.HTTP2_HEADER_PATH]: "/query/1",
+          [http2.constants.HTTP2_HEADER_PATH]: path,
           [http2.constants.HTTP2_HEADER_METHOD]: method,
         };
 
@@ -227,6 +232,7 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
     data: requestData,
     headers: requestHeaders,
     method,
+    path = this.#defaultStreamPath,
   }: HTTPStreamRequest): StreamAdapter {
     let resolveChunk: (chunk: string[]) => void;
     let rejectChunk: (reason: any) => void;
@@ -298,7 +304,7 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
     async function* reader(): AsyncGenerator<string> {
       const httpRequestHeaders: OutgoingHttpHeaders = {
         ...requestHeaders,
-        [http2.constants.HTTP2_HEADER_PATH]: "/stream/1",
+        [http2.constants.HTTP2_HEADER_PATH]: path,
         [http2.constants.HTTP2_HEADER_METHOD]: method,
       };
 

--- a/src/http-client/paths.ts
+++ b/src/http-client/paths.ts
@@ -1,0 +1,8 @@
+/**
+ * Readonly object representing the paths of the Fauna API to be used
+ * with HTTP clients.
+ */
+export const FaunaAPI = {
+  QUERY: "/query/1",
+  STREAM: "/stream/1",
+} as const;

--- a/src/http-client/paths.ts
+++ b/src/http-client/paths.ts
@@ -2,9 +2,10 @@
  * Readonly object representing the paths of the Fauna API to be used
  * with HTTP clients.
  */
-export const FaunaAPI = {
+export const FaunaAPIPaths = {
   QUERY: "/query/1",
   STREAM: "/stream/1",
 } as const;
 
-export type SupportedFaunaAPIs = (typeof FaunaAPI)[keyof typeof FaunaAPI];
+export type SupportedFaunaAPIPaths =
+  (typeof FaunaAPIPaths)[keyof typeof FaunaAPIPaths];

--- a/src/http-client/paths.ts
+++ b/src/http-client/paths.ts
@@ -6,3 +6,5 @@ export const FaunaAPI = {
   QUERY: "/query/1",
   STREAM: "/stream/1",
 } as const;
+
+export type SupportedFaunaAPIs = (typeof FaunaAPI)[keyof typeof FaunaAPI];


### PR DESCRIPTION
This PR extends the existing `HTTPRequest` to take an optional path to support POST requests to endpoints other than `/query/1`.

### Description
We'll need to support requests to Fauna APIs beyond `/query/1`. Today, this API path is hardcoded in both the fetch and http2 client wrappers. This PR does the following:

- Extends `HTTPRequest` to accept an optional `path`
- Updates `FetchClient` to use default API paths, but override per request when one is provided on `HTTPRequest`
- Updates `NodeHTTP2Client` to use default API paths, but override per request when one is provided on `HTTPRequest`
- Adds a readonly `FaunaAPI` to represent the supported API paths in the driver
- Restricts `HTTPRequest["path"]` to the union of supported endpoints via `FaunaAPI`

### Motivation and context
We need to support more endpoints in this driver. The current http clients really only have a fixed concept of requesting queries or streaming. This change allows for a backwards compatible way to introduce providing a path without breaking existing code or interfaces.

Alternatives considered:

- Making `HTTPClient.request` be `(path: SupportedFaunaAPIs, req: HTTPRequest)`: backwards incompat
- Supporting both the signature above and the current one: Seems overly complex
- Adding `path` to a second optional argument of a new `HTTPRequestOptions` interface to `request`: Best alternative, but also lacking much more substance--especially since `HTTPRequest` already supports additional meta options, like timeout.

In the future, we may want to reconsider redesigning these interfaces in a major version bump, but that is out of scope for this PR.

Definitely open the other implementation approaches!

### How was the change tested?
These changes have dedicated unit tests. The unit tests validate the override logic as well as type enforcement.

Because these changes are backwards compatible, all existing code and tests should work as expected.

### Screenshots (if appropriate):
N/A

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.