### PR TITLE
Use fauna/faunadb:latest in our release pipeline

### DIFF
--- a/concourse/scripts/docker-compose-fauna.yml
+++ b/concourse/scripts/docker-compose-fauna.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   faunadb:
-    image: fauna/faunadb:5.10.0
+    image: fauna/faunadb:latest
     container_name: faunadb
     ports:
       - "8443:8443"


### PR DESCRIPTION
This PR updates the concourse pipeline to use fauna/faunadb:latest. The current version does not have event feed support in it.

### Description
This updates the image from 5.10.0 to use latest.

### Motivation and context
The release pipeline should always run against the newest docker image for Fauna as that will represent the most up-to-date APIs and behaviors.

### How was the change tested?
This PR will need to kick down the concourse pipeline.

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.
