### PR TITLE
Update Node environments

### DIFF
--- a/.github/workflows/pr_validate.yml
+++ b/.github/workflows/pr_validate.yml
@@ -17,7 +17,7 @@ jobs:
           - 7443:8443
     strategy:
       matrix:
-        node: ["18", "20"]
+        node: ["18", "20", "22"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See the [Fauna Documentation](https://docs.fauna.com/fauna/current/) for additio
 <details>
 <summary>Table of Contents</summary>
 
-- [The Official JavaScript Driver for Fauna.](#the-official-javascript-driver-for-fauna)
+- [Official JavaScript Driver for Fauna v10 (current)](#official-javascript-driver-for-fauna-v10-current)
   - [Supported runtimes](#supported-runtimes)
   - [API reference](#api-reference)
   - [Install](#install)
@@ -49,8 +49,9 @@ See the [Fauna Documentation](https://docs.fauna.com/fauna/current/) for additio
 
 Node.js - [Current and active LTS versions](https://nodejs.org/en/about/releases/):
 
-- Current - v20
-- LTS - v18
+- Current - v22
+- LTS - v20
+- LTS (Maintenance) - v18
 
 **Cloud providers**
 

--- a/concourse/scripts/docker-compose-fauna-limits.yml
+++ b/concourse/scripts/docker-compose-fauna-limits.yml
@@ -7,7 +7,7 @@ networks:
 
 services:
   query-limits-tests:
-    image: node:20.2-alpine3.16
+    image: node:22.10-alpine3.20
     container_name: node-current-limits-test
     networks:
       - limit-net

--- a/concourse/scripts/docker-compose-fauna.yml
+++ b/concourse/scripts/docker-compose-fauna.yml
@@ -8,7 +8,7 @@ services:
       - "8443:8443"
 
   node-lts:
-    image: node:18.20-alpine3.19
+    image: node:20.18-alpine3.20
     container_name: node-lts
     depends_on:
       - faunadb
@@ -27,7 +27,7 @@ services:
         yarn test:integration
 
   node-current:
-    image: node:20.13-alpine3.19
+    image: node:22.10-alpine3.20
     container_name: node-current
     depends_on:
       - faunadb

--- a/concourse/tasks/npm-publish.yml
+++ b/concourse/tasks/npm-publish.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: node
-    tag: 20.2-alpine3.16
+    tag: 22.10-alpine3.20
 
 params:
   NPM_TOKEN:

--- a/concourse/tasks/publish-docs.yml
+++ b/concourse/tasks/publish-docs.yml
@@ -4,7 +4,7 @@ image_resource:
   type: registry-image
   source:
     repository: node
-    tag: 15.14.0-alpine3.10
+    tag: 22.10-alpine3.20
 
 inputs:
   - name: fauna-js-repository


### PR DESCRIPTION
Issues: FE-5636

### Description
Update the Node environments in Concourse to latest images for Node v20 and v22.

### Motivation and context
Node v22 has been current for several months and we should be testing against it.

### How was the change tested?
I can run tests locally using Node v22.

Concourse will be updated and we'll see results before publishing new version.

### Change types
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


