### PR TITLE
Better support for interfaces as query responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See the [Fauna Documentation](https://docs.fauna.com/fauna/current/) for additio
   - [Usage](#usage)
     - [Write FQL queries](#write-fql-queries)
     - [Typescript support](#typescript-support)
+      - [Interfaces as `QueryValue` responses](#interfaces-as-queryvalue-responses)
     - [Query options](#query-options)
     - [Query statistics](#query-statistics)
   - [Pagination](#pagination)
@@ -237,6 +238,25 @@ console.assert(userDoc.name === "Alice");
 console.assert(userDoc.email === "alice@site.example");
 
 client.close();
+```
+
+#### Interfaces as `QueryValue` responses
+
+To use a custom interface as a query response, extend the `QueryValueObject`
+interface.
+
+```typescript
+interface User extends QueryValueObject {
+  name: string;
+  email: string;
+}
+
+const query = fql`{
+  name: "Alice",
+  email: "alice@site.example",
+}`;
+
+const response: QuerySuccess<User> = await client.query<User>(query);
 ```
 
 ### Query options

--- a/src/wire-protocol.ts
+++ b/src/wire-protocol.ts
@@ -353,9 +353,9 @@ export interface Span {
  * QueryValue.
  * These objects can be returned in {@link QuerySuccess}.
  */
-export type QueryValueObject = {
+export interface QueryValueObject {
   [key: string]: QueryValue;
-};
+}
 
 /**
  * A QueryValue represents the possible return values in a {@link QuerySuccess}.


### PR DESCRIPTION
Provide better support and documentation for how to use interfaces as query responses.

resolves #304 

### Description
- Changes `QueryValueObject` from a `type` to an `interface`.
- Add some instruction for how to use the `QueryValueObject` interface to the README.

### Motivation and context
Sometimes, specifying interfaces for query responses is preferred over types. However, custom interfaces are currently not assignable to `QueryValue` and cannot be used where `QueryValue` is required (e.g. the `Client.query()` method).

See #304 

### How was the change tested?
I added tests to demonstrate how interfaces may be used.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/fb870b1e-d8a1-4256-95f6-4506b633f722)


### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


