### PR TITLE
Fix modules link in ref docs

### DIFF
--- a/overview.md
+++ b/overview.md
@@ -14,4 +14,4 @@ docs](https://docs.fauna.com/fauna/current/build/drivers/js-client/).
 
 ## All modules
 
-For all available modules, see [Modules](Modules.html).
+For all available modules, see [Modules](modules.html).


### PR DESCRIPTION
### Description
The modules link in the [driver reference docs](https://fauna.github.io/fauna-js/latest/) is broken. This fixes the link. I've manually fixed the link in our existing docs.

### Motivation and context
See above. 

### How was the change tested?
Ran `npm run doc` and checked the link.

### Screenshots (if appropriate):

![Screenshot 2025-01-19 at 3 26 29 PM](https://github.com/user-attachments/assets/1ea17e78-a3d6-4ade-b3a0-174c6951a548)

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


