### PR TITLE
Fix concourse pipeline for docs gen

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -132,6 +132,7 @@ jobs:
       - get: main.git
         passed:
           - test
+      - get: fauna-js-repository-docs
 
       - task: integration-tests
         file: main.git/concourse/tasks/integration-tests.yml


### PR DESCRIPTION
### Description
Adds a missing step to the release pipeline for docs.

### Motivation and context
Without this step, we can't autogen + publish docs on release. 😢  See https://concourse.faunadb.net/teams/devex/pipelines/js-driver-release-v10/jobs/release/builds/42

### How was the change tested?
```
fly validate-pipeline --config concourse/pipeline.yml
looks good
```

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


