### PR TITLE
Revert backwards incompatible changes to HTTPClient interface

### DIFF
--- a/__tests__/functional/client-configuration.test.ts
+++ b/__tests__/functional/client-configuration.test.ts
@@ -110,9 +110,6 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
       },
 
       close() {},
-      getURL(): string {
-        return "http://foo.com/bar";
-      },
     };
 
     const client = getClient(
@@ -150,9 +147,6 @@ an environmental variable named FAUNA_SECRET or pass it to the Client constructo
         },
 
         close() {},
-        getURL(): string {
-          return "https://foo.com/bar";
-        },
       };
 
       const client = getClient(

--- a/__tests__/functional/feed-client.test.ts
+++ b/__tests__/functional/feed-client.test.ts
@@ -31,7 +31,6 @@ const mockHttpClient = {
     .fn()
     .mockImplementation(() => Promise.resolve({ ...mockHttpResponse })),
   close: jest.fn(),
-  getURL: jest.fn(() => "bar"),
 };
 
 const defaultConfig: FeedClientConfiguration = {

--- a/__tests__/integration/client-last-txn-tracking.test.ts
+++ b/__tests__/integration/client-last-txn-tracking.test.ts
@@ -15,9 +15,6 @@ describe("last_txn_ts tracking in client", () => {
       },
 
       close() {},
-      getURL(): string {
-        return "http://foo.com/bar";
-      },
     };
 
     const myClient = getClient(
@@ -66,9 +63,6 @@ describe("last_txn_ts tracking in client", () => {
       },
 
       close() {},
-      getURL(): string {
-        return "http://foo.com/bar";
-      },
     };
 
     const myClient = getClient(

--- a/__tests__/integration/query.test.ts
+++ b/__tests__/integration/query.test.ts
@@ -140,9 +140,6 @@ describe("query", () => {
           return dummyResponse;
         },
         close() {},
-        getURL(): string {
-          return "http://foo.com/bar";
-        },
       };
       const clientConfiguration: Partial<ClientConfiguration> = {
         linearized: true,
@@ -166,9 +163,6 @@ describe("query", () => {
         return dummyResponse;
       },
       close() {},
-      getURL() {
-        return "http://foo.com/bar";
-      },
     };
 
     let clientConfiguration: Partial<ClientConfiguration> = {
@@ -277,9 +271,6 @@ describe("query", () => {
           );
         },
         close() {},
-        getURL() {
-          return "http://foo.com/bar";
-        },
       };
       badClient = getClient({}, httpClient);
       await badClient.query(fql`"dummy"`);
@@ -388,9 +379,6 @@ describe("query", () => {
         return httpClient.request(badRequest);
       },
       close() {},
-      getURL() {
-        return "http://foo.com/bar";
-      },
     };
 
     const badClient = getClient({}, badHTTPClient);
@@ -412,9 +400,6 @@ describe("query", () => {
         throw new Error("boom!");
       },
       close() {},
-      getURL(): string {
-        return "http://foo.com/bar";
-      },
     };
     const badClient = getClient(
       {

--- a/__tests__/integration/set.test.ts
+++ b/__tests__/integration/set.test.ts
@@ -213,9 +213,6 @@ describe("SetIterator", () => {
       close() {
         return;
       },
-      getURL(): string {
-        return "http://foo.com/bar";
-      },
     };
     const testClient = getClient({}, httpClient);
 
@@ -250,9 +247,6 @@ describe("SetIterator", () => {
       },
       close() {
         return;
-      },
-      getURL(): string {
-        return "http://foo.com/bar";
       },
     };
     const testClient = getClient({}, httpClient);

--- a/src/client.ts
+++ b/src/client.ts
@@ -620,7 +620,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
       this.#clientConfiguration.logger.debug(
         "Fauna HTTP %s request to %s (timeout: %s), headers: %s",
         method,
-        this.#clientConfiguration.endpoint.toString(),
+        FaunaAPIPaths.QUERY,
         client_timeout_ms.toString(),
         JSON.stringify(headers),
       );
@@ -635,7 +635,7 @@ in an environmental variable named FAUNA_SECRET or pass it to the Client\
       this.#clientConfiguration.logger.debug(
         "Fauna HTTP response %s from %s, headers: %s",
         response.status,
-        this.#clientConfiguration.endpoint.toString(),
+        FaunaAPIPaths.QUERY,
         JSON.stringify(response.headers),
       );
 

--- a/src/http-client/fetch-client.ts
+++ b/src/http-client/fetch-client.ts
@@ -32,10 +32,6 @@ export class FetchClient implements HTTPClient, HTTPStreamClient {
     return new URL(path, this.#baseUrl).toString();
   }
 
-  getURL(): string {
-    return this.#resolveURL(this.#defaultRequestPath);
-  }
-
   /** {@inheritDoc HTTPClient.request} */
   async request<T = QueryRequest>({
     data,

--- a/src/http-client/http-client.ts
+++ b/src/http-client/http-client.ts
@@ -68,11 +68,6 @@ export interface HTTPClient {
    * is a no-op as there is no shared resource to close.
    */
   close(): void;
-
-  /**
-   * Return the full URL (path and endpoint) for the query endpoint for this client.
-   */
-  getURL(): string;
 }
 
 /**

--- a/src/http-client/node-http2-client.ts
+++ b/src/http-client/node-http2-client.ts
@@ -54,10 +54,6 @@ export class NodeHTTP2Client implements HTTPClient, HTTPStreamClient {
     this.#session = null;
   }
 
-  getURL(): string {
-    return this.#url;
-  }
-
   /**
    * Gets a {@link NodeHTTP2Client} matching the {@link HTTPClientOptions}
    * @param httpClientOptions - the {@link HTTPClientOptions}


### PR DESCRIPTION
### Description
This PR removed backwards-incompatible changes introduced in v2.4.0: remove the `getURL()` method from the `HTTPClient` interface.

Full (and accurate!) endpoints are not available at the point of logging for feeds and streams, so I updated the debug message to be the request path instead of full URL.

Bonus: 
- Added a debug line to starting stream connection for consistency with query and feed.
- tidied up imports

### Motivation and context
In #308, published in v2.4.0, we added some basic logging infrastructure, but that made breaking changes to the `HTTPClient` API. In retrospect, I don't believe those were helpful changes either - The `getURL()` implementations added to the built-in clients do not change with the request path, so using `getURL` when you want to gather information for a stream request, for example, it would return the incorrect URL.

### How was the change tested?
No changes to testing.

### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/2d51d5fc-6663-429d-ba56-c510e8aba465)

![image](https://github.com/user-attachments/assets/5372b7cd-00bb-4ea6-b94d-564957c5430a)

![image](https://github.com/user-attachments/assets/926fa74c-6944-4323-b2aa-24b9523701f4)


### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


