### PR TITLE
v10 driver - empty 200 response throws protocol error

### DIFF
--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -5,6 +5,7 @@ import {
   AuthorizationError,
   FetchClient,
   fql,
+  ProtocolError,
   QueryTimeoutError,
   ServiceError,
   ServiceInternalError,
@@ -123,7 +124,7 @@ describe("query", () => {
     expect(actual.summary).toEqual("the summary");
   });
 
-  it("Throws ServiceError on an empty 200 response", async () => {
+  it("Throws ProtocolError on an empty 200 response", async () => {
     expect.assertions(2);
     fetchMock.mockResponse("", {
       status: 200,
@@ -133,9 +134,9 @@ describe("query", () => {
       const result = await client.query(fql`'foo'.length`);
       console.log("result", result);
     } catch (e) {
-      if (e instanceof ServiceError) {
+      if (e instanceof ProtocolError) {
         expect(e.message).toEqual(
-          "There was an issue communicating with Fauna. Please try again.",
+          "There was an issue communicating with Fauna. Response is empty. Please try again.",
         );
         expect(e.httpStatus).toEqual(500);
       }

--- a/__tests__/unit/query.test.ts
+++ b/__tests__/unit/query.test.ts
@@ -123,6 +123,25 @@ describe("query", () => {
     expect(actual.summary).toEqual("the summary");
   });
 
+  it("Throws ServiceError on an empty 200 response", async () => {
+    expect.assertions(2);
+    fetchMock.mockResponse("", {
+      status: 200,
+      headers: [["content-length", "0"]],
+    });
+    try {
+      const result = await client.query(fql`'foo'.length`);
+      console.log("result", result);
+    } catch (e) {
+      if (e instanceof ServiceError) {
+        expect(e.message).toEqual(
+          "There was an issue communicating with Fauna. Please try again.",
+        );
+        expect(e.httpStatus).toEqual(500);
+      }
+    }
+  });
+
   // it("throws an NetworkError on a timeout", async () => {
   //   expect.assertions(2);
   //   // axios mock adapater currently has a bug that cannot match

--- a/src/client.ts
+++ b/src/client.ts
@@ -642,8 +642,8 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
       // Receiving a 200 with no body/content indicates an issue with core router
       if (
         response.status === 200 &&
-        response.body.length === 0 &&
-        response.headers["content-length"] === "0"
+        (response.body.length === 0 ||
+          response.headers["content-length"] === "0")
       ) {
         throw new ProtocolError({
           message:

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,7 +11,6 @@ import {
   NetworkError,
   ProtocolError,
   ServiceError,
-  ServiceInternalError,
   ThrottlingError,
   getServiceError,
 } from "./errors";
@@ -646,16 +645,11 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
         response.body.length === 0 &&
         response.headers["content-length"] === "0"
       ) {
-        throw new ServiceInternalError(
-          {
-            error: {
-              code: "internal_error",
-              message:
-                "There was an issue communicating with Fauna. Please try again.",
-            },
-          },
-          500,
-        );
+        throw new ProtocolError({
+          message:
+            "There was an issue communicating with Fauna. Response is empty. Please try again.",
+          httpStatus: 500,
+        });
       }
 
       let parsedResponse;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->

https://faunadb.atlassian.net/browse/FE-6237

Core router may return a 200 with an empty response, indicating an issue on their end. [See LSE](https://faunadb.atlassian.net/browse/LSE-205)
Don't try to parse that like we do a normal response, instead throw a protocol error.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added a query test

### Screenshots (if appropriate):
Shell before:
![Screenshot 2024-12-16 at 6 06 46 PM](https://github.com/user-attachments/assets/e4479c4e-aa78-41e0-a6ef-3faec7293903)



Shell after:
<img width="766" alt="Screenshot 2024-12-16 at 12 10 48 PM" src="https://github.com/user-attachments/assets/a67722d2-23b4-455d-9759-840ae76f227d" />


### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)




