### PR TITLE
Allow using a query and cursor together when calling client.feed()

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -434,15 +434,6 @@ export class Client {
       ...options,
     };
 
-    if (
-      clientConfiguration.cursor !== undefined &&
-      tokenOrQuery instanceof Query
-    ) {
-      throw new ClientError(
-        "The `cursor` configuration can only be used with a stream token.",
-      );
-    }
-
     const tokenOrGetToken =
       tokenOrQuery instanceof Query
         ? () => this.query<EventSource>(tokenOrQuery).then((res) => res.data)


### PR DESCRIPTION
This PR enables supplying a `cursor` value when using an unevaluated query with `client.feed()`.

### Description
This PR removes a check that prevented you from calling `client.feed()` with a `query` and a `cursor`. It is an unnecessary constraint, and event feeds will behave as you'd expect without this check.

### Motivation and context
This change allows you to resume at a given cursor while still passing in a query to generate the event source. Before this change, you'd need to first evaluate the query for the event source yourself before calling `feed` with `cursor`.

### How was the change tested?

* An integration test on client was added
* Existing integration tests pass

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


