### PR TITLE
Add backwards compatible type params for HTTPRequest and HTTPStreamRequest

### DIFF
--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -6,15 +6,17 @@ import { SupportedFaunaAPIPaths } from "./paths";
 /**
  * An object representing an http request.
  * The {@link Client} provides this to the {@link HTTPClient} implementation.
+ *
+ * @typeParam T - The expected type of the request sent to fauna.
  */
-export type HTTPRequest = {
+export type HTTPRequest<T = QueryRequest> = {
   /**
    * The timeout of each http request, in milliseconds.
    */
   client_timeout_ms: number;
 
-  /** The encoded Fauna query to send */
-  data: QueryRequest;
+  /** The encoded request to send */
+  data: T;
 
   /** Headers in object format */
   headers: Record<string, string | undefined>;
@@ -73,11 +75,13 @@ export interface HTTPClient {
 /**
  * An object representing an http request.
  * The {@link Client} provides this to the {@link HTTPStreamClient} implementation.
+ *
+ * @typeParam T - The expected type of the request sent to fauna.
  */
-export type HTTPStreamRequest = {
-  /** The encoded Fauna query to send */
+export type HTTPStreamRequest<T = StreamRequest> = {
+  /** The encoded Fauna request to send */
   // TODO: Allow type to be a QueryRequest once implemented by the db
-  data: StreamRequest;
+  data: T;
 
   /** Headers in object format */
   headers: Record<string, string | undefined>;


### PR DESCRIPTION
Data types for `HTTPRequest` and `HTTPStreamRequest` are hardcoded today. Because of #288, we need to support generics for `data`. They default to backwards compatible types.

### Description
This PR makes the following backwards compatible changes:

- `HTTPRequest` now takes a type parameter that is applied to `data`. It defaults to `QueryRequest`.
- `HTTPStreamRequest` now takes a type parameter that is applied to `data`. It defaults to `StreamRequest`.

### Motivation and context
To take advantage of `HTTPClient.request` against endpoints other than `/query/v1`, we need to support payloads other than `QueryRequest`.  While we don't have an immediate use case for extending `HTTPStreamRequest`, I would argue it makes sense to keep the approaches the same across our two primary request types (call/response and streaming).

### How was the change tested?
No tests were added for this specific change. If all existing tests pass, this is a safe change. The underlying data types are never referred to or accessed directly within the client.

### Screenshots (if appropriate):
N/A

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


