### PR TITLE
Add `rate_limits_hit` to `QueryStats` type

### DIFF
--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -37,6 +37,7 @@ const dummyResponse: HTTPResponse = {
       storage_bytes_read: 0,
       storage_bytes_write: 0,
       contention_retries: 0,
+      rate_limits_hit: ["read", "write", "compute"],
     },
   }),
   headers: {},
@@ -62,6 +63,7 @@ describe("query", () => {
     expect(result.stats?.compute_ops).toBeDefined();
     expect(result.stats?.contention_retries).toBeDefined();
     expect(result.stats?.query_time_ms).toBeDefined();
+    expect(result.stats?.rate_limits_hit).toBeDefined();
     expect(result.stats?.read_ops).toBeDefined();
     expect(result.stats?.storage_bytes_read).toBeDefined();
     expect(result.stats?.storage_bytes_write).toBeDefined();

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,6 +2,7 @@ import type {
   ConstraintFailure,
   QueryFailure,
   QueryInfo,
+  QueryStats,
   QueryValue,
 } from "./wire-protocol";
 
@@ -227,7 +228,7 @@ export class QueryTimeoutError extends ServiceError {
   /**
    * Statistics regarding the query.
    */
-  readonly stats?: { [key: string]: number };
+  readonly stats?: QueryStats;
 
   constructor(failure: QueryFailure, httpStatus?: number) {
     super(failure, httpStatus);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -227,6 +227,9 @@ export class ThrottlingError extends ServiceError {
 export class QueryTimeoutError extends ServiceError {
   /**
    * Statistics regarding the query.
+   *
+   * TODO: Deprecate this `stats` field. All `ServiceError`s already provide
+   * access to stats through `queryInfo.stats`
    */
   readonly stats?: QueryStats;
 

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -134,6 +134,11 @@ export type QueryStats = {
   contention_retries: number;
   /** The number query attempts made due to retryable errors. */
   attempts: number;
+  /**
+   * A list of rate limits hit.
+   * Included with QueryFailure responses when the query is rate limited.
+   */
+  rate_limits_hit?: ("read" | "write" | "compute")[];
 };
 
 export type QueryInfo = {


### PR DESCRIPTION
[FE-6078](https://faunadb.atlassian.net/browse/FE-6078)

### Description
Update the `QueryStats` type to include the `rate_limits_hit` field, which is included in the response of throttling errors. 

### Motivation and context
There is no issue with JavaScript populating stats with the `rate_limits_hit` response, but it is inaccessible to TypeScript users relying on our types.

### How was the change tested?
I extended a test that ensures the stats are propagated to query responses. Existing tests ensure that stats go to the right place for `ServiceErrors`. There are no existing integration tests that demonstrate stats actually come from the database, and none were added.

Here are some screenshots of me triggering rate limiting with the raw responses

_Read limit_
![image](https://github.com/user-attachments/assets/20c8a82e-0720-4910-8b73-aff73519d76a)

_Write limit_
![image](https://github.com/user-attachments/assets/78d6984f-5695-41f9-afd9-2c7277fafcac)

_Compute limit_
![image](https://github.com/user-attachments/assets/c48aed31-caf1-46f9-b90f-d9ed4804d1af)

`rate_limits_hit` is returned as an empty array on successful queries
![image](https://github.com/user-attachments/assets/1b4f5abc-09a5-4b8e-a652-bbb17d35ccca)

### Change types
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
    * `rate_limits_hit` is already noted in the [HTTP API docs](https://docs.fauna.com/fauna/current/reference/http/reference/core-api/#operation/query).
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.




[FE-6078]: https://faunadb.atlassian.net/browse/FE-6078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ