### PR TITLE
Respect the relative path to the fauna-js-repository during doc publication.

### DIFF
--- a/concourse/scripts/publish_docs.sh
+++ b/concourse/scripts/publish_docs.sh
@@ -27,10 +27,10 @@ fi
 
 cp -R "../fauna-js-repository/docs" "$PACKAGE_VERSION"
 
-HEAD_GTM=$(cat ./fauna-js-repository/concourse/scripts/head_gtm.dat)
+HEAD_GTM=$(cat ../fauna-js-repository/concourse/scripts/head_gtm.dat)
 sed -i.bak "0,/<\/title>/{s/<\/title>/<\/title>${HEAD_GTM}/}" ./$PACKAGE_VERSION/index.html
 
-BODY_GTM=$(cat ./fauna-js-repository/concourse/scripts/body_gtm.dat)
+BODY_GTM=$(cat ../fauna-js-repository/concourse/scripts/body_gtm.dat)
 sed -i.bak "0,/<body>/{s/<body>/<body>${BODY_GTM}/}" ./$PACKAGE_VERSION/index.html
 
 rm ./$PACKAGE_VERSION/index.html.bak


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
<!--- Describe your changes in detail. -->
Our deployment workflows have a bug for docs publication.
They attempt to read files using incorrect relative paths.
This change uses the correct relative path; this should enable us to automate docs publishing again.
### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->
We would like to automate docs publishing.
### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The best way to test this is to run the automation.
### Screenshots (if appropriate):
N/A
### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


