### PR TITLE
Validate cursor for feeds

### DIFF
--- a/__tests__/functional/feed-client-configuration.test.ts
+++ b/__tests__/functional/feed-client-configuration.test.ts
@@ -97,4 +97,16 @@ describe("FeedClientConfiguration", () => {
       expect(e).toBeInstanceOf(RangeError);
     }
   });
+
+  it("throws a TypeError if 'cursor' is not a string", async () => {
+    const config = { ...defaultConfig, cursor: null };
+    try {
+      new FeedClient(
+        dummyStreamToken,
+        config as unknown as FeedClientConfiguration,
+      );
+    } catch (e: any) {
+      expect(e).toBeInstanceOf(TypeError);
+    }
+  });
 });

--- a/src/client.ts
+++ b/src/client.ts
@@ -1152,6 +1152,10 @@ export class FeedClient<T extends QueryValue = any> {
         "Only one of 'start_ts' or 'cursor' can be defined in the client configuration.",
       );
     }
+
+    if (config.cursor !== undefined && typeof config.cursor !== "string") {
+      throw new TypeError("'cursor' must be a string.");
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a validation check for cursor and makes sure it's a string at runtime. Non-string values can produce vague error messages otherwise.

### Description
This PR follows the current client configuration validation pattern to make sure `cursor` is a string when it is set.

### Motivation and context
While testing this change internally, we discovered if you managed to pass a non-string cursor during runtime, the error returned wasn't very helpful. It's probably easiest to mitigate this by validating it.

### How was the change tested?
Added a test to the existing client configuration tests. The existing tests still pass.

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.
